### PR TITLE
Fixes scaling of images with alpha channel with Java

### DIFF
--- a/sirius-biz.iml
+++ b/sirius-biz.iml
@@ -104,4 +104,8 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.ant:ant-launcher:1.9.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:2.5.1" level="project" />
   </component>
+  <component name="sonarModuleSettings">
+    <option name="localAnalysisScripName" value="&lt;PROJECT&gt;" />
+    <option name="serverName" value="&lt;PROJECT&gt;" />
+  </component>
 </module>

--- a/src/main/java/sirius/biz/storage/VersionManager.java
+++ b/src/main/java/sirius/biz/storage/VersionManager.java
@@ -29,6 +29,7 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.ImageOutputStream;
+import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.Transparency;
@@ -329,9 +330,6 @@ public class VersionManager {
      * @author Chris Campbell
      */
     private BufferedImage getScaledInstance(BufferedImage img, int targetWidth, int targetHeight) {
-        int type = (img.getTransparency() == Transparency.OPAQUE) ?
-                   BufferedImage.TYPE_INT_RGB :
-                   BufferedImage.TYPE_INT_ARGB;
         BufferedImage ret = img;
         int width = img.getWidth();
         int height = img.getHeight();
@@ -349,10 +347,10 @@ public class VersionManager {
                 height = targetHeight;
             }
 
-            BufferedImage tmp = new BufferedImage(width, height, type);
+            BufferedImage tmp = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
             Graphics2D g2 = tmp.createGraphics();
             g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-            g2.drawImage(ret, 0, 0, width, height, null);
+            g2.drawImage(ret, 0, 0, width, height, Color.WHITE, null);
             g2.dispose();
             ret = tmp;
         } while (width != targetWidth || height != targetHeight);

--- a/src/main/java/sirius/biz/storage/VersionManager.java
+++ b/src/main/java/sirius/biz/storage/VersionManager.java
@@ -32,7 +32,6 @@ import javax.imageio.stream.ImageOutputStream;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
-import java.awt.Transparency;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;


### PR DESCRIPTION
The JPEG writer screws up the channels when an alpha channel exists. Instead of creating a BufferedImage with an alpha channel and then relying on the JPEG writer to deal with it, now we always make it a RGB image and fill the background with white when drawing the original image.