### PR TITLE
Make CodeListEntries translatable

### DIFF
--- a/src/main/java/sirius/biz/codelists/CodeListEntry.java
+++ b/src/main/java/sirius/biz/codelists/CodeListEntry.java
@@ -15,6 +15,7 @@ import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Trim;
 import sirius.db.mixing.annotations.Unique;
+import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Framework;
 import sirius.kernel.di.std.Priorized;
 
@@ -71,6 +72,16 @@ public class CodeListEntry extends BizEntity {
     @Length(1024)
     @NullAllowed
     private String description;
+
+    /**
+     * Returns the value of the entry which is translated via
+     * {@link Value#translate()}.
+     *
+     * @return the translated value
+     */
+    public String getTranslatedValue() {
+        return Value.of(value).translate().getString();
+    }
 
     public SQLEntityRef<CodeList> getCodeList() {
         return codeList;

--- a/src/main/java/sirius/biz/codelists/CodeLists.java
+++ b/src/main/java/sirius/biz/codelists/CodeLists.java
@@ -14,6 +14,7 @@ import sirius.kernel.Sirius;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
+import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
@@ -45,6 +46,20 @@ public class CodeLists {
     private OMA oma;
 
     private static final Log LOG = Log.get("codelists");
+
+    /**
+     * Returns the value translated from the given code list associated with the given code.
+     * <p>
+     * If no matching entry exists, the code itself will be returned.
+     *
+     * @param codeList the code list to search in
+     * @param code     the code to lookup
+     * @return the translated value associated with the code or the code itself if no value exists
+     */
+    @Nullable
+    public String getTranslatedValue(@Nonnull String codeList, @Nullable String code) {
+        return Value.of(getValue(codeList, code)).translate().getString();
+    }
 
     /**
      * Returns the value from the given code list associated with the given code.

--- a/src/main/java/sirius/biz/model/PersonData.java
+++ b/src/main/java/sirius/biz/model/PersonData.java
@@ -10,8 +10,8 @@ package sirius.biz.model;
 
 import sirius.biz.codelists.CodeLists;
 import sirius.biz.web.Autoloaded;
-import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Composite;
+import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Trim;
@@ -139,7 +139,7 @@ public class PersonData extends Composite {
      * @return the value for <tt>salutation</tt> from the <tt>salutations</tt> code list
      */
     public String getTranslatedSalutation() {
-        return codeLists.getValue("salutations", salutation);
+        return codeLists.getTranslatedValue("salutations", salutation);
     }
 
     public String getTitle() {

--- a/src/main/resources/default/taglib/w/codelistSelect.html.pasta
+++ b/src/main/resources/default/taglib/w/codelistSelect.html.pasta
@@ -17,6 +17,6 @@
 
 <w:singleSelect span="@span" name="@name" label="@label" help="@help" optional="@optional" required="@required" readonly="@readonly" adminOnly="@adminOnly" forceFullWidth="@forceFullWidth">
     <i:for var="entry" type="sirius.biz.codelists.CodeListEntry" items="@codeLists.getEntries(list)">
-        <option value="@entry.getCode()" @if(entry.getCode().equals(value)) {selected="selected"} >@entry.getValue()</option>
+        <option value="@entry.getCode()" @if(entry.getCode().equals(value)) {selected="selected"} >@entry.getTranslatedValue()</option>
     </i:for>
 </w:singleSelect>


### PR DESCRIPTION
Some systems have several languages in place. In order to use the same entries for salutations the codelist entries can now be translated for those systems.

Tags: codelist, translation, nls