### PR TITLE
Ignores empty amounts (Amount.NOTHING) in range checks.

### DIFF
--- a/src/main/java/sirius/biz/importer/format/AmountRangeCheck.java
+++ b/src/main/java/sirius/biz/importer/format/AmountRangeCheck.java
@@ -15,6 +15,8 @@ import sirius.kernel.nls.NLS;
 
 /**
  * Enforces a given range for values in the associated field.
+ * <p>
+ * Note that this check will ignore empty amounts. To prohibit these, use a {@link RequiredCheck}.
  */
 public class AmountRangeCheck implements ValueCheck {
 
@@ -88,6 +90,10 @@ public class AmountRangeCheck implements ValueCheck {
     @Override
     public void perform(Value value) {
         Amount amount = value.getAmount();
+        if (amount.isEmpty()) {
+            return;
+        }
+
         if (min.isFilled()) {
             if (includeMin) {
                 if (amount.isLessThan(min)) {

--- a/src/test/java/sirius/biz/importer/format/AmountRangeCheckSpec.groovy
+++ b/src/test/java/sirius/biz/importer/format/AmountRangeCheckSpec.groovy
@@ -105,4 +105,13 @@ class AmountRangeCheckSpec extends Specification {
         noExceptionThrown()
     }
 
+    def "empty values are ignored"() {
+        when:
+        new AmountRangeCheck(NumberFormat.NO_DECIMAL_PLACES).withLowerLimitInclusive(Amount.ONE).
+                withUpperLimitExclusive(Amount.ONE_HUNDRED).
+                perform(Value.of(Amount.NOTHING))
+        then:
+        noExceptionThrown()
+    }
+
 }


### PR DESCRIPTION
(cherry picked from commit d28cc62a69476c00f5f80351eae3afe7db68ebe8)