### PR TITLE
Expose path of StoredObject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>4.1</version>
+    <version>4.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/java/sirius/biz/storage/StoredObject.java
+++ b/src/main/java/sirius/biz/storage/StoredObject.java
@@ -31,6 +31,13 @@ public interface StoredObject {
     String getFilename();
 
     /**
+     * Returns the path of the object.
+     *
+     * @return the path of the object
+     */
+    String getPath();
+
+    /**
      * Returns the size of the object in bytes.
      *
      * @return the size in bytes

--- a/src/main/java/sirius/biz/storage/VirtualObject.java
+++ b/src/main/java/sirius/biz/storage/VirtualObject.java
@@ -215,6 +215,7 @@ public class VirtualObject extends TenantAware implements StoredObject {
         this.fileSize = fileSize;
     }
 
+    @Override
     public String getPath() {
         return path;
     }


### PR DESCRIPTION
The path of StoredObject is now accessible and can be used e.g. for filtering files based on their path.