### PR TITLE
Adds a de-duplication when collecting descriptions for cluster jobs.

### DIFF
--- a/src/main/java/sirius/biz/cluster/ClusterController.java
+++ b/src/main/java/sirius/biz/cluster/ClusterController.java
@@ -14,7 +14,6 @@ import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.DelayLine;
 import sirius.kernel.async.Tasks;
-import sirius.kernel.commons.Tuple;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.HandledException;
@@ -158,8 +157,9 @@ public class ClusterController implements Controller {
                                           .collect(Collectors.toList());
         Map<String, String> descriptions = clusterInfo.stream()
                                                       .flatMap(node -> node.getJobs().entrySet().stream())
-                                                      .map(e -> Tuple.create(e.getKey(), e.getValue().getDescription()))
-                                                      .collect(Collectors.toMap(Tuple::getFirst, Tuple::getSecond));
+                                                      .collect(Collectors.toMap(Map.Entry::getKey,
+                                                                                e -> e.getValue().getDescription(),
+                                                                                (a, b) -> a));
         ctx.respondWith()
            .template("templates/cluster/cluster.html.pasta", jobKeys, descriptions, clusterInfo, locks.getLocks());
     }

--- a/src/main/java/sirius/biz/cluster/ClusterController.java
+++ b/src/main/java/sirius/biz/cluster/ClusterController.java
@@ -161,7 +161,7 @@ public class ClusterController implements Controller {
                                                                                 e -> e.getValue().getDescription(),
                                                                                 (a, b) -> a));
         ctx.respondWith()
-           .template("templates/cluster/cluster.html.pasta", jobKeys, descriptions, clusterInfo, locks.getLocks());
+           .template("templates/cluster/cluster.html.pasta", jobKeys, descriptions, clusterInfo, locks);
     }
 
     /**

--- a/src/main/java/sirius/biz/cluster/InterconnectClusterManager.java
+++ b/src/main/java/sirius/biz/cluster/InterconnectClusterManager.java
@@ -137,7 +137,9 @@ public class InterconnectClusterManager implements ClusterManager, InterconnectH
 
             return result;
         } catch (Exception e) {
-            return new JSONObject().fluentPut(RESPONSE_ERROR, true).fluentPut(RESPONSE_ERROR_MESAGE, e.getMessage());
+            return new JSONObject().fluentPut(RESPONSE_NODE_NAME, nodeName)
+                                   .fluentPut(RESPONSE_ERROR, true)
+                                   .fluentPut(RESPONSE_ERROR_MESAGE, e.getMessage());
         }
     }
 

--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -387,6 +387,10 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
     }
 
     private BackgroundInfo parseBackgroundInfos(JSONObject jsonObject) {
+        if (jsonObject.getBooleanValue(InterconnectClusterManager.RESPONSE_ERROR)) {
+            return new BackgroundInfo(jsonObject.getString(InterconnectClusterManager.RESPONSE_NODE_NAME), "-");
+        }
+
         BackgroundInfo result = new BackgroundInfo(jsonObject.getString(InterconnectClusterManager.RESPONSE_NODE_NAME),
                                                    jsonObject.getString(ClusterController.RESPONSE_UPTIME));
         jsonObject.getJSONArray(ClusterController.RESPONSE_JOBS).forEach(job -> {

--- a/src/main/resources/default/templates/cluster/cluster.html.pasta
+++ b/src/main/resources/default/templates/cluster/cluster.html.pasta
@@ -1,7 +1,7 @@
 <i:arg type="List" name="keys"/>
 <i:arg type="Map" name="descriptions"/>
 <i:arg type="List" name="nodes"/>
-<i:arg type="List" name="locks"/>
+<i:arg type="sirius.biz.locks.Locks" name="locks"/>
 
 <w:page title="Cluster State">
     <i:block name="breadcrumbs">
@@ -72,7 +72,7 @@
 
     <i:if test="locks != null">
         <w:heading>Locks</w:heading>
-        <w:table data="locks">
+        <w:table data="locks.getLocks()">
             <i:for type="sirius.biz.locks.LockInfo" var="lock" items="locks">
                 <tr>
                     <th><b>Name</b></th>

--- a/src/main/resources/default/templates/cluster/cluster.html.pasta
+++ b/src/main/resources/default/templates/cluster/cluster.html.pasta
@@ -70,21 +70,23 @@
         </table>
     </i:for>
 
-    <w:heading>Locks</w:heading>
-    <w:table data="locks">
-        <i:for type="sirius.biz.locks.LockInfo" var="lock" items="locks">
-            <tr>
-                <th><b>Name</b></th>
-                <th>Owner</th>
-                <th>Thread</th>
-                <th>Acquired</th>
-            </tr>
-            <tr>
-                <td><b>@lock.getName()</b></td>
-                <td>@lock.getOwner()</td>
-                <td>@lock.getThread()</td>
-                <td>@toUserString(lock.getAcquired())</td>
-            </tr>
-        </i:for>
-    </w:table>
+    <i:if test="locks != null">
+        <w:heading>Locks</w:heading>
+        <w:table data="locks">
+            <i:for type="sirius.biz.locks.LockInfo" var="lock" items="locks">
+                <tr>
+                    <th><b>Name</b></th>
+                    <th>Owner</th>
+                    <th>Thread</th>
+                    <th>Acquired</th>
+                </tr>
+                <tr>
+                    <td><b>@lock.getName()</b></td>
+                    <td>@lock.getOwner()</td>
+                    <td>@lock.getThread()</td>
+                    <td>@toUserString(lock.getAcquired())</td>
+                </tr>
+            </i:for>
+        </w:table>
+    </i:if>
 </w:page>


### PR DESCRIPTION
As most probably each node reports all jobs, we only need to use
the first description as (if all nodes run the same software version)
the descriptions would be the same anyway.