### PR TITLE
Switch key value when merging dictionaries

### DIFF
--- a/src/main/java/sirius/biz/importer/ImportDictionary.java
+++ b/src/main/java/sirius/biz/importer/ImportDictionary.java
@@ -129,7 +129,7 @@ public class ImportDictionary {
      * @return the dictionary itself for fluent method calls
      */
     public ImportDictionary mergeDictionary(ImportDictionary otherDictionary) {
-        otherDictionary.getAliases().forEach(this::withAlias);
+        otherDictionary.getAliases().forEach((alias, field) -> withAlias(field, alias));
         return this;
     }
 }


### PR DESCRIPTION
Since the withAliases functionen reverses the field and alias from keys to values we have to take care of this behaviour in the merge function.

-Tags: Bug