### PR TITLE
required flag for selectObject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>4.0.3</version>
+    <version>4.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/resources/default/taglib/w/selectObject.html.pasta
+++ b/src/main/resources/default/taglib/w/selectObject.html.pasta
@@ -6,6 +6,7 @@
 <i:arg name="helpKey" type="String" default="" />
 <i:arg name="help" type="String" default="@i18n(helpKey)" />
 <i:arg name="optional" type="boolean" default="false" />
+<i:arg name="required" type="boolean" default="false" />
 <i:arg name="strict" type="boolean" default="false" />
 <i:arg name="forceFullWidth" type="boolean" default="false" />
 
@@ -16,7 +17,11 @@
 
 <div class="col-md-@span form-group">
     <i:if test="isFilled(label)">
-        <label>@label</label>
+        <label>
+            <span class="@if (required) { input-required }">
+                @label
+            </span>
+        </label>
     </i:if>
 
     <select name="@name" class="form-control @user.signalFieldError(name)" id="select-@localId"


### PR DESCRIPTION
The dropdown for selecting a file from the storage engine has now a flag to indicate to the user that the field is required to fill.