### PR TITLE
Allows for a job parameter based on a list of priorized parts

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/PartListParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/PartListParameter.java
@@ -25,11 +25,11 @@ import java.util.Optional;
 public class PartListParameter<E> extends Parameter<E, PartListParameter<E>> {
 
     @Part
-    private static GlobalContext globalContext;
+    protected static GlobalContext globalContext;
 
-    private final Class<E> type;
+    protected final Class<E> type;
 
-    private Collection<E> parts;
+    protected Collection<E> parts;
 
     /**
      * Creates a new parameter with the given name and label.

--- a/src/main/java/sirius/biz/jobs/params/PriorizedPartListParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/PriorizedPartListParameter.java
@@ -1,0 +1,63 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.params;
+
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Priorized;
+import sirius.kernel.nls.NLS;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Provides the selection of a {@link Part} from a list of parts with a common {@link sirius.kernel.di.std.Register registered} superclass as parameter.
+ *
+ * @param <E> the common {@link sirius.kernel.di.std.Register registered} superclass
+ */
+public class PriorizedPartListParameter<E extends Priorized> extends PartListParameter<E> {
+
+    /**
+     * Creates a new parameter with the given name and label.
+     *
+     * @param name  the name of the parameter
+     * @param label the label of the parameter, which will be {@link NLS#smartGet(String) auto translated}
+     * @param type  the type of parts being fetched
+     */
+    public PriorizedPartListParameter(String name, String label, Class<E> type) {
+        super(name, label, type);
+    }
+
+    /**
+     * Enumerates all parts implementing the common superclass part.
+     *
+     * @return the list of parts implementing the common superclass part sorted by priority
+     */
+    @Override
+    public Collection<E> getValues() {
+        if (parts == null) {
+            ArrayList<E> sortedParts = new ArrayList<>(globalContext.getParts(type));
+            sortedParts.sort((o1, o2) -> {
+                if (o1 == o2) {
+                    return 0;
+                }
+                if (o2 == null) {
+                    return -1;
+                }
+                if (o1 == null) {
+                    return 1;
+                }
+                return o1.getPriority() - o2.getPriority();
+            });
+
+            parts = sortedParts;
+        }
+        return Collections.unmodifiableCollection(parts);
+    }
+}

--- a/src/main/java/sirius/biz/jobs/params/PriorizedPartListParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/PriorizedPartListParameter.java
@@ -15,6 +15,8 @@ import sirius.kernel.nls.NLS;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * Provides the selection of a {@link Part} from a list of parts with a common {@link sirius.kernel.di.std.Register registered} superclass as parameter.
@@ -42,19 +44,8 @@ public class PriorizedPartListParameter<E extends Priorized> extends PartListPar
     @Override
     public Collection<E> getValues() {
         if (parts == null) {
-            ArrayList<E> sortedParts = new ArrayList<>(globalContext.getParts(type));
-            sortedParts.sort((o1, o2) -> {
-                if (o1 == o2) {
-                    return 0;
-                }
-                if (o2 == null) {
-                    return -1;
-                }
-                if (o1 == null) {
-                    return 1;
-                }
-                return o1.getPriority() - o2.getPriority();
-            });
+            List<E> sortedParts = new ArrayList<>(globalContext.getParts(type));
+            sortedParts.sort(Comparator.comparingInt(Priorized::getPriority));
 
             parts = sortedParts;
         }


### PR DESCRIPTION
This allows to select from a list of classes that implement and register a common superclass when starting a job.
The list of provided select options is sorted by the priority of the parts.
As a label for the single select toString of the classes is called.
The job is provided with the registered implementation object of the selected part.