### PR TITLE
Small word wrap css fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>5.0</version>
+    <version>5.0.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/resources/default/taglib/w/storedObjectUploader.html.pasta
+++ b/src/main/resources/default/taglib/w/storedObjectUploader.html.pasta
@@ -12,7 +12,7 @@
     <div class="qq-upload-drop-area qq-image-area qq-upload-drop-area-js">
         <div class="file-upload-file file-upload-file-js">
             <i:if test="@showStorageKey">
-                <p>
+                <p style="word-wrap: break-word">
                     @objectRef.toString()
                 </p>
             </i:if>


### PR DESCRIPTION
Updates the word-wrap style to break-word since objektrefkeys can be  long.
.word-wrap cant be used since we dont want to use hyphons here.
Version-Bump