### PR TITLE
Allow to set the external address to announce in FTP passive mode

### DIFF
--- a/src/main/java/sirius/biz/vfs/ftp/FTPBridge.java
+++ b/src/main/java/sirius/biz/vfs/ftp/FTPBridge.java
@@ -45,6 +45,9 @@ public class FTPBridge {
     @ConfigValue("vfs.ftp.bindAddress")
     private String bindAddress;
 
+    @ConfigValue("vfs.ftp.passiveExternalAddress")
+    private String passiveExternalAddress;
+
     @ConfigValue("vfs.ftp.idleTimeout")
     private Duration idleTimeout;
 
@@ -131,14 +134,18 @@ public class FTPBridge {
             factory.setServerAddress(bindAddress);
         }
 
+        DataConnectionConfigurationFactory dataConnectionConfigurationFactory =
+                new DataConnectionConfigurationFactory();
+
         if (Strings.isFilled(passivePorts)) {
-            DataConnectionConfigurationFactory dataConnectionConfigurationFactory =
-                    new DataConnectionConfigurationFactory();
-
             dataConnectionConfigurationFactory.setPassivePorts(passivePorts);
-
-            factory.setDataConnectionConfiguration(dataConnectionConfigurationFactory.createDataConnectionConfiguration());
         }
+
+        if (Strings.isFilled(passiveExternalAddress)) {
+            dataConnectionConfigurationFactory.setPassiveExternalAddress(passiveExternalAddress);
+        }
+
+        factory.setDataConnectionConfiguration(dataConnectionConfigurationFactory.createDataConnectionConfiguration());
     }
 
     private void setupFtplets(FtpServerFactory serverFactory) {

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -390,6 +390,9 @@ vfs {
         # Specifies the IP address to bind to. Leave empty to use all IP addresses.
         bindAddress = ""
 
+        # Specifies the IP address clients have to connect to in passive mode.
+        passiveExternalAddress = ""
+
         # Specifies the max. login failures before disconnecting.
         maxLoginFailures = 5
 


### PR DESCRIPTION
This is needed for dockerization as the FTP server has to announce the correct address in passive mode for clients to connect to.