### PR TITLE
Flush cashes when a Tenant is deleted

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -275,7 +275,6 @@ public class TenantData extends Composite implements Journaled {
     }
 
     @BeforeSave
-    @BeforeDelete
     protected void onModify() {
         if (journal.hasJournaledChanges()) {
             TenantUserManager.flushCacheForTenant((Tenant<?>) tenantObject);
@@ -285,6 +284,12 @@ public class TenantData extends Composite implements Journaled {
         if (Strings.isFilled(samlFingerprint)) {
             samlFingerprint = samlFingerprint.replace(" ", "").toLowerCase();
         }
+    }
+
+    @BeforeDelete
+    protected void onDelete() {
+        TenantUserManager.flushCacheForTenant((Tenant<?>) tenantObject);
+        tenants.flushTenantChildrenCache();
     }
 
     /**


### PR DESCRIPTION
No matter if 'journal.hasJournaledChanges()' is true or not.

The code before resulted in the following problem:
- When deleting a child-tenant the "tenants.flushTenantChildrenCache();" code was not triggered, because journal.hasJournaledChanges() was false.
- Therefore the parent-tenant could not be deleted, because "tenants.hasChildTenants(id)" still returned true in the "CheckForMongoChildrenTask"