### PR TITLE
Increase lengths for by fields in TraceData

### DIFF
--- a/src/main/java/sirius/biz/protocol/TraceData.java
+++ b/src/main/java/sirius/biz/protocol/TraceData.java
@@ -48,7 +48,7 @@ public class TraceData extends Composite {
     public static final Mapping CREATED_IN = Mapping.named("createdIn");
     @NoJournal
     @NullAllowed
-    @Length(50)
+    @Length(150)
     private String createdIn;
 
     /**
@@ -57,7 +57,7 @@ public class TraceData extends Composite {
     public static final Mapping CHANGED_BY = Mapping.named("changedBy");
     @NoJournal
     @NullAllowed
-    @Length(150)
+    @Length(50)
     private String changedBy;
 
     /**

--- a/src/main/java/sirius/biz/protocol/TraceData.java
+++ b/src/main/java/sirius/biz/protocol/TraceData.java
@@ -15,6 +15,7 @@ import sirius.db.mixing.annotations.Length;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
 import sirius.kernel.async.TaskContext;
+import sirius.kernel.commons.Strings;
 import sirius.web.security.UserContext;
 
 import java.time.LocalDateTime;
@@ -30,7 +31,7 @@ public class TraceData extends Composite {
     public static final Mapping CREATED_BY = Mapping.named("createdBy");
     @NoJournal
     @NullAllowed
-    @Length(150)
+    @Length(50)
     private String createdBy;
 
     /**
@@ -47,7 +48,7 @@ public class TraceData extends Composite {
     public static final Mapping CREATED_IN = Mapping.named("createdIn");
     @NoJournal
     @NullAllowed
-    @Length(150)
+    @Length(50)
     private String createdIn;
 
     /**
@@ -83,11 +84,11 @@ public class TraceData extends Composite {
     protected void update() {
         if (!silent) {
             if (createdAt == null) {
-                createdBy = UserContext.getCurrentUser().getUserName();
+                createdBy = Strings.limit(UserContext.getCurrentUser().getUserName(), 50);
                 createdAt = LocalDateTime.now();
                 createdIn = TaskContext.get().getSystemString();
             }
-            changedBy = UserContext.getCurrentUser().getUserName();
+            changedBy = Strings.limit(UserContext.getCurrentUser().getUserName(), 50);
             changedAt = LocalDateTime.now();
             changedIn = TaskContext.get().getSystemString();
         }

--- a/src/main/java/sirius/biz/protocol/TraceData.java
+++ b/src/main/java/sirius/biz/protocol/TraceData.java
@@ -30,7 +30,7 @@ public class TraceData extends Composite {
     public static final Mapping CREATED_BY = Mapping.named("createdBy");
     @NoJournal
     @NullAllowed
-    @Length(50)
+    @Length(150)
     private String createdBy;
 
     /**
@@ -56,7 +56,7 @@ public class TraceData extends Composite {
     public static final Mapping CHANGED_BY = Mapping.named("changedBy");
     @NoJournal
     @NullAllowed
-    @Length(50)
+    @Length(150)
     private String changedBy;
 
     /**

--- a/src/main/java/sirius/biz/protocol/TraceData.java
+++ b/src/main/java/sirius/biz/protocol/TraceData.java
@@ -86,11 +86,11 @@ public class TraceData extends Composite {
             if (createdAt == null) {
                 createdBy = Strings.limit(UserContext.getCurrentUser().getUserName(), 50);
                 createdAt = LocalDateTime.now();
-                createdIn = TaskContext.get().getSystemString();
+                createdIn = Strings.limit(TaskContext.get().getSystemString(), 150);
             }
             changedBy = Strings.limit(UserContext.getCurrentUser().getUserName(), 50);
             changedAt = LocalDateTime.now();
-            changedIn = TaskContext.get().getSystemString();
+            changedIn = Strings.limit(TaskContext.get().getSystemString(), 150);
         }
     }
 


### PR DESCRIPTION
As LoginData allows an username of 150 characters the TraceData should be able to store this length, too.

Tags: tracing