### PR TITLE
Permits to utilize aliases when verifying the column headings.

### DIFF
--- a/src/test/java/sirius/biz/importer/ImportDictionarySpec.groovy
+++ b/src/test/java/sirius/biz/importer/ImportDictionarySpec.groovy
@@ -21,7 +21,7 @@ class ImportDictionarySpec extends BaseSpecification {
         and:
         def problems = new ArrayList()
         then:
-        dict.detectHeaderProblems(Values.of("A", "C", "D", "E"), { problem -> problems.add(problem) }, true)
+        dict.detectHeaderProblems(Values.of("A", "C", "D", "E"), { problem, _ -> problems.add(problem) }, true)
         and:
         problems.get(0) == "Die Spalte 2 ('B') fehlt."
         problems.size() == 1
@@ -34,7 +34,7 @@ class ImportDictionarySpec extends BaseSpecification {
         and:
         def problems = new ArrayList()
         then:
-        dict.detectHeaderProblems(Values.of("A", "D", "E"), { problem -> problems.add(problem) }, true)
+        dict.detectHeaderProblems(Values.of("A", "D", "E"), { problem, _ -> problems.add(problem) }, true)
         and:
         problems.get(0) == "Die Spalte 2 ('B') fehlt."
         problems.get(1) == "Die Spalte 3 ('C') fehlt."
@@ -48,7 +48,7 @@ class ImportDictionarySpec extends BaseSpecification {
         and:
         def problems = new ArrayList()
         then:
-        dict.detectHeaderProblems(Values.of("A", "A1", "B", "C"), { problem -> problems.add(problem) }, true)
+        dict.detectHeaderProblems(Values.of("A", "A1", "B", "C"), { problem, _ -> problems.add(problem) }, true)
         and:
         problems.get(0) == "Die Spalte 2 ('A1') ist unerwartet."
         problems.size() == 1
@@ -61,7 +61,7 @@ class ImportDictionarySpec extends BaseSpecification {
         and:
         def problems = new ArrayList()
         then:
-        dict.detectHeaderProblems(Values.of("A", "A1", "A2", "B", "C"), { problem -> problems.add(problem) }, true)
+        dict.detectHeaderProblems(Values.of("A", "A1", "A2", "B", "C"), { problem, _ -> problems.add(problem) }, true)
         and:
         problems.get(0) == "Die Spalte 2 ('A1') ist unerwartet."
         problems.get(1) == "Die Spalte 3 ('A2') ist unerwartet."
@@ -75,7 +75,7 @@ class ImportDictionarySpec extends BaseSpecification {
         and:
         def problems = new ArrayList()
         then:
-        dict.detectHeaderProblems(Values.of("A", "F", "G", "H"), { problem -> problems.add(problem) }, true)
+        dict.detectHeaderProblems(Values.of("A", "F", "G", "H"), { problem, _ -> problems.add(problem) }, true)
         and:
         problems.get(0) == "In der Spalte 2 wurde 'B' erwartet, aber 'F' gefunden."
         problems.get(1) == "In der Spalte 3 wurde 'C' erwartet, aber 'G' gefunden."
@@ -90,7 +90,7 @@ class ImportDictionarySpec extends BaseSpecification {
         and:
         def problems = new ArrayList()
         then:
-        dict.detectHeaderProblems(Values.of("A", "B", "C", "D"), { problem -> problems.add(problem) }, true)
+        dict.detectHeaderProblems(Values.of("A", "B", "C", "D"), { problem, _ -> problems.add(problem) }, true)
         and:
         problems.get(0) == "Die Spalte 4 ('D') ist unerwartet."
         problems.size() == 1
@@ -103,7 +103,7 @@ class ImportDictionarySpec extends BaseSpecification {
         and:
         def problems = new ArrayList()
         then:
-        dict.detectHeaderProblems(Values.of("A", "B", "C"), { problem -> problems.add(problem) }, true)
+        dict.detectHeaderProblems(Values.of("A", "B", "C"), { problem, _ -> problems.add(problem) }, true)
         and:
         problems.get(0) == "Die Spalte 4 ('D') fehlt."
         problems.size() == 1

--- a/src/test/java/sirius/biz/importer/ImportDictionarySpec.groovy
+++ b/src/test/java/sirius/biz/importer/ImportDictionarySpec.groovy
@@ -8,8 +8,10 @@
 
 package sirius.biz.importer
 
+import sirius.biz.importer.format.FieldDefinition
 import sirius.biz.importer.format.ImportDictionary
 import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Tuple
 import sirius.kernel.commons.Values
 
 class ImportDictionarySpec extends BaseSpecification {
@@ -81,6 +83,24 @@ class ImportDictionarySpec extends BaseSpecification {
         problems.get(1) == "In der Spalte 3 wurde 'C' erwartet, aber 'G' gefunden."
         problems.get(2) == "In der Spalte 4 wurde 'D' erwartet, aber 'H' gefunden."
         problems.size() == 3
+    }
+
+    def "detectHeaderProblems warns for aliased columns"() {
+        when:
+        ImportDictionary dict = new ImportDictionary()
+        dict.addField(FieldDefinition.stringField("A", 25).addAlias("XA"))
+        dict.useMapping(Arrays.asList("A", "B", "C", "D"))
+        and:
+        def problems = new ArrayList()
+        def problemDetected = dict.detectHeaderProblems(Values.of("XA", "B", "C", "D"), { problem, errorFlag ->
+            problems.add(Tuple.create(problem, errorFlag))
+        }, true)
+        then:
+        problemDetected == false
+        and:
+        problems.get(0).getFirst() == "In der Spalte 1 wurde 'A' erwartet, aber 'XA' gefunden."
+        problems.get(0).getSecond() == false
+        problems.size() == 1
     }
 
     def "detectHeaderProblems detects additional columns"() {


### PR DESCRIPTION
If a column doesn't match but can be associated by using the aliases, a warning will be emitted but no real error
will be reported.