### PR TITLE
Downloads via StoredObjectRef can be marked as eternally valid

### DIFF
--- a/src/main/java/sirius/biz/storage/StoredObjectRef.java
+++ b/src/main/java/sirius/biz/storage/StoredObjectRef.java
@@ -110,7 +110,20 @@ public class StoredObjectRef {
      * @return the URL for this reference
      */
     public String getURLWithVersion(String version, String defaultURL) {
-        return getURLWithVersionAndAddonText(version, null, defaultURL);
+        return getURLWithVersion(version, defaultURL, false);
+    }
+
+    /**
+     * Determines the URL for this reference. Returns either the URL if the reference is an external one, or the
+     * versioned URL for the {@link StoredObject} if it exists, otherwise the default URL.
+     *
+     * @param version        the version string
+     * @param defaultURL     the default URL
+     * @param eternallyValid whether a eternally valid url should be generated
+     * @return the URL for this reference
+     */
+    public String getURLWithVersion(String version, String defaultURL, boolean eternallyValid) {
+        return getURLWithVersionAndAddonText(version, null, defaultURL, eternallyValid);
     }
 
     /**
@@ -123,6 +136,23 @@ public class StoredObjectRef {
      * @return the URL for this reference
      */
     public String getURLWithVersionAndAddonText(String version, String addonText, String defaultURL) {
+        return getURLWithVersionAndAddonText(version, addonText, defaultURL, false);
+    }
+
+    /**
+     * Determines the URL for this reference. Returns either the URL if the reference is an external one, or the
+     * versioned URL for the {@link StoredObject} if it exists, otherwise the default URL.
+     *
+     * @param version        the version string
+     * @param addonText      the addon text to add to the generated URL
+     * @param defaultURL     the default URL
+     * @param eternallyValid whether a eternally valid url should be generated
+     * @return the URL for this reference
+     */
+    public String getURLWithVersionAndAddonText(String version,
+                                                String addonText,
+                                                String defaultURL,
+                                                boolean eternallyValid) {
         if (isURL()) {
             return getKey();
         }
@@ -131,7 +161,13 @@ public class StoredObjectRef {
             return defaultURL;
         }
 
-        return getObject().prepareURL().withVersion(version).withAddonText(addonText).buildURL().orElse(defaultURL);
+        DownloadBuilder downloadBuilder = getObject().prepareURL().withVersion(version).withAddonText(addonText);
+
+        if (eternallyValid) {
+            downloadBuilder.eternallyValid();
+        }
+
+        return downloadBuilder.buildURL().orElse(defaultURL);
     }
 
     /**


### PR DESCRIPTION
Currently they are only valid for a limited timeframe. Now it is possible to generate a eternally valid url.

Tags: storage