### PR TITLE
 Correctly keeps 'flag-system-tenant' when switching to another tenant

### DIFF
--- a/src/main/java/sirius/biz/tenants/Tenant.java
+++ b/src/main/java/sirius/biz/tenants/Tenant.java
@@ -30,8 +30,8 @@ public interface Tenant<I> extends Transformable, Traced, Journaled, RateLimited
     /**
      * This flag permission is granted to tenant objects only.
      * <p>
-     * This can be used in role / permission mappings to filter specific user roles for the system
-     * tenant. When a user of the system tenant takes control over another tenant, this permission is kept.
+     * This can be used in role / permission mappings to filter specific user roles for the system tenant.
+     * When a user of the system tenant takes control over another tenant, this permission is kept.
      * <p>
      * Use {@link #hasPermission(String)} to check for this flag. For user specific permissions the flags
      * {@link TenantUserManager#PERMISSION_SYSTEM_TENANT_MEMBER} and

--- a/src/main/java/sirius/biz/tenants/Tenant.java
+++ b/src/main/java/sirius/biz/tenants/Tenant.java
@@ -31,7 +31,7 @@ public interface Tenant<I> extends Transformable, Traced, Journaled, RateLimited
      * This flag permission is granted to tenant objects only.
      * <p>
      * This can be used in role / permission mappings to filter specific user roles for the system
-     * tenant.
+     * tenant. When a user of the system tenant takes control over another tenant, this permission is kept.
      * <p>
      * Use {@link #hasPermission(String)} to check for this flag. For user specific permissions the flags
      * {@link TenantUserManager#PERMISSION_SYSTEM_TENANT_MEMBER} and

--- a/src/main/java/sirius/biz/tenants/TenantController.java
+++ b/src/main/java/sirius/biz/tenants/TenantController.java
@@ -345,6 +345,10 @@ public abstract class TenantController<I, T extends BaseEntity<I> & Tenant<I>, U
 
     /**
      * Makes the current user belong to the given tenant.
+     * The user is will keep the permissions tied to its user,
+     * but the permissions granted by his tenant will change to the new tenant.
+     * Exception to this is {@link Tenant#PERMISSION_SYSTEM_TENANT}, this will be kept if the user originally belonged to the system tenant.
+     * Additionatly, the permission {@link TenantUserManager#PERMISSION_SPY_USER} is given, so the system can identify the tenant switch.
      *
      * @param ctx the current request
      * @param id  the id of the tenant to switch to

--- a/src/main/java/sirius/biz/tenants/TenantController.java
+++ b/src/main/java/sirius/biz/tenants/TenantController.java
@@ -345,6 +345,7 @@ public abstract class TenantController<I, T extends BaseEntity<I> & Tenant<I>, U
 
     /**
      * Makes the current user belong to the given tenant.
+     * <p>
      * The user is will keep the permissions tied to its user,
      * but the permissions granted by his tenant will change to the new tenant.
      * Exception to this is {@link Tenant#PERMISSION_SYSTEM_TENANT}, this will be kept if the user originally belonged to the system tenant.

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -263,8 +263,9 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
         // And overwrite with the new tenant...
         modifiedUser.getTenant().setValue(tenant);
 
-        Set<String> roles =
-                computeRoles(modifiedUser, tenant, originalUser.hasPermission(PERMISSION_SYSTEM_ADMINISTRATOR));
+        Set<String> roles = computeRoles(modifiedUser,
+                                         tenant,
+                                         Strings.areEqual(systemTenant, String.valueOf(originalUser.getTenantId())));
         roles.add(PERMISSION_SPY_USER);
         roles.add(PERMISSION_SELECT_TENANT);
         return asUserWithRoles(modifiedUser, roles, () -> computeTenantname(null, originalUser.getTenantId()));

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -88,7 +88,8 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
      * <p>
      * The id of the system tenant can be set in the scope config. The system tenant usually is the administrative
      * company which owns / runs the system.
-     * Unlike {@link #PERMISSION_SYSTEM_TENANT_MEMBER}, this flag is kept always even when the user either has taken control over another tenant or user account.
+     * Unlike {@link #PERMISSION_SYSTEM_TENANT_MEMBER}, this flag is kept always,
+     * even when the user either has taken control over another tenant or user account.
      */
     public static final String PERMISSION_SYSTEM_TENANT_AFFILIATE = "flag-system-tenant-affiliate";
 
