### PR TITLE
We must not ignore handled exceptions here.

### DIFF
--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -209,8 +209,6 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
             InsertQuery<Event> qry = queries.computeIfAbsent(event.getClass(),
                                                              type -> (InsertQuery<Event>) ctx.insertQuery(type, false));
             qry.insert(event, false, true);
-        } catch (HandledException e) {
-            Exceptions.ignore(e);
         } catch (Exception e) {
             if (!event.retried) {
                 event.retried = true;


### PR DESCRIPTION
First of all we're not expecting any exception here, as "invokeChecks" is set to false
(the checks are executed when recording the event).

Second, if a database error occurs (like clickhouse being down), we'll
also receive a handled exception from "insert" and should abort right here. This
will let the loop sleep for another 5 minutes and will give clickhouse enough time
to startup...