### PR TITLE
Allows to fetch the process id from a process context

### DIFF
--- a/src/main/java/sirius/biz/process/ProcessContext.java
+++ b/src/main/java/sirius/biz/process/ProcessContext.java
@@ -37,6 +37,13 @@ import java.util.function.Supplier;
 public interface ProcessContext extends TaskContextAdapter {
 
     /**
+     * Returns the id of the process context.
+     *
+     * @return the id of the process
+     */
+    String getProcessId();
+
+    /**
      * Returns the title of the underlying process.
      *
      * @return the title of the process

--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -105,6 +105,11 @@ class ProcessEnvironment implements ProcessContext {
     }
 
     @Override
+    public String getProcessId() {
+        return processId;
+    }
+
+    @Override
     public String getTitle() {
         return processes.fetchProcess(processId).map(Process::getTitle).orElse(null);
     }


### PR DESCRIPTION
This can be useful e.g. when starting a async task from within a process context which should log into
the same process.