### PR TITLE
 Moves the tenant check for job parameters into it's own method

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/EntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameter.java
@@ -17,7 +17,6 @@ import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mixing;
 import sirius.db.mongo.Mango;
-import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
@@ -142,29 +141,25 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
     @Override
     protected String checkAndTransformValue(Value input) {
         V entity = getMapper().find(getType(), input.get()).orElse(null);
+
         if (entity == null) {
             return null;
         }
-        if (entity instanceof TenantAware) {
-            tenants.assertTenant((TenantAware) entity);
-        }
-        if (!checkAccess(entity)) {
-            return null;
-        }
+
+        assertAccess(entity);
 
         return entity.getIdAsString();
     }
 
     /**
-     * Determines if the current user may use the given entity as value for this parameter.
+     * Checks if the current user may use the given entity as value for this parameter.
      *
      * @param entity the entity to check
-     * @return <tt>true</tt> if the entity may be used as parameter value, <tt>false otherwise</tt>
      */
-    @SuppressWarnings("squid:S1172")
-    @Explain("Parameter may be used by subclasses")
-    protected boolean checkAccess(V entity) {
-        return true;
+    protected void assertAccess(V entity) {
+        if (entity instanceof TenantAware) {
+            tenants.assertTenant((TenantAware) entity);
+        }
     }
 
     private EntityDescriptor getDescriptor() {

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -185,6 +185,7 @@ Model.priority = Sortierung
 Model.security = Sicherheit
 Model.tenant = Mandant
 Model.userAccount = Anwender
+Model.virtualobject = Datei
 Parameter.invalidValue = Fehler im Parameter ${name}: ${message}
 Parameter.required = Der Parameter ${name} muss gefüllt sein.
 PersonData.birthday = Geburtstag


### PR DESCRIPTION
This makes it possible to overwrite it in order to also allow selection of entities belonging to the parent tenant.

Gives the VirtualObjectParameter a label