### PR TITLE
Flush UserAccount caches correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.5.4</version>
+    <version>1.5.5</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -126,8 +126,8 @@ public class TenantUserManager extends GenericUserManager {
      */
     public static void flushCacheForUserAccount(UserAccount account) {
         rolesCache.remove(account.getUniqueName());
-        userAccountCache.remove(account.getIdAsString());
-        configCache.remove(account.getIdAsString());
+        userAccountCache.remove(account.getUniqueName());
+        configCache.remove(account.getUniqueName());
     }
 
     /**


### PR DESCRIPTION
Values for userAccountCache and configCache are inserted by unique name of objects so flushing them for those needs the same property in order to remove the corresponding element.