### PR TITLE
Uses ensureSafePOST() instead of isSafePOST()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>11.0</sirius.kernel>
-        <sirius.web>18.4</sirius.web>
+        <sirius.web>18.5</sirius.web>
         <sirius.db>5.0-SNAPSHOT</sirius.db>
     </properties>
 

--- a/src/main/java/sirius/biz/jdbc/codelists/CodeListController.java
+++ b/src/main/java/sirius/biz/jdbc/codelists/CodeListController.java
@@ -115,7 +115,7 @@ public class CodeListController extends BizController {
     public void codeListEntry(WebContext ctx, String codeListId) {
         CodeList cl = findForTenant(CodeList.class, codeListId);
         assertNotNew(cl);
-        if (ctx.isSafePOST()) {
+        if (ctx.ensureSafePOST()) {
             if (ctx.get("code").isFilled()) {
                 String code = ctx.get("code").asString();
                 CodeListEntry cle = oma.select(CodeListEntry.class)

--- a/src/main/java/sirius/biz/jdbc/jobs/JobsController.java
+++ b/src/main/java/sirius/biz/jdbc/jobs/JobsController.java
@@ -49,7 +49,7 @@ public class JobsController extends BizController {
     public void runJob(WebContext ctx, String factory, String jobName) {
         JobDescription job = jobs.resolve(factory, jobName);
         List<JobParameterDescription> params = fetchParameterDescriptions(job);
-        if (ctx.isSafePOST()) {
+        if (ctx.ensureSafePOST()) {
             try {
                 Context context = Context.create();
                 boolean hasWarnings = loadParameters(ctx, params, context);

--- a/src/main/java/sirius/biz/jdbc/tenants/ProfileController.java
+++ b/src/main/java/sirius/biz/jdbc/tenants/ProfileController.java
@@ -57,7 +57,7 @@ public class ProfileController extends BizController {
         UserAccount userAccount = oma.refreshOrFail(getUser().getUserObject(UserAccount.class));
         assertNotNew(userAccount);
 
-        if (ctx.isSafePOST()) {
+        if (ctx.ensureSafePOST()) {
             try {
                 String oldPassword = ctx.get(PARAM_OLD_PASSWORD).asString();
                 String newPassword = ctx.get(PARAM_NEW_PASSWORD).asString();

--- a/src/main/java/sirius/biz/jdbc/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/jdbc/tenants/UserAccountController.java
@@ -205,7 +205,7 @@ public class UserAccountController extends BizController {
         UserAccount userAccount = findForTenant(UserAccount.class, id);
         assertNotNew(userAccount);
 
-        if (ctx.isSafePOST()) {
+        if (ctx.ensureSafePOST()) {
             try {
                 String oldPassword = ctx.get(PARAM_OLD_PASSWORD).asString();
                 String newPassword = ctx.get(PARAM_NEW_PASSWORD).asString();

--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -354,11 +354,11 @@ public class BizController extends BasicController {
          * @return <tt>true</tt> if the request was handled (the user was redirected), <tt>false</tt> otherwise
          */
         public boolean saveEntity(BaseEntity<?> entity) {
-            if (!((acceptUnsafePOST && ctx.isUnsafePOST()) || ctx.isSafePOST())) {
-                return false;
-            }
-
             try {
+                if (!((acceptUnsafePOST && ctx.isUnsafePOST()) || ctx.ensureSafePOST())) {
+                    return false;
+                }
+
                 boolean wasNew = entity.isNew();
 
                 if (autoload) {


### PR DESCRIPTION
This is because we want to provide feedback to the user if the token is invalid e.g. because of token lifetime
instead of silently skipping deletion/modification.