### PR TITLE
Disables the uniqueness check for paths for temporary objects.

### DIFF
--- a/src/main/java/sirius/biz/storage/VirtualObject.java
+++ b/src/main/java/sirius/biz/storage/VirtualObject.java
@@ -117,7 +117,7 @@ public class VirtualObject extends TenantAware implements StoredObject {
 
     @BeforeSave
     protected void ensureUniquenessOfPath() {
-        if (Strings.isEmpty(reference)) {
+        if (Strings.isEmpty(reference) && !temporary) {
             assertUnique(PATH, getPath(), TENANT, BUCKET);
         }
     }


### PR DESCRIPTION
These'll have their reference filled later, therefore we must suppress
the check.