### PR TITLE
Update SaveHelper with a bit of new logic.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.2</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>


### PR DESCRIPTION
Changes the logic of the saveHelper.saveEntity() function in order to keep it more in line with the desired effect.
Deprecates the editAfterCreate function since it is no longer necassary to set a flag for editAfterCreate.
Removes the editAfterCreate boolean since it is no longer needed.
Changes the JavaDoc to reflect the Changes made.
Bump version to 1.8.2