### PR TITLE
Uses a lambda instead of a method reference to prevent a jdk Bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>7.0.1</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>testJDKBug</version>
+    <version>DEVELOPMENT-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>7.0.1</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
-    <version>DEVELOPMENT-SNAPSHOT</version>
+    <version>testJDKBug</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS biz</name>

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -16,6 +16,7 @@ import sirius.db.mixing.query.Query;
 import sirius.db.mixing.types.BaseEntityRef;
 import sirius.kernel.cache.Cache;
 import sirius.kernel.cache.CacheManager;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.transformers.Composable;
@@ -187,8 +188,11 @@ public abstract class Tenants<I, T extends BaseEntity<I> & Tenant<I>, U extends 
      *
      * @param tenantId the id to be checked
      */
+    @SuppressWarnings("squid:S1612")
+    @Explain("Using a method reference here leads to a BootstrapMethod error due to a JDK bug " 
+             + "see https://bugs.openjdk.java.net/browse/JDK-8058112 (seems to be also present in OracleJDK)")
     public void assertTenant(@Nullable String tenantId) {
-        String currentTenantId = getCurrentTenant().map(Tenant::getIdAsString).orElse(null);
+        String currentTenantId = getCurrentTenant().map(tenant -> tenant.getIdAsString()).orElse(null);
         if (Strings.isFilled(tenantId) && !Strings.areEqual(tenantId, currentTenantId)) {
             throw Exceptions.createHandled().withNLSKey("Tenants.invalidTenant").handle();
         }

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -203,12 +203,15 @@ public abstract class Tenants<I, T extends BaseEntity<I> & Tenant<I>, U extends 
      *
      * @param tenantAware {@link TenantAware} entity to be asserted
      */
+    @SuppressWarnings("squid:S1612")
+    @Explain("Using a method reference here leads to a BootstrapMethod error due to a JDK bug "
+             + "see https://bugs.openjdk.java.net/browse/JDK-8058112 (seems to be also present in OracleJDK)")
     public void assertTenantOrParentTenant(TenantAware tenantAware) {
         if (tenantAware == null) {
             return;
         }
 
-        String currentTenantId = getCurrentTenant().map(Tenant::getIdAsString).orElse(null);
+        String currentTenantId = getCurrentTenant().map(tenant -> tenant.getIdAsString()).orElse(null);
         if (!Strings.areEqual(tenantAware.getTenantAsString(), currentTenantId)
             && !Objects.equals(tenantAware.getTenantAsString(),
                                getCurrentTenant().map(Tenant::getParent)


### PR DESCRIPTION
Using a method reference can lead to a LambdaMetaFactory validate exception:

When trying to apply a map() using a Function over a multi-bounded intersection generic type, the JRE fails with error message
Caused by: java.lang.invoke.LambdaConversionException: Type mismatch for lambda argument 0: interface B is not convertible to interface A

see https://bugs.openjdk.java.net/browse/JDK-8058112