### PR TITLE
Shows a slightly less generic error message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -292,6 +292,8 @@ public class BizController extends BasicController {
                     return true;
                 }
                 showSavedMessage();
+            } catch (IllegalArgumentException e) {
+                UserContext.message(new Message(e.getMessage(), null, Message.ERROR));
             } catch (Exception e) {
                 UserContext.handle(e);
             }


### PR DESCRIPTION
Catches IllegalArgumentException.

This will remove the exception type at the end of the message
and the „unexpected exception occured“ string at the beginning.

E.g. Shows "Please enter a valid decimal number. 'zzz' is invalid." instead of 
"An unexpected exception occurred: Please enter a valid decimal number. 'zzz' is invalid. (java.lang.IllegalArgumentException)"