### PR TITLE
Make the parsing of dates strict in DateTimeFormatCheck

### DIFF
--- a/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
+++ b/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
@@ -20,6 +20,10 @@ import java.time.format.ResolverStyle;
 
 /**
  * Determines if the given values matches a date format.
+ * <p>
+ * The formating notation used is the notation described in {@link DateTimeFormatter}.
+ * <p>
+ * <i>Hint</i>: Use 'u' instead of 'y' for years.
  */
 public class DateTimeFormatCheck implements ValueCheck {
 
@@ -28,10 +32,20 @@ public class DateTimeFormatCheck implements ValueCheck {
 
     /**
      * Creates a new check using the given date format.
+     * <p>
+     * The formating noation used is the notation decribed in {@link DateTimeFormatter}.
+     * <p>
+     * <i>Hint</i>: Use 'u' instead of 'y' for years.
      *
-     * @param format the {@link DateTimeFormatter} which will be used to check the value
+     * @param format the String describing the formats of the dates
      */
     public DateTimeFormatCheck(@Nonnull String format) {
+        if (format.contains("y")) {
+            // We want to use the 'strict' resolver, so dates like 30.02.2019 are marked invalid and not resolved to a
+            // valid date. But when using the strict resolver, one needs to give the era (BC or AD) when using 'y' or
+            // it does not become a valid date. To avoid this 'u' needs to be used.
+            throw new IllegalArgumentException("Use 'u' instead of 'y' for years in format string.");
+        }
         this.format = format;
         this.formatter = DateTimeFormatter.ofPattern(format).withResolverStyle(ResolverStyle.STRICT);
     }

--- a/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
+++ b/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
@@ -36,14 +36,16 @@ public class DateTimeFormatCheck implements ValueCheck {
      * The formating noation used is the notation decribed in {@link DateTimeFormatter}.
      * <p>
      * <i>Hint</i>: Use 'u' instead of 'y' for years.
+     * <p>
+     * <i>Reason</i>: We want to use the 'strict' resolver, so dates like 30.02.2019 are marked invalid and not resolved to a
+     * valid date. But when using the strict resolver, one needs to give the era (BC or AD) when using 'y' or it does
+     * not become a valid date. To avoid this 'u' needs to be used.
      *
      * @param format the String describing the formats of the dates
+     * @throws IllegalArgumentException when 'y' is used for year
      */
     public DateTimeFormatCheck(@Nonnull String format) {
         if (format.contains("y")) {
-            // We want to use the 'strict' resolver, so dates like 30.02.2019 are marked invalid and not resolved to a
-            // valid date. But when using the strict resolver, one needs to give the era (BC or AD) when using 'y' or
-            // it does not become a valid date. To avoid this 'u' needs to be used.
             throw new IllegalArgumentException("Use 'u' instead of 'y' for years in format string.");
         }
         this.format = format;

--- a/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
+++ b/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
@@ -29,7 +29,7 @@ public class DateTimeFormatCheck implements ValueCheck {
     /**
      * Creates a new check using the given date format.
      *
-     * @param format the {@link org.joda.time.format.DateTimeFormat} which will be used to check the value
+     * @param format the {@link DateTimeFormatter} which will be used to check the value
      */
     public DateTimeFormatCheck(@Nonnull String format) {
         this.format = format;

--- a/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
+++ b/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
@@ -21,7 +21,7 @@ import java.time.format.ResolverStyle;
 /**
  * Determines if the given values matches a date format.
  * <p>
- * The formating notation used is the notation described in {@link DateTimeFormatter}.
+ * The formatting notation used is the notation described in {@link DateTimeFormatter}.
  * <p>
  * <i>Hint</i>: Use 'u' instead of 'y' for years.
  */
@@ -33,7 +33,7 @@ public class DateTimeFormatCheck implements ValueCheck {
     /**
      * Creates a new check using the given date format.
      * <p>
-     * The formating noation used is the notation decribed in {@link DateTimeFormatter}.
+     * The formatting notation used is the notation described in {@link DateTimeFormatter}.
      * <p>
      * <i>Hint</i>: Use 'u' instead of 'y' for years.
      * <p>

--- a/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
+++ b/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
@@ -13,8 +13,10 @@ import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Determines if the given values matches a date format.
@@ -31,7 +33,7 @@ public class DateTimeFormatCheck implements ValueCheck {
      */
     public DateTimeFormatCheck(@Nonnull String format) {
         this.format = format;
-        this.formatter = DateTimeFormatter.ofPattern(format);
+        this.formatter = DateTimeFormatter.ofPattern(format).withResolverStyle(ResolverStyle.STRICT);
     }
 
     @Override
@@ -42,7 +44,7 @@ public class DateTimeFormatCheck implements ValueCheck {
 
         String stringValue = value.asString();
         try {
-            formatter.parse(stringValue);
+            LocalDate.parse(stringValue, formatter);
         } catch (DateTimeParseException e) {
             throw new IllegalArgumentException(NLS.fmtr("DateTimeFormatCheck.errorMsg")
                                                   .set("value", stringValue)

--- a/src/test/java/sirius/biz/importer/format/DateTimeFormatCheckSpec.groovy
+++ b/src/test/java/sirius/biz/importer/format/DateTimeFormatCheckSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.importer.format
+
+import sirius.kernel.commons.Value
+import spock.lang.Specification
+
+class DateTimeFormatCheckSpec extends Specification {
+
+    def "valid dates throws no exception"() {
+        when:
+        new DateTimeFormatCheck("dd.MM.uuuu").perform(Value.of("23.10.2019"))
+        new DateTimeFormatCheck("dd.MM.uuuu").perform(Value.of("01.05.1854"))
+        new DateTimeFormatCheck("dd.MM.uuuu").perform(Value.of("24.12.9000"))
+        then:
+        noExceptionThrown()
+    }
+
+    def "invalid date throws exception"() {
+        when:
+        new DateTimeFormatCheck("dd.MM.uuuu").perform(Value.of("31.09.2019"))
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "date with to little numbers is invalid"() {
+        when:
+        new DateTimeFormatCheck("dd.MM.uuuu").perform(Value.of("4.4.19"))
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "date with to much numbers is invalid"() {
+        when:
+        new DateTimeFormatCheck("dd.MM.uuuu").perform(Value.of("4.011.19"))
+        then:
+        thrown(IllegalArgumentException)
+    }
+}

--- a/src/test/java/sirius/biz/importer/format/DateTimeFormatCheckSpec.groovy
+++ b/src/test/java/sirius/biz/importer/format/DateTimeFormatCheckSpec.groovy
@@ -42,4 +42,24 @@ class DateTimeFormatCheckSpec extends Specification {
         then:
         thrown(IllegalArgumentException)
     }
+
+    def "dates not matching the provided format are correctly marked as invalid"() {
+        when:
+        new DateTimeFormatCheck("ddMMuuuu").perform(Value.of(date))
+        then:
+        thrown IllegalArgumentException
+        where:
+        date << [1092019, "1092019", "TEST", "01.09.2019"]
+    }
+
+    def "dates matching the provided format are correctly marked as valid"() {
+        expect:
+        new DateTimeFormatCheck(format).perform(Value.of(date))
+        where:
+        format       | date
+        "ddMMuuuu"   | 11092019
+        "ddMMuuuu"   | "01092019"
+        "ddMMuuuu"   | "11092019"
+        "dd.MM.uuuu" | "01.09.2019"
+    }
 }

--- a/src/test/java/sirius/biz/importer/format/ValueCheckSpec.groovy
+++ b/src/test/java/sirius/biz/importer/format/ValueCheckSpec.groovy
@@ -14,26 +14,6 @@ import spock.lang.Specification
 
 class ValueCheckSpec extends Specification {
 
-    def "dates not matching the provided format are correctly marked as invalid"() {
-        when:
-        new DateTimeFormatCheck("ddMMyyyy").perform(Value.of(date))
-        then:
-        thrown IllegalArgumentException
-        where:
-        date << [1092019, "1092019", "TEST", "01.09.2019"]
-    }
-
-    def "dates matching the provided format are correctly marked as valid"() {
-        expect:
-        new DateTimeFormatCheck(format).perform(Value.of(date))
-        where:
-        format       | date
-        "ddMMyyyy"   | 11092019
-        "ddMMyyyy"   | "01092019"
-        "ddMMyyyy"   | "11092019"
-        "dd.MM.yyyy" | "01.09.2019"
-    }
-
     def "amount scale check correctly marks non numeric values as invalid"() {
         when:
         AmountScaleCheck scaleCheck = new AmountScaleCheck(5, 2)


### PR DESCRIPTION
This detects wrong dates like the 31.09.2019 (September only has 30 days).

The trade off to this solution is, that years have to be declared with 'u' in pattern instead of 'y'.
The other option one could achieve strict parsing with is the 'SimpleDateFormat'-class, but it comes with its own set of problems, also it is legacy java.

Additional reading from StackOverflow:

DateTimeFormatter:
`uuuu` versus `yyyy`: https://stackoverflow.com/questions/41177442/uuuu-versus-yyyy-in-datetimeformatter-formatting-pattern-codes-in-java
Issues with `yyyy` isntead of `uuuu`: https://stackoverflow.com/questions/41103603/issue-with-datetimeparseexception-when-using-strict-resolver-style

SimpleDateFormat:
Ignores additional/missing characters in pattern: https://stackoverflow.com/questions/16014488/simpledateformat-parse-ignores-the-number-of-characters-in-pattern
Make SimpleDateFormat more strict (also see comments of top answer): https://stackoverflow.com/questions/13088140/java-how-to-parse-a-date-strictly