### PR TITLE
Change name of FTP root node

### DIFF
--- a/src/main/java/sirius/biz/storage/vfs/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/vfs/VirtualFile.java
@@ -62,7 +62,7 @@ public class VirtualFile {
      * @return now file, which can be used as root node for a virtual file system
      */
     public static VirtualFile createRootNode() {
-        return new VirtualFile("");
+        return new VirtualFile("/");
     }
 
     /**


### PR DESCRIPTION
This must not be an empty string or the apache server will throw an error when listing files.