### PR TITLE
Add option for buckets to always search with like

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>4.4.4</version>
+    <version>4.5</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/java/sirius/biz/storage/BucketInfo.java
+++ b/src/main/java/sirius/biz/storage/BucketInfo.java
@@ -29,6 +29,7 @@ public class BucketInfo {
     private boolean canCreate;
     private boolean canEdit;
     private boolean canDelete;
+    private boolean alwaysUseLikeSearch;
     private int deleteFilesAfterDays;
     private PhysicalStorageEngine engine;
 
@@ -50,6 +51,7 @@ public class BucketInfo {
         this.canCreate = extension.get("canCreate").asBoolean();
         this.canEdit = extension.get("canEdit").asBoolean();
         this.canDelete = extension.get("canDelete").asBoolean();
+        this.alwaysUseLikeSearch = extension.get("alwaysUseLikeSearch").asBoolean();
         this.deleteFilesAfterDays = extension.get("deleteFilesAfterDays").asInt(0);
         this.engine = context.findPart(extension.get("engine").asString(), PhysicalStorageEngine.class);
     }
@@ -103,7 +105,7 @@ public class BucketInfo {
     }
 
     /**
-     * Determines if a user can edit objects within thi bucket.
+     * Determines if a user can edit objects within this bucket.
      *
      * @return <tt>true</tt> if a user can modify an object within this bucket, <tt>false</tt> otherwise
      */
@@ -112,12 +114,21 @@ public class BucketInfo {
     }
 
     /**
-     * Determines if a user can delete objects within thi bucket.
+     * Determines if a user can delete objects within this bucket.
      *
      * @return <tt>true</tt> if a user can delete an object within this bucket, <tt>false</tt> otherwise
      */
     public boolean isCanDelete() {
         return canDelete;
+    }
+
+    /**
+     * Determines if searching in a bucket always uses a like on search.
+     *
+     * @return <tt>true</tt> if a like on search is to be used, <tt>false</tt> otherwise
+     */
+    public boolean isAlwaysUseLikeSearch() {
+        return alwaysUseLikeSearch;
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/StorageController.java
+++ b/src/main/java/sirius/biz/storage/StorageController.java
@@ -88,7 +88,7 @@ public class StorageController extends BizController {
                                                  .where(FieldOperator.on(VirtualObject.PATH).notEqual(null))
                                                  .orderDesc(VirtualObject.TRACE.inner(TraceData.CHANGED_AT));
 
-        applyQuery(ctx.get("query").asString(), baseQuery);
+        applyQuery(ctx.get("query").asString(), baseQuery, bucket.isAlwaysUseLikeSearch());
 
         PageHelper<VirtualObject> pageHelper = PageHelper.withQuery(baseQuery).withContext(ctx).forCurrentTenant();
 
@@ -137,7 +137,7 @@ public class StorageController extends BizController {
                                                  .orderDesc(VirtualObject.TRACE.inner(TraceData.CHANGED_AT))
                                                  .limit(10);
 
-        applyQuery(query, baseQuery);
+        applyQuery(query, baseQuery, bucket.isAlwaysUseLikeSearch());
         for (VirtualObject object : baseQuery.queryList()) {
             result.accept(new AutocompleteHelper.Completion(object.getObjectKey(),
                                                             object.getFilename(),
@@ -150,10 +150,11 @@ public class StorageController extends BizController {
      * but most user will search for a filename without a leading slash. Therefore we
      * gracefully fix this.
      *
-     * @param query     the query string to apply
-     * @param baseQuery the query to expand
+     * @param query               the query string to apply
+     * @param baseQuery           the query to expand
+     * @param alwaysUseLikeSearch determines wheter we always use a like on for matching
      */
-    private void applyQuery(String query, SmartQuery<VirtualObject> baseQuery) {
+    private void applyQuery(String query, SmartQuery<VirtualObject> baseQuery, boolean alwaysUseLikeSearch) {
         if (Strings.isEmpty(query)) {
             return;
         }
@@ -163,7 +164,7 @@ public class StorageController extends BizController {
             queryString = "/" + queryString;
         }
 
-        if (queryString.contains("*")) {
+        if (queryString.contains("*") || alwaysUseLikeSearch) {
             baseQuery.where(Or.of(Like.on(VirtualObject.PATH).matches(queryString),
                                   Like.on(VirtualObject.OBJECT_KEY).matches(query)));
         } else {

--- a/src/main/java/sirius/biz/storage/StorageController.java
+++ b/src/main/java/sirius/biz/storage/StorageController.java
@@ -160,11 +160,19 @@ public class StorageController extends BizController {
         }
 
         String queryString = query;
+        if (alwaysUseLikeSearch) {
+            if (!queryString.startsWith("*")) {
+                queryString = "*" + queryString;
+            }
+            if (!queryString.endsWith("*")) {
+                queryString += "*";
+            }
+        }
         if (!(queryString.startsWith("*") || queryString.startsWith("/"))) {
             queryString = "/" + queryString;
         }
 
-        if (queryString.contains("*") || alwaysUseLikeSearch) {
+        if (queryString.contains("*")) {
             baseQuery.where(Or.of(Like.on(VirtualObject.PATH).matches(queryString),
                                   Like.on(VirtualObject.OBJECT_KEY).matches(query)));
         } else {

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -136,6 +136,9 @@ storage {
             # Determines if an object (file) can be edited via the management UI.
             canEdit = false
 
+            # Determines whether a search in a bucket should always use a like constraint.
+            alwaysUseLikeSearch = false
+
             # Determines if an object (file) can be deleted via the management UI.
             canDelete = false
 


### PR DESCRIPTION
For some buckets it is desired that the search is executed as if you would like to search only parts of the file name.