### PR TITLE
Prevents duplicate typename prefix when fetching user accounts

### DIFF
--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -376,7 +376,7 @@ public abstract class Tenants<I, T extends BaseEntity<I> & Tenant<I>, U extends 
             return Optional.of(userRef.getValue());
         }
 
-        return fetchCachedUserAccount(userRef.getUniqueObjectName());
+        return fetchCachedUserAccount(userRef.getIdAsString());
     }
 
     /**


### PR DESCRIPTION
Don't use the uniqueName of the ref Object, as the string method already prefixes the id