### PR TITLE
Prevents marking an empty input field as a weak password

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/resources/default/templates/password/password.html.pasta
+++ b/src/main/resources/default/templates/password/password.html.pasta
@@ -106,5 +106,8 @@
         $('#confirmation').keyup(function () {
             verifyConfirmation(@minLength);
         });
+
+        // Reset all alert classes
+        removeAlertClasses($('.security-level-js'));
     });
 </script>


### PR DESCRIPTION
It might be confusing for the user to see the message "weak password" after loading the page.
- Fixes: SE-4166