### PR TITLE
Set correct value of tenant id for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.2</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.10</version>
+    <version>1.10.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/test/java/sirius/biz/tenants/TenantsHelper.java
+++ b/src/test/java/sirius/biz/tenants/TenantsHelper.java
@@ -86,7 +86,7 @@ public class TenantsHelper {
      * @param request the request to perform as test user and tenant
      */
     public static void installBackendUser(TestRequest request) {
-        request.setSessionValue("default-tenant-id", getTestTenant().getUniqueName());
+        request.setSessionValue("default-tenant-id", getTestTenant().getId());
         request.setSessionValue("default-tenant-name", getTestTenant().getName());
         request.setSessionValue("default-user-id", getTestUser().getUniqueName());
         request.setSessionValue("default-user-name", getTestUser().getEmail());


### PR DESCRIPTION
This got mixed up somewhere. For tenant id the id from database is used. However, for user ids the unique name is used. The wrong assignment caused some tests to fail because test user accounts were different from user accounts in production.