### PR TITLE
Allows to recalculate the searchPrefixes field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>12.0-rc26</sirius.kernel>
         <sirius.web>19.0-rc23</sirius.web>
-        <sirius.db>5.0-rc33</sirius.db>
+        <sirius.db>5.0-rc38</sirius.db>
     </properties>
 
     <dependencies>

--- a/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
@@ -12,6 +12,7 @@ import sirius.biz.protocol.NoJournal;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.Index;
+import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.types.NestedList;
 import sirius.db.mixing.types.StringList;
 import sirius.db.mixing.types.StringListMap;
@@ -39,10 +40,15 @@ public abstract class PrefixSearchableEntity extends MongoEntity {
     @NoJournal
     private final StringList searchPrefixes = new StringList();
 
+    @Transient
+    private boolean forceUpdateSearchPrefixes;
+
     @BeforeSave
     protected void updateSearchField() {
         if (!isNew()
-            && getDescriptor().isFetched(this, getDescriptor().getProperty(SEARCH_PREFIXES))
+            && !forceUpdateSearchPrefixes
+            && getDescriptor().isFetched(this,
+                                         getDescriptor().getProperty(SEARCH_PREFIXES))
             && !isAnyMappingChanged()) {
             return;
         }
@@ -111,5 +117,21 @@ public abstract class PrefixSearchableEntity extends MongoEntity {
 
     public StringList getSearchPrefixes() {
         return searchPrefixes;
+    }
+
+    /**
+     * Returns whether the search prefixes will be definitely recalculated on the next {@link BeforeSave} event
+     *
+     * @return whether the search prefixes will be definitely recalculated on the next {@link BeforeSave} event
+     */
+    public boolean isForceUpdateSearchPrefixes() {
+        return forceUpdateSearchPrefixes;
+    }
+
+    /**
+     * Forces the search prefixes to be recalculated on the next {@link BeforeSave} event
+     */
+    public void setForceUpdateSearchPrefixes(boolean forceUpdateSearchPrefixes) {
+        this.forceUpdateSearchPrefixes = forceUpdateSearchPrefixes;
     }
 }

--- a/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
@@ -41,7 +41,9 @@ public abstract class PrefixSearchableEntity extends MongoEntity {
 
     @BeforeSave
     protected void updateSearchField() {
-        if (!isNew() && !isAnyMappingChanged()) {
+        if (!isNew()
+            && getDescriptor().isFetched(this, getDescriptor().getProperty(SEARCH_PREFIXES))
+            && !isAnyMappingChanged()) {
             return;
         }
 


### PR DESCRIPTION
If an Entity becomes a `PrefixSearchableEntity` or if some fields of an `PrefixSearchableEntity` get or lose the `@PrefixSearchContent` annotation, the `searchPrefixes` field is not automatically updated. The new `setForceUpdateSearchPrefixes` method allows to create a command that forces to recalculate the `searchPrefixes` field manually after the patch. Furthermore, the `searchPrefixes` field is created if it didn't exist already.