### PR TITLE
Allows to set the base url per tenant instead of only once per product

### DIFF
--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -141,6 +141,11 @@ public class BizController extends BasicController {
                 LOG.WARN("product.baseUrl is not filled. Please update the system configuration!");
             }
         }
+
+        if (UserContext.getSettings().getConfig().hasPath("tenant.baseUrl")) {
+            return UserContext.getSettings().get("tenant.baseUrl").asString();
+        }
+
         return baseUrl;
     }
 


### PR DESCRIPTION
Backend users of the tenant should not always the the product url but
their own url
- Fixes: SE-4956