### PR TITLE
Fix pagination url for logs and protocols

### DIFF
--- a/src/main/resources/default/templates/protocol/logs.html.pasta
+++ b/src/main/resources/default/templates/protocol/logs.html.pasta
@@ -59,7 +59,7 @@
                 </tbody>
             </w:table>
 
-            <w:pagination page="logs" baseUrl="system/logs"/>
+            <w:pagination page="logs" baseUrl="/system/logs"/>
         </div>
     </div>
 

--- a/src/main/resources/default/templates/protocol/protocol.html.pasta
+++ b/src/main/resources/default/templates/protocol/protocol.html.pasta
@@ -64,7 +64,7 @@
                 </tbody>
             </w:table>
 
-            <w:pagination page="protocol" baseUrl="system/protocol"/>
+            <w:pagination page="protocol" baseUrl="/system/protocol"/>
         </div>
     </div>
 


### PR DESCRIPTION
Pagination urls have to start with a slash.