### PR TITLE
Deletes getIdAsString from BizEntity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.2</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.9.1</version>
+    <version>1.9.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-db</artifactId>
-            <version>1.13.1</version>
+            <version>1.13.2</version>
         </dependency>
 
         <dependency>

--- a/sirius-biz.iml
+++ b/sirius-biz.iml
@@ -53,7 +53,7 @@
     <orderEntry type="library" name="Maven: stax:stax-api:1.0.1" level="project" />
     <orderEntry type="library" name="Maven: dom4j:dom4j:1.6.1" level="project" />
     <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.0.b2" level="project" />
-    <orderEntry type="library" name="Maven: com.scireum:sirius-db:1.13.2" level="project" />
+    <orderEntry type="library" name="Maven: com.scireum:sirius-db:1.13.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-dbcp2:2.1.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-pool2:2.4.2" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
@@ -88,9 +88,5 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.ant:ant:1.9.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.ant:ant-launcher:1.9.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:2.5.1" level="project" />
-  </component>
-  <component name="sonarModuleSettings">
-    <option name="localAnalysisScripName" value="&lt;PROJECT&gt;" />
-    <option name="serverName" value="&lt;PROJECT&gt;" />
   </component>
 </module>

--- a/sirius-biz.iml
+++ b/sirius-biz.iml
@@ -53,7 +53,7 @@
     <orderEntry type="library" name="Maven: stax:stax-api:1.0.1" level="project" />
     <orderEntry type="library" name="Maven: dom4j:dom4j:1.6.1" level="project" />
     <orderEntry type="library" name="Maven: xml-apis:xml-apis:1.0.b2" level="project" />
-    <orderEntry type="library" name="Maven: com.scireum:sirius-db:1.13.1" level="project" />
+    <orderEntry type="library" name="Maven: com.scireum:sirius-db:1.13.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-dbcp2:2.1.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-pool2:2.4.2" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
@@ -88,5 +88,9 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.ant:ant:1.9.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.ant:ant-launcher:1.9.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:2.5.1" level="project" />
+  </component>
+  <component name="sonarModuleSettings">
+    <option name="localAnalysisScripName" value="&lt;PROJECT&gt;" />
+    <option name="serverName" value="&lt;PROJECT&gt;" />
   </component>
 </module>

--- a/src/main/java/sirius/biz/model/BizEntity.java
+++ b/src/main/java/sirius/biz/model/BizEntity.java
@@ -14,39 +14,15 @@ import sirius.db.mixing.Entity;
 /**
  * Provides a base class for entities managed by a {@link sirius.biz.web.BizController}.
  * <p>
- * Next to having {@link TraceData} built in, it provides a {@link #getIdAsString()} method which returns
- * the database ID as string. However, for new entities (not yet persisted), it returns "new" which is
- * recognized by the {@link sirius.biz.web.BizController}.
- * <p>
- * Therefore a simple editor which responds to an URL like "/entity/ID" can be called via "/entity/new" to create a new
- * entity.
+ * Provides built in {@link TraceData}
  */
 public abstract class BizEntity extends Entity {
-
-    /**
-     * Contains the constant used to mark a new (unsaved) entity.
-     */
-    public static final String NEW = "new";
 
     /**
      * Contains tracing data which records which user created and last edited the entity
      */
     public static final Column TRACE = Column.named("trace");
     private final TraceData trace = new TraceData();
-
-    /**
-     * Returns a string representation of the entity ID.
-     * <p>
-     * If the entity is new, "new" will be returned.
-     *
-     * @return the entity ID as string or "new" if the entity {@link #isNew()}.
-     */
-    public String getIdAsString() {
-        if (isNew()) {
-            return NEW;
-        }
-        return String.valueOf(getId());
-    }
 
     public TraceData getTrace() {
         return trace;

--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -278,7 +278,7 @@ public class BizController extends BasicController {
          * @param entity the entity to update and save
          * @return <tt>true</tt> if the request was handled (the user was redirected), <tt>false</tt> otherwise
          */
-        public boolean saveEntity(BizEntity entity) {
+        public boolean saveEntity(Entity entity) {
             if (!ctx.isPOST()) {
                 return false;
             }
@@ -346,7 +346,7 @@ public class BizController extends BasicController {
      * @throws sirius.kernel.health.HandledException if either the id is unknown or a new instance cannot be created
      */
     protected <E extends Entity> E find(Class<E> type, String id) {
-        if (BizEntity.NEW.equals(id) && BizEntity.class.isAssignableFrom(type)) {
+        if (Entity.NEW.equals(id) && Entity.class.isAssignableFrom(type)) {
             try {
                 return type.newInstance();
             } catch (Throwable e) {
@@ -375,7 +375,7 @@ public class BizController extends BasicController {
      * or if the id was <tt>new</tt>
      */
     protected <E extends Entity> Optional<E> tryFind(Class<E> type, String id) {
-        if (BizEntity.NEW.equals(id)) {
+        if (Entity.NEW.equals(id)) {
             return Optional.empty();
         }
         return oma.find(type, id);


### PR DESCRIPTION
Is moved to Entity in sirius-db to allow BizController to handle Entities without the tracing functionality.