### PR TITLE
Fixes the query for possible tenants for /tenants/select

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.5</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/sirius-biz.iml
+++ b/sirius-biz.iml
@@ -12,6 +12,8 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-web:test-jar:tests:4.6.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-db:test-jar:tests:1.3.1" level="project" />
     <orderEntry type="library" name="Maven: com.scireum:sirius-web:4.6.1" level="project" />
     <orderEntry type="library" name="Maven: com.scireum:sirius-kernel:3.1" level="project" />
     <orderEntry type="library" name="Maven: com.scireum:sirius-ipl:1.3" level="project" />
@@ -58,8 +60,8 @@
     <orderEntry type="library" name="Maven: org.apache.ftpserver:ftplet-api:1.0.6" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.5.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.mina:mina-core:2.0.4" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-web:test-jar:tests:4.6.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-db:test-jar:tests:1.3.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-web:test-jar:tests:4.8" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-db:test-jar:tests:1.4.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-kernel:test-jar:tests:3.1" level="project" />
     <orderEntry type="library" name="Maven: com.typesafe:config:1.0.2" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />

--- a/src/main/java/sirius/biz/tenants/TenantController.java
+++ b/src/main/java/sirius/biz/tenants/TenantController.java
@@ -263,12 +263,16 @@ public class TenantController extends BizController {
         if (originalTenant.isPresent()) {
             SmartQuery<Tenant> baseQuery = oma.select(Tenant.class);
             if (!hasPermission(TenantUserManager.PERMISSION_SYSTEM_TENANT)) {
-                baseQuery.where(Or.of(And.of(FieldOperator.on(Tenant.PARENT).eq(tenantId),
-                                             FieldOperator.on(Tenant.PARENT_CAN_ACCESS).eq(true)),
-                                      And.of(FieldOperator.on(Tenant.ID).eq(originalTenant.get().getParent().getId()),
-                                             FieldOperator.on(Tenant.CAN_ACCESS_PARENT).eq(true))));
-            }
-            return baseQuery;
+                if (originalTenant.get().isCanAccessParent()) {
+                    baseQuery.where(Or.of(And.of(FieldOperator.on(Tenant.PARENT).eq(tenantId),
+                                                 FieldOperator.on(Tenant.PARENT_CAN_ACCESS).eq(true)),
+                                          FieldOperator.on(Tenant.ID).eq(originalTenant.get().getParent().getId())));
+                } else {
+                    baseQuery.where(And.of(FieldOperator.on(Tenant.PARENT).eq(tenantId),
+                                           FieldOperator.on(Tenant.PARENT_CAN_ACCESS).eq(true)),
+                                    FieldOperator.on(Tenant.ID).eq(originalTenant.get().getParent().getId()));
+                }
+            } return baseQuery;
         } else {
             throw Exceptions.createHandled().withSystemErrorMessage("Cannot determine current tenant!").handle();
         }


### PR DESCRIPTION
Fixes the query for possible tenants for /tenants/select

When determining of the parent tenant can be accessed, we have to check
the value set for the child - not the parent