### PR TITLE
Outputs all parameters of the batch job

### DIFF
--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -11,6 +11,8 @@ package sirius.biz.jobs;
 import sirius.biz.jobs.infos.JobInfo;
 import sirius.biz.jobs.infos.JobInfoCollector;
 import sirius.biz.jobs.params.Parameter;
+import sirius.biz.process.ProcessContext;
+import sirius.biz.process.logs.ProcessLog;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Strings;
@@ -106,6 +108,16 @@ public abstract class BasicJobFactory implements JobFactory {
      * @param parameterCollector the collector to be supplied with the expected parameters
      */
     protected abstract void collectParameters(Consumer<Parameter<?, ?>> parameterCollector);
+
+    @Override
+    public void logParameters(ProcessContext process) {
+        String output = "Parameter \"%s\": %s";
+
+        collectParameters(param -> {
+            String value = process.getParameter(param).map(NLS::toUserString).orElse("");
+            process.log(ProcessLog.info().withFormattedMessage(output, param.getLabel(), value));
+        });
+    }
 
     @Nullable
     @Override

--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -11,8 +11,6 @@ package sirius.biz.jobs;
 import sirius.biz.jobs.infos.JobInfo;
 import sirius.biz.jobs.infos.JobInfoCollector;
 import sirius.biz.jobs.params.Parameter;
-import sirius.biz.process.ProcessContext;
-import sirius.biz.process.logs.ProcessLog;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Strings;
@@ -109,15 +107,6 @@ public abstract class BasicJobFactory implements JobFactory {
      */
     protected abstract void collectParameters(Consumer<Parameter<?, ?>> parameterCollector);
 
-    @Override
-    public void logParameters(ProcessContext process) {
-        String output = "Parameter \"%s\": %s";
-
-        collectParameters(param -> {
-            String value = process.getParameter(param).map(NLS::toUserString).orElse("");
-            process.log(ProcessLog.info().withFormattedMessage(output, param.getLabel(), value));
-        });
-    }
 
     @Nullable
     @Override

--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -106,8 +106,7 @@ public abstract class BasicJobFactory implements JobFactory {
      * @param parameterCollector the collector to be supplied with the expected parameters
      */
     protected abstract void collectParameters(Consumer<Parameter<?, ?>> parameterCollector);
-
-
+    
     @Nullable
     @Override
     public String generatePresetUrl(Object targetObject) {

--- a/src/main/java/sirius/biz/jobs/JobFactory.java
+++ b/src/main/java/sirius/biz/jobs/JobFactory.java
@@ -10,7 +10,6 @@ package sirius.biz.jobs;
 
 import sirius.biz.jobs.infos.JobInfo;
 import sirius.biz.jobs.params.Parameter;
-import sirius.biz.process.ProcessContext;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Named;
 import sirius.kernel.di.std.Priorized;
@@ -155,11 +154,4 @@ public interface JobFactory extends Named, Priorized {
      * @return the name of the job category
      */
     String getCategory();
-
-    /**
-     * Writes all parameters with its values to the process log.
-     *
-     * @param process the current {@link ProcessContext}
-     */
-    void logParameters(ProcessContext process);
 }

--- a/src/main/java/sirius/biz/jobs/JobFactory.java
+++ b/src/main/java/sirius/biz/jobs/JobFactory.java
@@ -10,6 +10,7 @@ package sirius.biz.jobs;
 
 import sirius.biz.jobs.infos.JobInfo;
 import sirius.biz.jobs.params.Parameter;
+import sirius.biz.process.ProcessContext;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Named;
 import sirius.kernel.di.std.Priorized;
@@ -154,4 +155,11 @@ public interface JobFactory extends Named, Priorized {
      * @return the name of the job category
      */
     String getCategory();
+
+    /**
+     * Writes all parameters with its values to the process log.
+     *
+     * @param process the current {@link ProcessContext}
+     */
+    void logParameters(ProcessContext process);
 }

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
@@ -170,6 +170,7 @@ public abstract class BatchProcessJobFactory extends BasicJobFactory {
      */
     protected void executeTask(ProcessContext process) throws Exception {
         try (BatchJob job = createJob(process)) {
+            logParameters(process);
             job.execute();
         }
     }

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
@@ -179,11 +179,16 @@ public abstract class BatchProcessJobFactory extends BasicJobFactory {
     protected abstract BatchJob createJob(ProcessContext process) throws Exception;
 
     private void logParameters(ProcessContext process) {
-        String output = "Parameter \"%s\": %s";
+        StringBuilder output = new StringBuilder();
+        output.append("Parameter:\n\n");
 
         getParameters().forEach(param -> {
             String value = process.getParameter(param).map(NLS::toUserString).orElse("");
-            process.log(ProcessLog.info().withFormattedMessage(output, param.getLabel(), value));
+            output.append(param.getLabel());
+            output.append(": ");
+            output.append(value);
+            output.append("\n");
         });
+        process.log(ProcessLog.info().withMessage(output.toString().trim()));
     }
 }

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
@@ -18,6 +18,7 @@ import sirius.biz.process.ProcessLink;
 import sirius.biz.process.Processes;
 import sirius.biz.process.logs.ProcessLog;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.nls.NLS;
 import sirius.web.http.WebContext;
 import sirius.web.security.UserContext;
 
@@ -169,11 +170,20 @@ public abstract class BatchProcessJobFactory extends BasicJobFactory {
      * @throws Exception in case of any error which should abort this job
      */
     protected void executeTask(ProcessContext process) throws Exception {
+        logParameters(process);
         try (BatchJob job = createJob(process)) {
-            logParameters(process);
             job.execute();
         }
     }
 
     protected abstract BatchJob createJob(ProcessContext process) throws Exception;
+
+    private void logParameters(ProcessContext process) {
+        String output = "Parameter \"%s\": %s";
+
+        getParameters().forEach(param -> {
+            String value = process.getParameter(param).map(NLS::toUserString).orElse("");
+            process.log(ProcessLog.info().withFormattedMessage(output, param.getLabel(), value));
+        });
+    }
 }


### PR DESCRIPTION
This allows us to inspect the parameters of a job instead of asking the executor of the job
which is a little bit error prone
- Fixes: SIRI-86