### PR TITLE
No longer import empty rows from a linebased import file

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportJob.java
@@ -83,6 +83,10 @@ public class LineBasedImportJob<E extends BaseEntity<?>> extends FileImportJob i
 
     @Override
     public void handleRow(int index, Values row) {
+        if (row.length() == 0) {
+            return;
+        }
+
         if (aliases == null) {
             aliases = new LineBasedAliases(row, dictionary);
             process.log(ProcessLog.info().withMessage(aliases.toString()));


### PR DESCRIPTION
No longer import empty rows from a import import file. When no data is contained in a row we do not handle the row.