### PR TITLE
Parse AS400Text with correct encoding

### DIFF
--- a/src/main/java/sirius/biz/i5/I5Connection.java
+++ b/src/main/java/sirius/biz/i5/I5Connection.java
@@ -239,4 +239,13 @@ public class I5Connection implements Closeable {
     public String toString() {
         return pool + ": " + i5;
     }
+
+    /**
+     * Returns the CCSID (code page) used by the i5 at the other end.
+     *
+     * @return the CCSID to use when encoding or decoding strings
+     */
+    public int getCcsid() {
+        return i5.getCcsid();
+    }
 }

--- a/src/main/java/sirius/biz/i5/I5Connection.java
+++ b/src/main/java/sirius/biz/i5/I5Connection.java
@@ -22,6 +22,7 @@ import sirius.kernel.health.HandledException;
 import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nonnull;
+import java.io.Closeable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -29,7 +30,7 @@ import java.util.List;
 /**
  * Represents a connection to an IBM AS400 also known as i5.
  */
-public class I5Connection {
+public class I5Connection implements Closeable {
 
     protected AS400 i5;
     protected I5ConnectionPool pool;
@@ -87,6 +88,7 @@ public class I5Connection {
     /**
      * Closes the connection by returning it back to the connection pool.
      */
+    @Override
     public void close() {
         if (borrowed) {
             pool.returnConnection(this);

--- a/src/main/java/sirius/biz/i5/Transformable.java
+++ b/src/main/java/sirius/biz/i5/Transformable.java
@@ -33,16 +33,19 @@ public abstract class Transformable {
     /**
      * Tries for create a new instance of the given type by parsing the given byte array.
      *
-     * @param type the type to be created
-     * @param <T>  the generic type for <tt>type</tt>
-     * @param data the byte array to parse
+     * @param type       the type to be created
+     * @param <T>        the generic type for <tt>type</tt>
+     * @param data       the byte array to parse
+     * @param connection the connection used to determine the CCSID (code page) to use
      * @return a new instance of T filled with the data parsed from <tt>data</tt>
      */
-    public static <T extends Transformable> T parse(@Nonnull Class<T> type, @Nonnull byte[] data) {
+    public static <T extends Transformable> T parse(@Nonnull Class<T> type,
+                                                    @Nonnull byte[] data,
+                                                    I5Connection connection) {
         try {
             Transformer tx = getTransformer(type);
             T result = type.getDeclaredConstructor().newInstance();
-            tx.fromBytes(result, data);
+            tx.fromBytes(result, data, connection.getCcsid());
 
             return result;
         } catch (Exception e) {
@@ -57,9 +60,10 @@ public abstract class Transformable {
      * Transforms this object into a byte representation which can be sent to an i5.
      *
      * @param destination the byte array to fill
+     * @param connection the connection used to determine the CCSID (code page) to use
      */
-    public void toBytes(byte[] destination) {
-        getTransformer(getClass()).toBytes(this, destination);
+    public void toBytes(byte[] destination, I5Connection connection) {
+        getTransformer(getClass()).toBytes(this, destination, connection.getCcsid());
     }
 
     @Override


### PR DESCRIPTION
The AS400 object itself holds the correct encoding to use to parse an AS400Text. Therefore this information is used to parse the text as the system locale might be different than the AS400's locale and therefore its used encoding.

Tags: i5, as400