### PR TITLE
Improved health checks and support for bleeding out cluster members

### DIFF
--- a/src/main/java/sirius/biz/cluster/BackgroundInfo.java
+++ b/src/main/java/sirius/biz/cluster/BackgroundInfo.java
@@ -17,11 +17,13 @@ import java.util.Map;
  */
 public class BackgroundInfo {
     private String nodeName;
+    private boolean bleeding;
     private String uptime;
     protected Map<String, BackgroundJobInfo> jobs = new HashMap<>();
 
-    protected BackgroundInfo(String nodeName, String uptime) {
+    protected BackgroundInfo(String nodeName, boolean bleeding, String uptime) {
         this.nodeName = nodeName;
+        this.bleeding = bleeding;
         this.uptime = uptime;
     }
 
@@ -41,6 +43,10 @@ public class BackgroundInfo {
      */
     public String getUptime() {
         return uptime;
+    }
+
+    public boolean isBleeding() {
+        return bleeding;
     }
 
     /**

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -74,6 +74,10 @@ sirius.frameworks {
 # This address has to be reachable from all other cluster nodes.
 sirius.nodeAddress = ""
 
+# Contains a local token which is used by the Cluster controller so that some APIs can be invoked without
+# further authentication.
+sirius.clusterToken = ""
+
 # Contains settings for the built-in firewall and rate-limiting facility
 isenguard {
     # Determines which limiter is used. By default we use a "smart" strategy,
@@ -124,8 +128,8 @@ health.limits {
     # We start to warn as soon as we encounter one long running lock
     # (held for at least 30min). As this can still be quite alright
     # we do not consider this critical (red)
-    locks-long-running.gray  = 0
-    locks-long-running.warning  = 1
+    locks-long-running.gray = 0
+    locks-long-running.warning = 1
     locks-long-running.error = 0
 
     # Monitors the utilization of the events buffer which is used by the
@@ -133,6 +137,12 @@ health.limits {
     events-buffer-usage.gray = 0
     events-buffer-usage.warning = 80
     events-buffer-usage.error = 99
+
+    # Number of active tasks (remains gray when zero). There is no limit
+    # to warn about, as the number can be specified in the system configuration.
+    active-distributed-tasks.gray = 1
+    active-distributed-tasks.warning = 0
+    active-distributed-tasks.error = 0
 }
 
 async {

--- a/src/main/resources/default/templates/biz/cluster/cluster.html.pasta
+++ b/src/main/resources/default/templates/biz/cluster/cluster.html.pasta
@@ -10,10 +10,51 @@
 
     <w:pageHeader title="Cluster State"/>
 
+    <w:heading>Nodes</w:heading>
+    <table class="table table-striped">
+        <tr>
+            <th>Node</th>
+            <th>Uptime</th>
+            <th>Bleeding</th>
+            <th/>
+        </tr>
+        <i:for type="sirius.biz.cluster.BackgroundInfo" var="node" items="nodes">
+            <tr>
+                <td>
+                    <b>@node.getNodeName()</b>
+
+                </td>
+                <td>
+                    @node.getUptime()
+                </td>
+                <td>
+                    <i:if test="node.isBleeding()">
+                        <span class="label label-warning">Yes</span>
+                        <small><a href="/system/cluster/bleed/disable/@node.getNodeName()" class="link">Stop</a></small>
+                        <i:else>
+                            <span class="label label-info">No</span>
+                            <small><a href="/system/cluster/bleed/enable/@node.getNodeName()" class="link">Start</a>
+                            </small>
+                        </i:else>
+                    </i:if>
+                </td>
+                <td>
+                    <small>
+                        <a href="/system/cluster/kill/@node.getNodeName()" class="link link-danger"
+                           title="Remove as Cluster Member">
+                            Kill
+                        </a>
+                    </small>
+                </td>
+            </tr>
+        </i:for>
+    </table>
+
     <w:heading>Background Jobs</w:heading>
     <i:for type="String" var="job" items="keys">
         <w:subHeading>
-            @job <small class="muted">(@descriptions.get(job))</small>
+            @job
+            <small class="muted">(@descriptions.get(job))</small>
         </w:subHeading>
         <table class="table table-striped">
             <tr>

--- a/src/test/java/sirius/biz/s3/ObjectStoresSpec.groovy
+++ b/src/test/java/sirius/biz/s3/ObjectStoresSpec.groovy
@@ -53,7 +53,7 @@ class ObjectStoresSpec extends BaseSpecification {
         URLConnection c = new URL(stores.store().
                                           objectUrl(stores.store().getBucketName("test"), "test")).openConnection()
         and:
-        downloadedData = new String(ByteStreams.toByteArray(c.getInputStream()), Charsets.UTF_8)
+        String downloadedData = new String(ByteStreams.toByteArray(c.getInputStream()), Charsets.UTF_8)
         then:
         Files.toString(file, Charsets.UTF_8) == Files.toString(download, Charsets.UTF_8)
         and:

--- a/src/test/java/sirius/biz/s3/ObjectStoresSpec.groovy
+++ b/src/test/java/sirius/biz/s3/ObjectStoresSpec.groovy
@@ -9,6 +9,7 @@
 package sirius.biz.s3
 
 import com.google.common.base.Charsets
+import com.google.common.io.ByteStreams
 import com.google.common.io.Files
 import sirius.kernel.BaseSpecification
 import sirius.kernel.commons.Tuple
@@ -23,13 +24,40 @@ class ObjectStoresSpec extends BaseSpecification {
         File download
         when:
         File file = File.createTempFile("test", "")
-        Files.write("This is a test.", file, Charsets.UTF_8)
+        for (int i = 0; i < 10024; i++) {
+            Files.append("This is a test.", file, Charsets.UTF_8)
+        }
         and:
         stores.store().upload(stores.store().getBucketName("test"), "test", file, null)
         and:
         download = stores.store().download(stores.store().getBucketName("test"), "test")
         then:
         Files.toString(file, Charsets.UTF_8) == Files.toString(download, Charsets.UTF_8)
+        cleanup:
+        sirius.kernel.commons.Files.delete(file)
+        sirius.kernel.commons.Files.delete((File) download)
+    }
+
+    def "PUT and GET works"() {
+        File download
+        when:
+        File file = File.createTempFile("test", "")
+        for (int i = 0; i < 10024; i++) {
+            Files.append("This is a test.", file, Charsets.UTF_8)
+        }
+        and:
+        stores.store().upload(stores.store().getBucketName("test"), "test", file, null)
+        and:
+        download = stores.store().download(stores.store().getBucketName("test"), "test")
+        and:
+        URLConnection c = new URL(stores.store().
+                                          objectUrl(stores.store().getBucketName("test"), "test")).openConnection()
+        and:
+        downloadedData = new String(ByteStreams.toByteArray(c.getInputStream()), Charsets.UTF_8)
+        then:
+        Files.toString(file, Charsets.UTF_8) == Files.toString(download, Charsets.UTF_8)
+        and:
+        downloadedData == Files.toString(file, Charsets.UTF_8)
         cleanup:
         sirius.kernel.commons.Files.delete(file)
         sirius.kernel.commons.Files.delete((File) download)

--- a/src/test/resources/docker-biz.yml
+++ b/src/test/resources/docker-biz.yml
@@ -36,7 +36,7 @@ services:
       - ES_JAVA_OPTS=-Xms32M -Xmx128M
     hostname: es
   s3-system:
-    image: scireum/s3-ninja:5.2.1
+    image: scireum/s3-ninja:5.2.2
     ports:
       - 80
     hostname: s3ninja

--- a/src/test/resources/docker-biz.yml
+++ b/src/test/resources/docker-biz.yml
@@ -36,7 +36,7 @@ services:
       - ES_JAVA_OPTS=-Xms32M -Xmx128M
     hostname: es
   s3-system:
-    image: scireum/s3-ninja:5
+    image: scireum/s3-ninja:5.2.1
     ports:
       - 80
     hostname: s3ninja


### PR DESCRIPTION
Improves rolling cluster upgrades by implementing a proper health check and support bleeding out a node before restarting it.

Using /system/cluster/ready as health check (in the load balancer) a node is only considered healthy when fully started up
(and not yet bleeding out).

Bleeding out can be started via the cluster UI or an API call (which should be the common case). This will
drop the node out of load balancing (via said health check) and also prevent the node from picking up
further background work (mainly distributed task), so that it can be restarted in a save way.

Additionally /system/cluster/halted can be invoked to determine if the node is already fully bled
out (not executing any distributed tasks anymore). Note that this implies that all long running
work is represented as distributed task (which is a good idea anyway...).