### PR TITLE
Fixxed tenant select on switching tenant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.3.5</version>
+    <version>1.3.6</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/java/sirius/biz/tenants/TenantController.java
+++ b/src/main/java/sirius/biz/tenants/TenantController.java
@@ -269,10 +269,10 @@ public class TenantController extends BizController {
                                           FieldOperator.on(Tenant.ID).eq(originalTenant.get().getParent().getId())));
                 } else {
                     baseQuery.where(And.of(FieldOperator.on(Tenant.PARENT).eq(tenantId),
-                                           FieldOperator.on(Tenant.PARENT_CAN_ACCESS).eq(true)),
-                                    FieldOperator.on(Tenant.ID).eq(originalTenant.get().getParent().getId()));
+                                           FieldOperator.on(Tenant.PARENT_CAN_ACCESS).eq(true)));
                 }
-            } return baseQuery;
+            }
+            return baseQuery;
         } else {
             throw Exceptions.createHandled().withSystemErrorMessage("Cannot determine current tenant!").handle();
         }


### PR DESCRIPTION
Removed unnecessary query on tenant switching which caused switching was only possible on tenants whose parent was the system tenant.