### PR TITLE
Prevent exception when Mixin targets MongoUserAccount

### DIFF
--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
@@ -46,9 +46,11 @@ public class MongoUserAccount extends MongoTenantAware implements UserAccount<St
 
     @Override
     public <A> Optional<A> tryAs(Class<A> adapterType) {
-        Optional<A> result = getUserAccountData().tryAs(adapterType);
-        if (result.isPresent()) {
-            return result;
+        if (getUserAccountData().is(adapterType)) {
+            Optional<A> result = getUserAccountData().tryAs(adapterType);
+            if (result.isPresent()) {
+                return result;
+            }
         }
 
         return super.tryAs(adapterType);


### PR DESCRIPTION
As it tries to assign the Mixin first to the UserAccountData which fails with an exception and therefore no other assignment is tried.

See SQLUserAccount#tryAs 48b8c462d98577ce2cc83d9f036a44bff3f82b4e