@@ -231,8 +232,8 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
      * Makes the user become/switch to another user.
      * <p>
      * See {@link UserAccountController#selectUserAccount}.
-     * 
-     * @param spyId the id of the user to become
+     *
+     * @param spyId    the id of the user to become
      * @param rootUser the original user that is becoming another user
      * @return the new user that was switched to
      */
@@ -270,7 +271,7 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
     }
 
     /**
-     * Makes the User appear as he is from another tenant.
+     * Makes the user appear as he is from another tenant.
      * <p>
      * See {@link TenantController#selectTenant}.
      *

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -78,7 +78,8 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
      * This flag permission is granted to <b>all users</b> which belong to the system tenant.
      * <p>
      * The id of the system tenant can be set in the scope config. The system tenant usually is the administrative
-     * company which owns / runs the system.
+     * company which owns / runs the system, this flag is kept when the user has taken control over another tenant,
+     * but is removed if the user has taken control over another user directly.
      */
     public static final String PERMISSION_SYSTEM_TENANT_MEMBER = "flag-system-tenant-member";
 
@@ -87,7 +88,7 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
      * <p>
      * The id of the system tenant can be set in the scope config. The system tenant usually is the administrative
      * company which owns / runs the system.
-     * Unlike {@link #PERMISSION_SYSTEM_TENANT_MEMBER}, this flag is kept when the user either has taken control over another tenant or user account.
+     * Unlike {@link #PERMISSION_SYSTEM_TENANT_MEMBER}, this flag is kept always even when the user either has taken control over another tenant or user account.
      */
     public static final String PERMISSION_SYSTEM_TENANT_AFFILIATE = "flag-system-tenant-affiliate";
 
@@ -226,6 +227,15 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
         return rootUser;
     }
 
+    /**
+     * Makes the user become/switch to another user.
+     * <p>
+     * See {@link UserAccountController#selectUserAccount}.
+     * 
+     * @param spyId the id of the user to become
+     * @param rootUser the original user that is becoming another user
+     * @return the new user that was switched to
+     */
     private UserInfo becomeSpyUser(String spyId, UserInfo rootUser) {
         U spyUser = fetchAccount(spyId);
         if (spyUser == null) {
@@ -256,7 +266,19 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
         if (tenant == null) {
             return originalUser;
         }
+        return switchTenant(originalUser, tenant);
+    }
 
+    /**
+     * Makes the User appear as he is from another tenant.
+     * <p>
+     * See {@link TenantController#selectTenant}.
+     *
+     * @param originalUser the user to be switched
+     * @param tenant       the tenant to switch to
+     * @return user the new user, now belonging to the given tenant
+     */
+    private UserInfo switchTenant(UserInfo originalUser, T tenant) {
         // Copy all relevant data into a new object (outside of the cache)...
         U modifiedUser = cloneUser(originalUser);
 

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -537,10 +537,15 @@ public abstract class UserAccountController<I, T extends BaseEntity<I> & Tenant<
     protected abstract BasePageHelper<U, ?, ?, ?> getSelectableUsersAsPage();
 
     /**
-     * Makes the current user belong to the given tenant.
+     * Switches fromt the current user to the given user.
+     * The current user can act on the behalf of the given user, he will appear as he is that user,
+     * and he will have the roles the given user has.
+     * The only permissions kept from the original user may be {@link TenantUserManager#PERMISSION_SYSTEM_TENANT_AFFILIATE},
+     * and {@link TenantUserManager#PERMISSION_SELECT_USER_ACCOUNT} (to switch back).
+     * Additionatly, the permission {@link TenantUserManager#PERMISSION_SPY_USER} is given, so the system can identify the user switch.
      *
      * @param ctx the current request
-     * @param id  the id of the tenant to switch to
+     * @param id  the id of the user to switch to
      */
     @LoginRequired
     @Routed("/user-accounts/select/:1")

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -537,7 +537,8 @@ public abstract class UserAccountController<I, T extends BaseEntity<I> & Tenant<
     protected abstract BasePageHelper<U, ?, ?, ?> getSelectableUsersAsPage();
 
     /**
-     * Switches fromt the current user to the given user.
+     * Switches from the current user to the given user.
+     * <p>
      * The current user can act on the behalf of the given user, he will appear as he is that user,
      * and he will have the roles the given user has.
      * The only permissions kept from the original user may be {@link TenantUserManager#PERMISSION_SYSTEM_TENANT_AFFILIATE},


### PR DESCRIPTION
Previously, this was only done for 'flag-system-administrator', but there might be other user profiles that are attached to 'flag-system-tenant'