### PR TITLE
Implements a minimum size for image versions

### DIFF
--- a/src/main/java/sirius/biz/storage/DownloadBuilder.java
+++ b/src/main/java/sirius/biz/storage/DownloadBuilder.java
@@ -74,6 +74,14 @@ public class DownloadBuilder {
 
     /**
      * Specifies the version of the file to use.
+     * <p>
+     * The syntax is a comma separated string of key-value pairs in the form of {@code key:value}. The available keys
+     * are {@code size} for the requested maximum size, and {@code min} for the minimum size. The value is the size in
+     * the format {@code <width>x<height>}.
+     * <p>
+     * Example: The version {@code size:500x500,min:100x100} would scale an image with 1000x800 pixels to 500x400. An
+     * image with 1000x150 would be scaled to 500x75 and then extended with a white border to 500x100. An image with
+     * 400x50 pixels would not be scaled but extended to 400x100.
      *
      * @param version the name of the version to use
      * @return the builder itself for fluent method calls

--- a/src/main/java/sirius/biz/storage/VersionManager.java
+++ b/src/main/java/sirius/biz/storage/VersionManager.java
@@ -155,37 +155,28 @@ public class VersionManager {
     private void performVersionComputation(VirtualObjectVersion objectVersion) {
         VirtualObject object = objectVersion.getVirtualObject().getValue();
         try {
-            int width = 0;
-            int height = 0;
-            int extendWidth = 0;
-            int extendHeight = 0;
+            Tuple<Integer, Integer> size = Tuple.create(0, 0);
+            Tuple<Integer, Integer> extendedSize = Tuple.create(0, 0);
 
             for (String part : objectVersion.getVersionKey().split(",")) {
                 Tuple<String, String> keyValuePair = Strings.split(part, ":");
+                String key = keyValuePair.getFirst().toLowerCase().trim();
 
-                switch (keyValuePair.getFirst().toLowerCase().trim()) {
-                    case "size":
-                        Tuple<String, String> widthAndHeight = Strings.split(keyValuePair.getSecond(), "x");
+                if ("size".equals(key)) {
+                    size = parseWidthAndHeight(keyValuePair.getSecond());
+                }
 
-                        width = Integer.parseInt(widthAndHeight.getFirst().trim());
-                        height = Integer.parseInt(widthAndHeight.getSecond().trim());
-
-                        break;
-
-                    case "min":
-                        Tuple<String, String> extendWidthAndHeight = Strings.split(keyValuePair.getSecond(), "x");
-
-                        extendWidth = Integer.parseInt(extendWidthAndHeight.getFirst().trim());
-                        extendHeight = Integer.parseInt(extendWidthAndHeight.getSecond().trim());
-
-                        break;
-
-                    default:
-                        Storage.LOG.WARN("Unknown key '" + keyValuePair.getFirst() + "' in version string.");
+                if ("min".equals(key)) {
+                    extendedSize = parseWidthAndHeight(keyValuePair.getSecond());
                 }
             }
 
-            convertAndStore(objectVersion, object, width, height, extendWidth, extendHeight);
+            convertAndStore(objectVersion,
+                            object,
+                            size.getFirst(),
+                            size.getSecond(),
+                            extendedSize.getFirst(),
+                            extendedSize.getSecond());
         } catch (Exception e) {
             Exceptions.handle()
                       .to(Storage.LOG)
@@ -196,6 +187,13 @@ public class VersionManager {
                       .handle();
             oma.delete(objectVersion);
         }
+    }
+
+    private Tuple<Integer, Integer> parseWidthAndHeight(String value) {
+        Tuple<String, String> widthAndHeight = Strings.split(value, "x");
+
+        return Tuple.create(Integer.parseInt(widthAndHeight.getFirst().trim()),
+                            Integer.parseInt(widthAndHeight.getSecond().trim()));
     }
 
     private void convertAndStore(VirtualObjectVersion objectVersion,

--- a/src/main/java/sirius/biz/storage/VersionManager.java
+++ b/src/main/java/sirius/biz/storage/VersionManager.java
@@ -66,6 +66,10 @@ public class VersionManager {
 
     @ConfigValue("storage.conversionCommand")
     private String conversionCommand;
+
+    @ConfigValue("storage.extendOption")
+    private String extendOption;
+
     private Boolean commandPresent;
 
     private Cache<String, Tuple<VirtualObject, Map<String, String>>> logicalToPhysicalCache =
@@ -98,7 +102,8 @@ public class VersionManager {
      * Fetches the pyhsical key for a version from the tuple retrieved via {@link #fetchPhysicalObjects(DownloadBuilder)}
      *
      * @param physicalObjects the map of already resolved keys
-     * @param version         the version to resolve
+     * @param version         the version to resolve, see {@link DownloadBuilder#withVersion(String)} for possible
+     *                        values
      * @return the physical key. If no version exists, a new one will be comouted and the main version will be used in
      * the mean time
      */
@@ -150,11 +155,37 @@ public class VersionManager {
     private void performVersionComputation(VirtualObjectVersion objectVersion) {
         VirtualObject object = objectVersion.getVirtualObject().getValue();
         try {
-            Tuple<String, String> widthAndHeight = Strings.split(objectVersion.getVersionKey(), "x");
-            int width = Integer.parseInt(widthAndHeight.getFirst());
-            int height = Integer.parseInt(widthAndHeight.getSecond());
+            int width = 0;
+            int height = 0;
+            int extendWidth = 0;
+            int extendHeight = 0;
 
-            convertAndStore(objectVersion, object, width, height);
+            for (String part : objectVersion.getVersionKey().split(",")) {
+                Tuple<String, String> keyValuePair = Strings.split(part, ":");
+
+                switch (keyValuePair.getFirst().toLowerCase().trim()) {
+                    case "size":
+                        Tuple<String, String> widthAndHeight = Strings.split(keyValuePair.getSecond(), "x");
+
+                        width = Integer.parseInt(widthAndHeight.getFirst().trim());
+                        height = Integer.parseInt(widthAndHeight.getSecond().trim());
+
+                        break;
+
+                    case "min":
+                        Tuple<String, String> extendWidthAndHeight = Strings.split(keyValuePair.getSecond(), "x");
+
+                        extendWidth = Integer.parseInt(extendWidthAndHeight.getFirst().trim());
+                        extendHeight = Integer.parseInt(extendWidthAndHeight.getSecond().trim());
+
+                        break;
+
+                    default:
+                        Storage.LOG.WARN("Unknown key '" + keyValuePair.getFirst() + "' in version string.");
+                }
+            }
+
+            convertAndStore(objectVersion, object, width, height, extendWidth, extendHeight);
         } catch (Exception e) {
             Exceptions.handle()
                       .to(Storage.LOG)
@@ -167,9 +198,13 @@ public class VersionManager {
         }
     }
 
-    private void convertAndStore(VirtualObjectVersion objectVersion, VirtualObject object, int width, int height)
-            throws IOException {
-        File resultingFile = convert(object, width, height);
+    private void convertAndStore(VirtualObjectVersion objectVersion,
+                                 VirtualObject object,
+                                 int width,
+                                 int height,
+                                 int extendWidth,
+                                 int extendHeight) throws IOException {
+        File resultingFile = convert(object, width, height, extendWidth, extendHeight);
         try {
             if (resultingFile == null || resultingFile.length() == 0) {
                 Storage.LOG.WARN("Converting %s (%s) to %sx%s resulted in an empty file.",
@@ -204,12 +239,13 @@ public class VersionManager {
         }
     }
 
-    private File convert(VirtualObject object, int width, int height) throws IOException {
+    private File convert(VirtualObject object, int width, int height, int extendWidth, int extendHeight)
+            throws IOException {
         if (isCommandLineAvailable()) {
-            return convertUsingCLI(object, width, height);
+            return convertUsingCLI(object, width, height, extendWidth, extendHeight);
         }
 
-        return convertUsingJava(object, width, height);
+        return convertUsingJava(object, width, height, extendWidth, extendHeight);
     }
 
     private boolean isCommandLineAvailable() {
@@ -231,30 +267,44 @@ public class VersionManager {
 
     /**
      * Resizes an image with an external tool over the CLI.
-     *
      * <p>
      * Because we can have different {@link PhysicalStorageEngine ways of storing the files}, we first need to create
      * two temporary files. The first one is the source image and the he second one is the destination image. The source
      * file needs to be filled with the data from the {@link Storage}.
      *
-     * @param object the metadata for the virtual file
-     * @param width the width in pixels
-     * @param height the height in pixels
+     * @param object       the metadata for the virtual file
+     * @param width        the width in pixels
+     * @param height       the height in pixels
+     * @param extendWidth  the minimum extended width in pixels
+     * @param extendHeight the minimum extended height in pixels
      * @return the destination file
      * @throws IOException in case of an IO error
      */
-    private File convertUsingCLI(VirtualObject object, int width, int height) throws IOException {
+    private File convertUsingCLI(VirtualObject object, int width, int height, int extendWidth, int extendHeight)
+            throws IOException {
         File src = File.createTempFile("resize-in-", "." + object.getFileExtension());
         try (FileOutputStream out = new FileOutputStream(src)) {
             ByteStreams.copy(storage.getData(object), out);
 
             File dest = File.createTempFile("resize-out-", ".jpg");
-            String command = Formatter.create(conversionCommand)
-                                      .set("src", src.getAbsolutePath())
-                                      .set("dest", dest.getAbsolutePath())
-                                      .set("width", width)
-                                      .set("height", height)
-                                      .format();
+            Formatter formatter = Formatter.create(conversionCommand)
+                                           .set("src", src.getAbsolutePath())
+                                           .set("dest", dest.getAbsolutePath())
+                                           .set("width", width)
+                                           .set("height", height);
+
+            if (extendWidth > 0 || extendHeight > 0) {
+                formatter.set("extend",
+                              Formatter.create(extendOption)
+                                       .set("extendWidth", extendWidth)
+                                       .set("extendHeight", extendHeight)
+                                       .format());
+            } else {
+                formatter.set("extend", "");
+            }
+
+            String command = formatter.format();
+
             try {
                 Exec.exec(command);
             } catch (Exec.ExecException e) {
@@ -281,7 +331,8 @@ public class VersionManager {
         }
     }
 
-    private File convertUsingJava(VirtualObject object, int width, int height) throws IOException {
+    private File convertUsingJava(VirtualObject object, int width, int height, int extendWidth, int extendHeight)
+            throws IOException {
         BufferedImage src;
         try (InputStream input = storage.getData(object)) {
             src = ImageIO.read(input);
@@ -291,28 +342,50 @@ public class VersionManager {
             return null;
         }
 
-        BufferedImage dest = resize(src, width, height);
+        BufferedImage dest = resize(src, width, height, extendWidth, extendHeight);
         return writeJPEG(dest, 0.9f);
     }
 
     /**
-     * Resizes the given image into a new image with the given dimensions.
+     * Resizes the given {@code BufferedImage} into a new image with the given dimensions.
+     * <p>
+     * First the image is scaled down to be at most the requested size. In this step the aspect ratio is not changed.
+     * The image is then extended to meet the extended size.
+     *
+     * @param image           the original image to be resized
+     * @param requestedWidth  the requested maximum width, in pixels
+     * @param requestedHeight the requested maximum height, in pixels
+     * @param extendWidth     the minimum extended width, in pixels
+     * @param extendHeight    the minimum extended height, in pixels
+     * @return a resized version of the original {@code BufferedImage}
      */
-    private BufferedImage resize(BufferedImage image, int requestedWidth, int requestedHeight) {
+    private BufferedImage resize(BufferedImage image,
+                                 int requestedWidth,
+                                 int requestedHeight,
+                                 int extendWidth,
+                                 int extendHeight) {
         double thumbRatio = (double) requestedWidth / requestedHeight;
         int imageWidth = image.getWidth(null);
         int imageHeight = image.getHeight(null);
         double aspectRatio = (double) imageWidth / imageHeight;
 
-        int newWidth = requestedWidth;
-        int newHeight = requestedHeight;
-        if (thumbRatio < aspectRatio) {
-            newHeight = (int) (newWidth / aspectRatio);
-        } else {
-            newWidth = (int) (newHeight * aspectRatio);
+        BufferedImage newImage = image;
+
+        if (requestedWidth < imageWidth && requestedHeight < imageHeight) {
+            int newWidth = requestedWidth;
+            int newHeight = requestedHeight;
+            if (thumbRatio < aspectRatio) {
+                newHeight = (int) (newWidth / aspectRatio);
+            } else {
+                newWidth = (int) (newHeight * aspectRatio);
+            }
+
+            newImage = getScaledInstance(newImage, newWidth, newHeight);
         }
 
-        return getScaledInstance(image, newWidth, newHeight);
+        newImage = getExtendedImageInstance(newImage, extendWidth, extendHeight);
+
+        return newImage;
     }
 
     /**
@@ -355,6 +428,35 @@ public class VersionManager {
         } while (width != targetWidth || height != targetHeight);
 
         return ret;
+    }
+
+    /**
+     * Extends the provided {@code BufferedImage} to be at least the specified width and height by putting a white
+     * border around the original image.
+     *
+     * @param image        the original image to be extended
+     * @param extendWidth  the minimum width of the extended instance, in pixels
+     * @param extendHeight the minimum height of the extended instance, in pixels
+     * @return a extended version of the original {@code BufferedImage}
+     */
+    private BufferedImage getExtendedImageInstance(BufferedImage image, int extendWidth, int extendHeight) {
+        BufferedImage newImage = image;
+        int width = image.getWidth();
+        int height = image.getHeight();
+
+        if (width < extendWidth || height < extendHeight) {
+            extendWidth = Math.max(extendWidth, width);
+            extendHeight = Math.max(extendHeight, height);
+
+            newImage = new BufferedImage(extendWidth, extendHeight, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g2 = newImage.createGraphics();
+            g2.setColor(Color.WHITE);
+            g2.fillRect(0, 0, extendWidth, extendHeight);
+            g2.drawImage(image, (extendWidth - width) / 2, (extendHeight - height) / 2, Color.WHITE, null);
+            g2.dispose();
+        }
+
+        return newImage;
     }
 
     /**

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -110,8 +110,11 @@ storage {
     baseDir = "data/storage"
 
     # If using ImageMagick, consider a command like:
-    # "convert ${src} -resize ${width}x${height}> -quiet -quality 89 -format jpeg -strip -colorspace RGB -background white -flatten ${dest}"
+    # "convert ${src} -resize ${width}x${height}> -quiet -quality 89 -format jpeg -strip -colorspace RGB -background white ${extend} -flatten ${dest}"
     conversionCommand=""
+
+    # Option for the conversion command to extend the image to a minimum size
+    extendOption = "-gravity center -extent ${extendWidth}x${extendHeight}<"
 
     # Defines all buckets known to the system.
     buckets {


### PR DESCRIPTION
The version string of VersionManager now supports the specification of a minimum size. The new syntax is a comma separated string of key-value pairs in the form of `key:value`. The available keys are `size` for the requested maximum size, and `min` for the minimum size. The value is the size in the format `<width>x<height>`.

Example: The version `size:500x500,min:100x100` would scale an image with 1000x800 pixels to 500x400. An image with 1000x150 would be scaled to 500x75 and then extended with a white border to 500x100. An image with 400x50 pixels would not be scaled but extended to 400x100.