### PR TITLE
Provides an extra method to override to check if a property has changed

### DIFF
--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -263,7 +263,7 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
      * @return the created entity or, if batch updates are active, the given entity
      */
     protected E createIfChanged(E entity, boolean batch) {
-        if (entity.isChanged(mappingsToLoad)) {
+        if (isChanged(entity)) {
             getInsertQuery().insert(entity, true, batch);
         }
 
@@ -295,11 +295,21 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
         // computed properties...
         descriptor.beforeSave(entity);
 
-        if (entity.isChanged(mappingsToLoad)) {
+        if (isChanged(entity)) {
             getUpdateQuery().update(entity, true, batch);
         }
 
         return entity;
+    }
+
+    /**
+     * Checks whether any property of the entity has changed.
+     *
+     * @param entity the entity to check
+     * @return <tt>true</tt> if any property checked is changed, <tt>false</tt> otherwise
+     */
+    protected boolean isChanged(E entity) {
+        return entity.isChanged(mappingsToLoad);
     }
 
     /**


### PR DESCRIPTION
we add values to the entity which are not AutoImported because we don't want them
to be changed through an import file.
E.g. the transactionId of a featureValue is manually set and we also need to check this property