### PR TITLE
Remove double translation in selectObject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-web</artifactId>
-            <version>9.0</version>
+            <version>9.3</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-web</artifactId>
-            <version>9.0</version>
+            <version>9.3</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/resources/default/taglib/w/selectObject.html.pasta
+++ b/src/main/resources/default/taglib/w/selectObject.html.pasta
@@ -16,7 +16,7 @@
 
 <div class="col-md-@span form-group">
     <i:if test="isFilled(label)">
-        <label>@i18n(label)</label>
+        <label>@label</label>
     </i:if>
 
     <select name="@name" class="form-control @user.signalFieldError(name)" id="select-@localId"
@@ -46,7 +46,7 @@
     <input type="file" id="upload-@localId" style="display:none;" />
 
     <i:if test="isFilled(help)">
-        <span class="help-block">@i18n(help)</span>
+        <span class="help-block">@help</span>
     </i:if>
 
     <a onclick="$('#upload-@localId').click()" class="link pointer" style="cursor: pointer">@i18n("StorageController.uploadFile")</a>


### PR DESCRIPTION
The strings for label and help are already translated so they do not need to be translated a second time.