### PR TITLE
Show log actions in details

### DIFF
--- a/src/main/resources/default/templates/biz/process/process-details.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-details.html.pasta
@@ -68,7 +68,15 @@
                 <tr class="@log.getRowClass()">
                     <td/>
                     <td>
-                        <pre class="plain" style="white-space: pre-wrap">@log.getMessage()</pre>
+                        <div>
+                            <pre class="plain" style="white-space: pre-wrap">@log.getMessage()</pre>
+                        </div>
+                        <div>
+                            <i:for type="sirius.biz.process.logs.ProcessLogAction" var="action" items="log.getActions()">
+                                <a href="@action.getUri()?returnUrl=@urlEncode(apply('/ps/%s', process.getId()))"
+                                   class="link link-inline"><i class="fa @action.getIcon()"></i> @action.getLabel()</a>
+                            </i:for>
+                        </div>
                     </td>
                     <td class="align-right">
                         @log.getTimestampAsString()<br>


### PR DESCRIPTION
It can be quite confusing if there is an action which is only present when viewing the process in the log view. Therefore the actions are now also shown in the details view.

Tags: processes