### PR TITLE
Delete UserAccounts later in the DeleteTenantJob

### DIFF
--- a/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLUserAccountsTask.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLUserAccountsTask.java
@@ -53,6 +53,6 @@ public class DeleteSQLUserAccountsTask implements DeleteTenantTask {
 
     @Override
     public int getPriority() {
-        return 100;
+        return 200;
     }
 }

--- a/src/main/java/sirius/biz/tenants/mongo/DeleteMongoUserAccountTask.java
+++ b/src/main/java/sirius/biz/tenants/mongo/DeleteMongoUserAccountTask.java
@@ -53,6 +53,6 @@ public class DeleteMongoUserAccountTask implements DeleteTenantTask {
 
     @Override
     public int getPriority() {
-        return 100;
+        return 200;
     }
 }


### PR DESCRIPTION
So entities referencing UserAccounts can be deleted beforehand with the default priority