### PR TITLE
Permits to ignore i5 data conversion errors.

### DIFF
--- a/src/main/java/sirius/biz/i5/Transform.java
+++ b/src/main/java/sirius/biz/i5/Transform.java
@@ -55,4 +55,14 @@ public @interface Transform {
      * @return the number of decimal places
      */
     int decimal() default 0;
+
+    /**
+     * Determines if errors during data conversion are ignored.
+     * <p>
+     * This can be used to handle naturally evolving interfaces (where one system ich patched before the other).
+     *
+     * @return <tt>true</tt> to ignore a conversion error and stick with the initial value of the field,
+     * <tt>false</tt> to throw an appropriate exception and abort the program call.
+     */
+    boolean ignoreErrors() default false;
 }

--- a/src/main/java/sirius/biz/i5/Transform.java
+++ b/src/main/java/sirius/biz/i5/Transform.java
@@ -57,9 +57,9 @@ public @interface Transform {
     int decimal() default 0;
 
     /**
-     * Determines if errors during data conversion are ignored.
+     * Determines if errors during data conversions are ignored.
      * <p>
-     * This can be used to handle naturally evolving interfaces (where one system ich patched before the other).
+     * This can be used to handle naturally evolving interfaces (where one system is patched before the other).
      *
      * @return <tt>true</tt> to ignore a conversion error and stick with the initial value of the field,
      * <tt>false</tt> to throw an appropriate exception and abort the program call.

--- a/src/main/java/sirius/biz/i5/Transformer.java
+++ b/src/main/java/sirius/biz/i5/Transformer.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Helps to transform byte oriented record (sent and received from the i5) into Java objects.
@@ -119,30 +120,31 @@ public class Transformer {
     private int transform(Entry<Field, Transform> e, Object object, byte[] data, int offset) {
         Transform info = e.getValue();
         Field field = e.getKey();
+        AtomicInteger nextIndex = new AtomicInteger(offset);
         try {
             if (info.targetType() == AS400Bin4.class) {
                 AS400Bin4 mapper = new AS400Bin4();
+                nextIndex.addAndGet(mapper.getByteLength());
                 field.set(object, mapper.toObject(data, offset));
-                return offset + mapper.getByteLength();
             }
             if (info.targetType() == AS400Text.class) {
                 AS400Text mapper = new AS400Text(info.length());
+                nextIndex.addAndGet(mapper.getByteLength());
                 field.set(object, ((String) mapper.toObject(data, offset)).trim());
-                return offset + mapper.getByteLength();
             }
             if (info.targetType() == AS400ZonedDecimal.class) {
                 AS400ZonedDecimal mapper = new AS400ZonedDecimal(info.length(), info.decimal());
+                nextIndex.addAndGet(mapper.getByteLength());
                 field.set(object, mapper.toObject(data, offset));
-                return offset + mapper.getByteLength();
             }
             if (info.targetType() == AS400PackedDecimal.class) {
                 AS400PackedDecimal mapper = new AS400PackedDecimal(info.length(), info.decimal());
+                nextIndex.addAndGet(mapper.getByteLength());
                 field.set(object, mapper.toObject(data, offset));
-                return offset + mapper.getByteLength();
             }
             if (info.targetType() == Byte.class) {
+                nextIndex.addAndGet(info.length());
                 field.set(object, Arrays.copyOfRange(data, offset, info.length()));
-                return offset + info.length();
             }
             throw Exceptions.handle()
                             .to(I5Connector.LOG)
@@ -152,15 +154,25 @@ public class Transformer {
                                                     field.getName())
                             .handle();
         } catch (Exception ex) {
-            throw Exceptions.handle()
-                            .to(I5Connector.LOG)
-                            .error(ex)
-                            .withSystemErrorMessage("Error while transforming '%s.%s' to %s: %s (%s)",
-                                                    object.getClass().getName(),
-                                                    field.getName(),
-                                                    info.targetType().getName())
-                            .handle();
+            if (info.ignoreErrors()) {
+                I5Connector.LOG.FINE("Ignoring a conversion error for %s of %s: %s (%s)",
+                                     field.getName(),
+                                     object.getClass().getName(),
+                                     ex.getMessage(),
+                                     ex.getClass().getName());
+            } else {
+                throw Exceptions.handle()
+                                .to(I5Connector.LOG)
+                                .error(ex)
+                                .withSystemErrorMessage("Error while transforming '%s.%s' to %s: %s (%s)",
+                                                        object.getClass().getName(),
+                                                        field.getName(),
+                                                        info.targetType().getName())
+                                .handle();
+            }
         }
+
+        return nextIndex.get();
     }
 
     /**

--- a/src/main/java/sirius/biz/i5/Transformer.java
+++ b/src/main/java/sirius/biz/i5/Transformer.java
@@ -160,6 +160,7 @@ public class Transformer {
                                      object.getClass().getName(),
                                      ex.getMessage(),
                                      ex.getClass().getName());
+                Exceptions.ignore(ex);
             } else {
                 throw Exceptions.handle()
                                 .to(I5Connector.LOG)


### PR DESCRIPTION
This is required if the "Java side" is updated before the i5 side as most probably the
left over byte buffer is uninitialized and will crash data conversions. The application
has to ensure itself that this data is never used up until it is populated correctly.

Also this feature is turned off by default for obvious reasons.