### PR TITLE
Fills the searchPrefixes field with more subtokens

### DIFF
--- a/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
@@ -19,8 +19,13 @@ import sirius.db.mixing.types.StringListMap;
 import sirius.db.mixing.types.StringMap;
 import sirius.db.mongo.Mango;
 import sirius.db.mongo.MongoEntity;
-import sirius.db.mongo.constraints.MongoFilterFactory;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Maintains a <tt>prefixSearchField</tt> in which all fields annotated with {@link PrefixSearchContent} are indexed.
@@ -32,6 +37,17 @@ public abstract class PrefixSearchableEntity extends MongoEntity {
      * We will not index anything longer than 255 characters as it is pointless.
      */
     private static final int MAX_TOKEN_LENGTH = 255;
+
+    /**
+     * Represents a regular expression which detects all character which aren't allowed in a search prefix.
+     */
+    public static final Pattern NON_SEARCH_PREFIX_CHARACTER = Pattern.compile("[^\\p{L}\\d_\\-@.#]");
+
+    /**
+     * Represents a regular expression which detects all characters which are allowed in a search prefix but still cause
+     * a token to be splitted.
+     */
+    public static final Pattern SPLIT_CHARACTER = Pattern.compile("[^\\p{L}]+");
 
     /**
      * Contains manually maintained content to be added to the search field.
@@ -90,18 +106,29 @@ public abstract class PrefixSearchableEntity extends MongoEntity {
      *
      * @param value the value to tokenize
      */
+    @SuppressWarnings("squid:S2259")
+    @Explain("input cannot be null due to Strings.isEmpty")
     public void addContentAsTokens(Object value) {
         String input = value == null ? null : String.valueOf(value);
         if (Strings.isEmpty(input)) {
             return;
         }
 
-        String tokenInLowerCase = input.toLowerCase();
-        for (String subToken : MongoFilterFactory.NON_PREFIX_CHARACTER.matcher(tokenInLowerCase)
-                                                                      .replaceAll(" ")
-                                                                      .split(" ")) {
-            appendSingleToken(subToken);
+        for (String subToken : NON_SEARCH_PREFIX_CHARACTER.matcher(input.toLowerCase()).replaceAll(" ").split(" ")) {
+            powerSet(subToken).forEach(this::appendSingleToken);
         }
+    }
+
+    private Set<String> powerSet(String token) {
+        Set<String> result = new HashSet<>();
+        result.add(token);
+
+        Matcher matcher = SPLIT_CHARACTER.matcher(token);
+        while (matcher.find()) {
+            result.addAll(powerSet(token.substring(0, matcher.start())));
+            result.addAll(powerSet(token.substring(matcher.end())));
+        }
+        return result;
     }
 
     private void appendSingleToken(String subToken) {

--- a/src/test/java/sirius/biz/mongo/PrefixSearchableEntitySpec.groovy
+++ b/src/test/java/sirius/biz/mongo/PrefixSearchableEntitySpec.groovy
@@ -38,6 +38,24 @@ class PrefixSearchableEntitySpec extends BaseSpecification {
         !tokens.contains("content")
     }
 
+    def "splitting with emails works"() {
+        given:
+        PrefixSearchableTestEntity e = new PrefixSearchableTestEntity()
+        when:
+        e.setTest(input)
+        and:
+        e.updateSearchField()
+        and:
+        List<String> tokens = e.getSearchPrefixes().modify().sort()
+        output.sort()
+        then:
+        tokens == output
+        where:
+        input      | output
+        "a.b@c.de" | ["a", "b", "c", "de", "a.b", "c.de", "a.b@c.de"]
+        "a24@x.de" | ["a24", "a", "x", "de", "x.de", "a24@x.de"]
+    }
+
     def "searching works"() {
         when:
         PrefixSearchableTestEntity e = new PrefixSearchableTestEntity()


### PR DESCRIPTION
# before

input | searchPrefixes
------|-------
`"a.b@c.de"` | `[a.b@c.de"]`
`"a24@x.de"` | `["a", "", "@x.de"]`
`"xyz–test.blubb"` | `["xyz", "test.blubb"]` 

# after

input | searchPrefixes
------|-------
`"a.b@c.de"` | `["a.b@c.de", "a.b", "a", "b", "c.de", "c", "de"]`
`"a24@x.de"` | `["a24@x.de", "a24", "a", "x.de", "x", "de"]`
`"xyz–test.blubb"` | `["xyz-test.blubb", "xyz", "test", "blubb"]` 