### PR TITLE
Avoid NPE on empty physical key

### DIFF
--- a/src/main/java/sirius/biz/storage/FSStorageEngine.java
+++ b/src/main/java/sirius/biz/storage/FSStorageEngine.java
@@ -98,6 +98,9 @@ public class FSStorageEngine implements PhysicalStorageEngine {
     @Nullable
     @Override
     public InputStream getData(String bucket, String physicalKey) {
+        if (Strings.isEmpty(physicalKey)) {
+            return null;
+        }
         File file = getFile(bucket, physicalKey);
 
         try {


### PR DESCRIPTION
A physical key could be empty. On building versions, this causes an NPE. Now null is returned in this case to avoid an NPE.

Tags: storage, versions