### PR TITLE
Adds an upper limit to the log message length.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>13.17</sirius.kernel>
         <sirius.web>24.0-rc26</sirius.web>
-        <sirius.db>DEVELOPMENT-SNAPSHOT</sirius.db>
+        <sirius.db>9.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -12,7 +12,9 @@ import sirius.biz.elastic.AutoBatchLoop;
 import sirius.db.es.Elastic;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
+import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.ExceptionHandler;
@@ -62,6 +64,9 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
 
     @Part
     private AutoBatchLoop autoBatch;
+
+    @ConfigValue("protocols.maxLogMessageLength")
+    private int maxMessageLength;
 
     private volatile AtomicLong disabledUntil;
 
@@ -136,7 +141,7 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
             LoggedMessage msg = new LoggedMessage();
             msg.setCategory(message.getReceiver().getName());
             msg.setLevel(message.getLogLevel().toString());
-            msg.setMessage(message.getMessage());
+            msg.setMessage(Strings.limit(message.getMessage(),maxMessageLength, false));
             msg.setNode(CallContext.getNodeName());
             msg.setUser(UserContext.getCurrentUser().getProtocolUsername());
 

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -361,6 +361,12 @@ protocols {
     keep-journal = 1000 days
     keep-neutral-audit-logs = 30 days
     keep-negative-audit-logs = 180 days
+
+    # We limit messages to this length when storing them in ES as otherwise we might run into
+    # low memory conditions or overload the AutoBatchLoop and ES. Note that the logging system which
+    # captures stdout will still receive the full message. Still consider to limit yourself to
+    # sane and digestable log messages.
+    maxLogMessageLength = 116384
 }
 
 # The audit log can write additional logs to the system log.


### PR DESCRIPTION
Due to a bug and excessive logging, we've observed a node going down
in the AutoBatchLoop when trying to bulk insert a large amount of large log messages.