### PR TITLE
Make sure newly created StoredObjectRef are stored

### DIFF
--- a/src/main/java/sirius/biz/storage/StoredObjectRef.java
+++ b/src/main/java/sirius/biz/storage/StoredObjectRef.java
@@ -96,7 +96,7 @@ public class StoredObjectRef {
      * @param key the key of the object to reference
      */
     public void setKey(String key) {
-        if (Strings.isFilled(this.key) && !Strings.areEqual(this.key, key)) {
+        if (!Strings.areEqual(this.key, key)) {
             this.changed = true;
         }
 


### PR DESCRIPTION
If a StoredObjectRef was filled the first time it was not marked as changed and therefore the referenced file was not marked as persistent but as temporary and got deleted on the next cleanup job run.