### PR TITLE
Fixes tenant/user switching for accounts of the system tenant

### DIFF
--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -545,8 +545,9 @@ public abstract class UserAccountController<I, T extends BaseEntity<I> & Tenant<
             selectUserAccounts(ctx);
             return;
         }
-
-        if (!hasPermission(TenantUserManager.PERMISSION_SYSTEM_TENANT)) {
+        
+        TenantUserManager<?, ?, ?> userManager = tenants.getTenantUserManager();
+        if (!userManager.getSystemTenantId().equals(userManager.getOriginalTenantId())) {
             assertTenant(user);
         }
 

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -545,9 +545,8 @@ public abstract class UserAccountController<I, T extends BaseEntity<I> & Tenant<
             selectUserAccounts(ctx);
             return;
         }
-        
-        TenantUserManager<?, ?, ?> userManager = tenants.getTenantUserManager();
-        if (!userManager.getSystemTenantId().equals(userManager.getOriginalTenantId())) {
+
+        if (!isUserAccountOfSystemTenant()) {
             assertTenant(user);
         }
 

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantController.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantController.java
@@ -64,7 +64,7 @@ public class SQLTenantController extends TenantController<Long, SQLTenant, SQLUs
 
     private SmartQuery<SQLTenant> queryPossibleTenants(SQLTenant currentTenant) {
         SmartQuery<SQLTenant> baseQuery = oma.select(SQLTenant.class);
-        if (!hasPermission(TenantUserManager.PERMISSION_SYSTEM_TENANT)) {
+        if (!isUserAccountOfSystemTenant()) {
             if (currentTenant.getTenantData().isCanAccessParent()) {
                 baseQuery.where(OMA.FILTERS.or(OMA.FILTERS.and(OMA.FILTERS.eq(Tenant.PARENT, currentTenant),
                                                                OMA.FILTERS.eq(Tenant.TENANT_DATA.inner(TenantData.PARENT_CAN_ACCESS),

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountController.java
@@ -12,7 +12,6 @@ import sirius.biz.model.LoginData;
 import sirius.biz.model.PersonData;
 import sirius.biz.tenants.Tenant;
 import sirius.biz.tenants.TenantData;
-import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.tenants.UserAccount;
 import sirius.biz.tenants.UserAccountController;
 import sirius.biz.tenants.UserAccountData;
@@ -67,7 +66,7 @@ public class SQLUserAccountController extends UserAccountController<Long, SQLTen
                                                   .orderAsc(UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.PERSON)
                                                                                          .inner(PersonData.FIRSTNAME));
 
-        if (!hasPermission(TenantUserManager.PERMISSION_SYSTEM_TENANT)) {
+        if (!isUserAccountOfSystemTenant()) {
             baseQuery = baseQuery.eq(UserAccount.TENANT, tenants.getRequiredTenant());
         }
 

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantController.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantController.java
@@ -58,7 +58,9 @@ public class MongoTenantController extends TenantController<String, MongoTenant,
 
     private MongoQuery<MongoTenant> queryPossibleTenants(MongoTenant currentTenant) {
         MongoQuery<MongoTenant> baseQuery = mango.select(MongoTenant.class);
-        if (!hasPermission(TenantUserManager.PERMISSION_SYSTEM_TENANT)) {
+        
+        TenantUserManager<?, ?, ?> userManager = tenants.getTenantUserManager();
+        if (!userManager.getSystemTenantId().equals(userManager.getOriginalTenantId())) {
             if (currentTenant.getTenantData().isCanAccessParent()) {
                 baseQuery.where(QueryBuilder.FILTERS.or(QueryBuilder.FILTERS.and(QueryBuilder.FILTERS.eq(Tenant.PARENT,
                                                                                                          currentTenant),

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantController.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantController.java
@@ -11,7 +11,6 @@ package sirius.biz.tenants.mongo;
 import sirius.biz.tenants.Tenant;
 import sirius.biz.tenants.TenantController;
 import sirius.biz.tenants.TenantData;
-import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.web.BasePageHelper;
 import sirius.biz.web.MongoPageHelper;
 import sirius.db.mixing.query.QueryField;
@@ -58,9 +57,8 @@ public class MongoTenantController extends TenantController<String, MongoTenant,
 
     private MongoQuery<MongoTenant> queryPossibleTenants(MongoTenant currentTenant) {
         MongoQuery<MongoTenant> baseQuery = mango.select(MongoTenant.class);
-        
-        TenantUserManager<?, ?, ?> userManager = tenants.getTenantUserManager();
-        if (!userManager.getSystemTenantId().equals(userManager.getOriginalTenantId())) {
+
+        if (!isUserAccountOfSystemTenant()) {
             if (currentTenant.getTenantData().isCanAccessParent()) {
                 baseQuery.where(QueryBuilder.FILTERS.or(QueryBuilder.FILTERS.and(QueryBuilder.FILTERS.eq(Tenant.PARENT,
                                                                                                          currentTenant),

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountController.java
@@ -9,7 +9,6 @@
 package sirius.biz.tenants.mongo;
 
 import sirius.biz.model.PersonData;
-import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.tenants.UserAccount;
 import sirius.biz.tenants.UserAccountController;
 import sirius.biz.tenants.UserAccountData;
@@ -44,8 +43,7 @@ public class MongoUserAccountController extends UserAccountController<String, Mo
     protected BasePageHelper<MongoUserAccount, ?, ?, ?> getSelectableUsersAsPage() {
         MongoQuery<MongoUserAccount> baseQuery = mango.select(MongoUserAccount.class);
 
-        TenantUserManager<?, ?, ?> userManager = tenants.getTenantUserManager();
-        if (!userManager.getSystemTenantId().equals(userManager.getOriginalTenantId())) {
+        if (!isUserAccountOfSystemTenant()) {
             baseQuery = baseQuery.eq(UserAccount.TENANT, tenants.getRequiredTenant());
         }
 

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountController.java
@@ -44,7 +44,8 @@ public class MongoUserAccountController extends UserAccountController<String, Mo
     protected BasePageHelper<MongoUserAccount, ?, ?, ?> getSelectableUsersAsPage() {
         MongoQuery<MongoUserAccount> baseQuery = mango.select(MongoUserAccount.class);
 
-        if (!hasPermission(TenantUserManager.PERMISSION_SYSTEM_TENANT)) {
+        TenantUserManager<?, ?, ?> userManager = tenants.getTenantUserManager();
+        if (!userManager.getSystemTenantId().equals(userManager.getOriginalTenantId())) {
             baseQuery = baseQuery.eq(UserAccount.TENANT, tenants.getRequiredTenant());
         }
 

--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -13,6 +13,7 @@ import com.google.common.hash.Hashing;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.biz.process.Processes;
 import sirius.biz.process.logs.ProcessLog;
+import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.tenants.Tenants;
 import sirius.db.es.Elastic;
 import sirius.db.jdbc.OMA;
@@ -122,6 +123,17 @@ public class BizController extends BasicController {
 
     private HandledException invalidTenantException() {
         return Exceptions.createHandled().withNLSKey("BizController.invalidTenant").handle();
+    }
+
+
+    /**
+     * Checks whether the current user is an account of the system tenant. This can be useful for granting extra features.
+     *
+     * @return <tt>true</tt> if the user is an account of the system tenant, <tt>false</tt> otherwise.
+     */
+    protected boolean isUserAccountOfSystemTenant() {
+        TenantUserManager<?, ?, ?> userManager = tenants.getTenantUserManager();
+        return userManager.getSystemTenantId().equals(userManager.getOriginalTenantId());
     }
 
     /**


### PR DESCRIPTION
As only accounts of the system tenant with the permission `user-administrator` get the `flag-syste-tenant` this was too restrictive for some use cases, e.g. when normal `administrator`s should also be able to support other users by switching to their tenant or account.

To enable this we check if the account is originaly from the system tenant when filtering the users/tenants and selecting them.