### PR TITLE
 Clears the object version cache when removing versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>5.1</version>
+    <version>5.1.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/java/sirius/biz/storage/Storage.java
+++ b/src/main/java/sirius/biz/storage/Storage.java
@@ -90,6 +90,9 @@ public class Storage {
     @Part
     private GlobalContext context;
 
+    @Part
+    private VersionManager versionManager;
+
     @ConfigValue("storage.sharedSecret")
     private String sharedSecret;
     private String safeSharedSecret;
@@ -424,7 +427,8 @@ public class Storage {
             virtualObjectCache.remove(object.getObjectKey());
 
             // Delete all (now outdated) versions
-            oma.select(VirtualObjectVersion.class).eq(VirtualObjectVersion.VIRTUAL_OBJECT, object).delete();
+            versionManager.removeVersionsForVirtualObject(object);
+
             // Delete old file
             engine.deletePhysicalObject(object.getBucket(), oldPhysicalKey);
         } catch (IOException e) {

--- a/src/main/java/sirius/biz/storage/Storage.java
+++ b/src/main/java/sirius/biz/storage/Storage.java
@@ -90,9 +90,6 @@ public class Storage {
     @Part
     private GlobalContext context;
 
-    @Part
-    private VersionManager versionManager;
-
     @ConfigValue("storage.sharedSecret")
     private String sharedSecret;
     private String safeSharedSecret;
@@ -179,6 +176,15 @@ public class Storage {
         }
 
         return Optional.ofNullable(virtualObject);
+    }
+
+    /**
+     * Clears the cache for a given {@link VirtualObject}.
+     *
+     * @param virtualObject the virtual object
+     */
+    protected void clearCacheForVirtualObject(VirtualObject virtualObject) {
+        virtualObjectCache.remove(virtualObject.getObjectKey());
     }
 
     private boolean checkIntegrity(VirtualObject virtualObject, @Nullable Tenant tenant, String bucket) {
@@ -308,7 +314,7 @@ public class Storage {
      * Deletes all automatically created objects except the given one.
      * <p>
      * Removes automatically created object ({@link #createTemporaryObject(Tenant, String, String, String)})
-     * if the reference is updated or the referencing entity is deleted. All deleted objects are removed from the cache.
+     * if the reference is updated or the referencing entity is deleted.
      *
      * @param reference         the reference (field+id of the entity) being referenced
      * @param excludedObjectKey if the reference is just changed, the new object is excluded, to just delete the old
@@ -322,8 +328,6 @@ public class Storage {
         if (Strings.isFilled(excludedObjectKey)) {
             qry.where(FieldOperator.on(VirtualObject.OBJECT_KEY).notEqual(excludedObjectKey));
         }
-
-        qry.iterateAll(virtualObject -> virtualObjectCache.remove(virtualObject.getObjectKey()));
 
         qry.delete();
     }
@@ -393,8 +397,6 @@ public class Storage {
 
     /**
      * Updates the given file based on the given stream.
-     * <p>
-     * The updated object is removed from the cache, to ensure that the cache is up to date.
      *
      * @param file     the S3 file to update
      * @param data     the data to store
@@ -423,11 +425,8 @@ public class Storage {
             object.setPhysicalKey(newPhysicalKey);
             oma.override(object);
 
-            // Remove from cache
-            virtualObjectCache.remove(object.getObjectKey());
-
             // Delete all (now outdated) versions
-            versionManager.removeVersionsForVirtualObject(object);
+            oma.select(VirtualObjectVersion.class).eq(VirtualObjectVersion.VIRTUAL_OBJECT, object).delete();
 
             // Delete old file
             engine.deletePhysicalObject(object.getBucket(), oldPhysicalKey);
@@ -474,7 +473,6 @@ public class Storage {
      */
     public void delete(StoredObject object) {
         if (object instanceof VirtualObject) {
-            virtualObjectCache.remove(object.getObjectKey());
             oma.delete((VirtualObject) object);
         }
     }

--- a/src/main/java/sirius/biz/storage/VersionManager.java
+++ b/src/main/java/sirius/biz/storage/VersionManager.java
@@ -103,15 +103,12 @@ public class VersionManager {
     }
 
     /**
-     * Removes all versions for a given {@link VirtualObject}.
-     * <p>
-     * And clears the cache.
+     * Clears the cache for a given {@link VirtualObject}.
      *
      * @param virtualObject the virtual object
      */
-    protected void removeVersionsForVirtualObject(VirtualObject virtualObject) {
+    protected void clearCacheForVirtualObject(VirtualObject virtualObject) {
         logicalToPhysicalCache.remove(virtualObject.getBucket() + "-" + virtualObject.getObjectKey());
-        oma.select(VirtualObjectVersion.class).eq(VirtualObjectVersion.VIRTUAL_OBJECT, virtualObject).delete();
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/VersionManager.java
+++ b/src/main/java/sirius/biz/storage/VersionManager.java
@@ -103,6 +103,18 @@ public class VersionManager {
     }
 
     /**
+     * Removes all versions for a given {@link VirtualObject}.
+     * <p>
+     * And clears the cache.
+     *
+     * @param virtualObject the virtual object
+     */
+    protected void removeVersionsForVirtualObject(VirtualObject virtualObject) {
+        logicalToPhysicalCache.remove(virtualObject.getBucket() + "-" + virtualObject.getObjectKey());
+        oma.select(VirtualObjectVersion.class).eq(VirtualObjectVersion.VIRTUAL_OBJECT, virtualObject).delete();
+    }
+
+    /**
      * Fetches the pyhsical key for a version from the tuple retrieved via {@link #fetchPhysicalObjects(DownloadBuilder)}
      *
      * @param physicalObjects the map of already resolved keys

--- a/src/main/java/sirius/biz/storage/VirtualObject.java
+++ b/src/main/java/sirius/biz/storage/VirtualObject.java
@@ -12,6 +12,7 @@ import sirius.biz.tenants.TenantAware;
 import sirius.db.KeyGenerator;
 import sirius.db.mixing.Column;
 import sirius.db.mixing.annotations.AfterDelete;
+import sirius.db.mixing.annotations.AfterSave;
 import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.Index;
 import sirius.db.mixing.annotations.Length;
@@ -115,6 +116,9 @@ public class VirtualObject extends TenantAware implements StoredObject {
     private static Storage storage;
 
     @Part
+    private static VersionManager versionManager;
+
+    @Part
     private static KeyGenerator keyGen;
 
     @BeforeSave
@@ -160,6 +164,13 @@ public class VirtualObject extends TenantAware implements StoredObject {
     @AfterDelete
     protected void removePhysicalObject() {
         storage.deletePhysicalObject(getBucket(), getPhysicalKey());
+    }
+
+    @BeforeSave
+    @AfterDelete
+    protected void removeObjectFromCaches() {
+        versionManager.clearCacheForVirtualObject(this);
+        storage.clearCacheForVirtualObject(this);
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/VirtualObjectVersion.java
+++ b/src/main/java/sirius/biz/storage/VirtualObjectVersion.java
@@ -76,6 +76,9 @@ public class VirtualObjectVersion extends Entity {
     @Part
     private static Storage storage;
 
+    @Part
+    private static VersionManager versionManager;
+
     @BeforeSave
     protected void initDate() {
         if (createdDate == null) {
@@ -86,6 +89,15 @@ public class VirtualObjectVersion extends Entity {
     @AfterDelete
     protected void removePhysicalFile() {
         storage.deletePhysicalObject(getBucket(), getPhysicalKey());
+    }
+
+    @BeforeSave
+    @AfterDelete
+    protected void removeVersionFromCaches() {
+        if (this.getVirtualObject().isFilled()) {
+            versionManager.clearCacheForVirtualObject(this.getVirtualObject().getValue());
+            storage.clearCacheForVirtualObject(this.getVirtualObject().getValue());
+        }
     }
 
     public EntityRef<VirtualObject> getVirtualObject() {


### PR DESCRIPTION
When a virtual object was updated the versions where only removed from the database, but not the cache. This lead to outdated URLs and therefore broken images.