### PR TITLE
Hanlde i5 Exceptions in call method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.2</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>1.11.1</version>
+    <version>1.12</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>


### PR DESCRIPTION
It is easier to work with this method if Exceptions get pre-handled instead of being rethrown. In most cases these Exceptions had to be handled anyways.