### PR TITLE
Fixing wrong page size in pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.6</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.6.4</version>
+    <version>1.6.5</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/sirius-biz.iml
+++ b/sirius-biz.iml
@@ -14,6 +14,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-web:test-jar:tests:4.6.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-db:test-jar:tests:1.4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-db:test-jar:tests:1.7.1" level="project" />
     <orderEntry type="library" name="Maven: com.scireum:sirius-web:5.3.4" level="project" />
     <orderEntry type="library" name="Maven: com.scireum:sirius-kernel:3.3.3" level="project" />
     <orderEntry type="library" name="Maven: com.scireum:sirius-ipl:1.3" level="project" />
@@ -48,6 +49,12 @@
     <orderEntry type="library" name="Maven: dom4j:dom4j:1.6.1" level="project" />
     <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.0.b2" level="project" />
     <orderEntry type="library" name="Maven: com.scireum:sirius-db:1.7.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-dbcp2:2.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-pool2:2.3" level="project" />
+    <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.hsqldb:hsqldb:2.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.mongodb:mongo-java-driver:2.12.4" level="project" />
+    <orderEntry type="library" name="Maven: redis.clients:jedis:2.8.1" level="project" />
     <orderEntry type="library" name="Maven: mysql:mysql-connector-java:5.1.35" level="project" />
     <orderEntry type="library" name="Maven: net.sf.jt400:jt400:6.7" level="project" />
     <orderEntry type="library" name="Maven: org.apache.ftpserver:ftpserver-core:1.0.6" level="project" />
@@ -55,13 +62,7 @@
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.5.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.mina:mina-core:2.0.4" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-web:test-jar:tests:5.3.4" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-db:test-jar:tests:1.7.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.apache.commons:commons-dbcp2:2.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.apache.commons:commons-pool2:2.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: commons-logging:commons-logging:1.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.hsqldb:hsqldb:2.3.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mongodb:mongo-java-driver:2.12.4" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: redis.clients:jedis:2.8.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-db:test-jar:tests:1.7.2" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.scireum:sirius-kernel:test-jar:tests:3.3.3" level="project" />
     <orderEntry type="library" name="Maven: com.typesafe:config:1.0.2" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />

--- a/src/main/java/sirius/biz/web/PageHelper.java
+++ b/src/main/java/sirius/biz/web/PageHelper.java
@@ -212,7 +212,7 @@ public class PageHelper<E extends Entity> {
     public Page<E> asPage() {
         Objects.requireNonNull(ctx);
         Watch w = Watch.start();
-        Page<E> result = new Page<E>().withStart(1);
+        Page<E> result = new Page<E>().withStart(1).withPageSize(PAGE_SIZE);
         result.bindToRequest(ctx);
         if (searchFields != null && searchFields.length > 0) {
             baseQuery.where(Like.allWordsInAnyField(result.getQuery(), searchFields));


### PR DESCRIPTION
In Sirius-Biz pages have a default size of 50 items per page. However, in Sirius-Web the default size is 25. The page size in Sirius-Web was not set by Sirius-Biz so the pagination showed 50 items per page but calculated next and previous page items with 25. By setting the page size in Sirius-Web this should be fixed.