### PR TITLE
Prevent a file being replaced by the same file

### DIFF
--- a/src/main/java/sirius/biz/storage/Storage.java
+++ b/src/main/java/sirius/biz/storage/Storage.java
@@ -418,6 +418,9 @@ public class Storage {
                            @Nullable String md5,
                            long size) {
         VirtualObject object = (VirtualObject) file;
+        if (Strings.isFilled(md5) && Strings.areEqual(object.getMd5(), md5)) {
+            return;
+        }
         String newPhysicalKey = keyGen.generateId();
         String oldPhysicalKey = object.getPhysicalKey();
         try {


### PR DESCRIPTION
If a file is uploaded in the storage engine and a md5 hash is provided, it can be checked whether the file has been changed with the already stored md5 hash. In this case it is not necessary to overwrite the file and delete all of its versions.

Tags: storage, upload