### PR TITLE
Respect codelist autofill settings

### DIFF
--- a/src/main/java/sirius/biz/codelists/CodeLists.java
+++ b/src/main/java/sirius/biz/codelists/CodeLists.java
@@ -144,7 +144,10 @@ public class CodeLists {
         if (Strings.isEmpty(codeList)) {
             throw new IllegalArgumentException("codeList must not be empty");
         }
-        CodeList cl = oma.select(CodeList.class).fields(SQLEntity.ID).eq(CodeList.CODE, codeList).queryFirst();
+        CodeList cl = oma.select(CodeList.class)
+                         .fields(SQLEntity.ID, CodeList.AUTO_FILL)
+                         .eq(CodeList.CODE, codeList)
+                         .queryFirst();
         if (cl == null) {
             Extension ext = Sirius.getSettings().getExtension("code-lists", codeList);
             cl = new CodeList();


### PR DESCRIPTION
If a codelist was set to autofill false in CodeLists::getValues a non present value would be added with no regard of the setting.

Tags: codelist