### PR TITLE
Fix Exception on reading null content versioned files

### DIFF
--- a/src/main/java/sirius/biz/storage/versions/VersionedFiles.java
+++ b/src/main/java/sirius/biz/storage/versions/VersionedFiles.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -104,6 +105,9 @@ public class VersionedFiles {
      * @return {@link List<String>} each string holding one line of the file content
      */
     public List<String> getContent(VersionedFile file) {
+        if (file.getStoredFile().isEmpty()) {
+            return Collections.emptyList();
+        }
         try (InputStream data = storage.getData(file.getStoredFile().getObject())) {
             return new BufferedReader(new InputStreamReader(data)).lines().collect(Collectors.toList());
         } catch (IOException e) {

--- a/src/test/java/sirius/biz/storage/VersionedFilesSpec.groovy
+++ b/src/test/java/sirius/biz/storage/VersionedFilesSpec.groovy
@@ -81,4 +81,13 @@ class VersionedFilesSpec extends BaseSpecification {
         then:
         versionedFiles.getVersions(tenant, identifier).size() == 1
     }
+
+    def "reading out a null version returns an empty list as content"() {
+        given:
+        String identifier = "null-version-content"
+        when:
+        def nullContentFile = versionedFiles.createVersion(tenant, identifier, null, null)
+        then:
+        versionedFiles.getContent(nullContentFile).isEmpty()
+    }
 }


### PR DESCRIPTION
storage.getData() is nonnull so therefore for a null content versioned file getContent would throw an Exception.

Tags: versioned files