### PR TITLE
Prevents the user from entering a non existent Entity as parameter

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/EntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameter.java
@@ -21,6 +21,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 
 import java.util.Map;
@@ -143,6 +144,13 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
         V entity = getMapper().find(getType(), input.get()).orElse(null);
 
         if (entity == null) {
+            if (input.isFilled()) {
+                throw Exceptions.createHandled()
+                                .withNLSKey("Parameter.invalidValue")
+                                .set("name", getLabel())
+                                .set("message", NLS.get("EntityParameter.mustExist"))
+                                .handle();
+            }
             return null;
         }
 

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -70,6 +70,7 @@ DatabaseController.reason = Grund
 DatabaseController.schema = Datenbank Schema
 DatabaseController.sql = SQL
 DatabaseController.unknownChange = Unbekannte Änderung
+EntityParameter.mustExist = Es ist ein existierendes Datenobjekt erforderlich.
 FileImportJob.fileNotSupported = Die Datei wird nicht unterstützt.
 FileImportJob.importingZipFile = Die Datei wird für den Import entpackt.
 FileImportJob.importingZippedFile = Die entpackte Datei '${filename}' wird importiert.


### PR DESCRIPTION
The inputfield allows to enter values that are not present in the autocomplete suggestions which currently leads to a null parameter value. Which is fine for mandatory parameters, as this catches the invalid input. But for optional parameters this results in an error while executing the job and not in an error message when trying to start the job - which is desired.

Fixes: OX-5335