### PR TITLE
Fix paging on mails site

### DIFF
--- a/src/main/resources/default/templates/protocol/mails.html.pasta
+++ b/src/main/resources/default/templates/protocol/mails.html.pasta
@@ -58,7 +58,7 @@
                 </tbody>
             </w:table>
 
-            <w:pagination page="mails" baseUrl="system/mails"/>
+            <w:pagination page="mails" baseUrl="/system/mails"/>
         </div>
     </div>
 


### PR DESCRIPTION
The base url for paging has to be absolute.