### PR TITLE
Autocomplete in storage always with wildcard

### DIFF
--- a/src/main/java/sirius/biz/jdbc/storage/StorageController.java
+++ b/src/main/java/sirius/biz/jdbc/storage/StorageController.java
@@ -167,14 +167,12 @@ public class StorageController extends BizController {
         if (!(queryString.startsWith("*") || queryString.startsWith("/"))) {
             queryString = "/" + queryString;
         }
-
-        if (queryString.contains("*")) {
-            baseQuery.where(OMA.FILTERS.or(OMA.FILTERS.like(VirtualObject.PATH).matches(queryString).build(),
-                                           OMA.FILTERS.like(VirtualObject.OBJECT_KEY).matches(query).build()));
-        } else {
-            baseQuery.where(OMA.FILTERS.or(OMA.FILTERS.eq(VirtualObject.PATH, queryString),
-                                           OMA.FILTERS.eq(VirtualObject.OBJECT_KEY, query)));
+        if (!queryString.contains("*")) {
+            queryString += "*";
         }
+
+        baseQuery.where(OMA.FILTERS.or(OMA.FILTERS.like(VirtualObject.PATH).matches(queryString).build(),
+                                       OMA.FILTERS.like(VirtualObject.OBJECT_KEY).matches(query).build()));
     }
 
     /**


### PR DESCRIPTION
Autocompletes for the storage engine should search with wildcard at the end for easier autocompletion. Only the first part of an stored object is now needed instead of the complete query. This is also used in the list for the objects.

Tags: storage, autocomplete