### PR TITLE
Fixes the logic to allow the creation of new folders via ftp

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFile.java
@@ -34,7 +34,6 @@ class BridgeFile implements FtpFile {
 
     BridgeFile(VirtualFile file) {
         this.file = file;
-        this.parent = file.parent();
     }
 
     BridgeFile(VirtualFile parent, String childName) {

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFile.java
@@ -34,6 +34,7 @@ class BridgeFile implements FtpFile {
 
     BridgeFile(VirtualFile file) {
         this.file = file;
+        this.parent = file.parent();
     }
 
     BridgeFile(VirtualFile parent, String childName) {
@@ -75,7 +76,7 @@ class BridgeFile implements FtpFile {
 
     @Override
     public boolean doesExist() {
-        return file != null;
+        return file != null && file.exists();
     }
 
     @Override
@@ -130,7 +131,7 @@ class BridgeFile implements FtpFile {
 
     @Override
     public boolean mkdir() {
-        if (file != null) {
+        if (doesExist()) {
             return file.isDirectory();
         } else {
             return parent.resolve(childName).tryCreateAsDirectory();
@@ -139,7 +140,7 @@ class BridgeFile implements FtpFile {
 
     @Override
     public boolean delete() {
-        if (file != null) {
+        if (doesExist()) {
             return file.tryDelete();
         }
 
@@ -149,7 +150,7 @@ class BridgeFile implements FtpFile {
     @Override
     public boolean move(FtpFile destination) {
         try {
-            if (file == null) {
+            if (!doesExist()) {
                 return false;
             }
 
@@ -173,7 +174,7 @@ class BridgeFile implements FtpFile {
     @Override
     public List<? extends FtpFile> listFiles() {
         List<FtpFile> result = new ArrayList<>();
-        if (file != null) {
+        if (doesExist()) {
             file.children(FileSearch.iterateAll(child -> result.add(new BridgeFile(child))));
         }
 
@@ -182,7 +183,7 @@ class BridgeFile implements FtpFile {
 
     @Override
     public OutputStream createOutputStream(long offset) throws IOException {
-        if (file != null) {
+        if (doesExist()) {
             return file.createOutputStream();
         }
 
@@ -191,7 +192,7 @@ class BridgeFile implements FtpFile {
 
     @Override
     public InputStream createInputStream(long offset) throws IOException {
-        if (file != null) {
+        if (doesExist()) {
             return file.createInputStream();
         }
 

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFileSystemView.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFileSystemView.java
@@ -68,7 +68,7 @@ class BridgeFileSystemView implements FileSystemView {
                 result = child;
             } else {
                 child = result.findChild(pathElement).orElse(null);
-                if (child != null) {
+                if (child != null && child.exists()) {
                     result = child;
                 } else if (i == pathElements.length - 1) {
                     // The last path element is unknown - create a placeholder child and let the parent file decide


### PR DESCRIPTION
The current logic will create a placeholder object and returns it with findChild.
Because of that we cannot just do a null check. We also need to check the exists method of the child
- Fixes: SE-8975