### PR TITLE
Uses word-wrap in Infobox' value column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>3.7</version>
+    <version>3.7.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/resources/default/view/parts/infoboxElement.html
+++ b/src/main/resources/default/view/parts/infoboxElement.html
@@ -1,10 +1,10 @@
 @args String labelKey, String value
 
 <div class="row info-line">
-    <div class="col-md-4 name">
+    <div class="col-md-6 name">
         @i18n(labelKey)
     </div>
-    <div class="col-md-8 value">
+    <div class="col-md-6 value word-wrap">
         <div>
             @value
         </div>


### PR DESCRIPTION
In order to break to long strings in value column to avoid overflowing content