### PR TITLE
Fix url in password mail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>3.9.4</version>
+    <version>3.9.5</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/resources/default/mail/useraccount/password-html.vm
+++ b/src/main/resources/default/mail/useraccount/password-html.vm
@@ -16,7 +16,9 @@
                 <li><b>#nls('mail-password.password'):</b> $password</li>
             </ul>
 
+            #if ($strings.isFilled($!url))
             <p>#nls('mail-password.loginHere'): <a href="$url">$url</a></p>
+            #end
         </td>
     </tr>
 </table>

--- a/src/main/resources/default/mail/useraccount/password.vm
+++ b/src/main/resources/default/mail/useraccount/password.vm
@@ -10,6 +10,6 @@ $reason
 
 * #nls('mail-password.username'): $username
 * #nls('mail-password.password'): $password
-#nls('mail-password.loginHere'): $url
+#if ($strings.isFilled($!url))#nls('mail-password.loginHere'): $url#end
 
 #parse('mail/mail-footer.vm')


### PR DESCRIPTION
If the url was not set in the config, the url variable appeared in the mail. However, this is not desired. So therefore the url is completely hidden in this case.