### PR TITLE
Check for login on autocompleting user accounts

### DIFF
--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -341,6 +341,7 @@ public class UserAccountController extends BizController {
      *
      * @param ctx the current request
      */
+    @LoginRequired
     @Routed("/user-accounts/autocomplete")
     public void usersAutocomplete(final WebContext ctx) {
         AutocompleteHelper.handle(ctx, (query, result) -> {


### PR DESCRIPTION
Before it was possible to read out user accounts without being logged in.