### PR TITLE
Corrects the redirect after canceling a process

### DIFF
--- a/src/main/java/sirius/biz/process/ProcessController.java
+++ b/src/main/java/sirius/biz/process/ProcessController.java
@@ -161,7 +161,7 @@ public class ProcessController extends BizController {
     public void cancelProcess(WebContext ctx, String processId) {
         Process process = findAccessibleProcess(processId);
         processes.markCanceled(process.getId());
-        ctx.respondWith().redirectToGet("/ps/" + process);
+        ctx.respondWith().redirectToGet("/ps/" + processId);
     }
 
     /**


### PR DESCRIPTION
the process.toString() method does not return the processId. We were redirecting to a
non existant page