### PR TITLE
Uses the items.size to fill the total size on single-page-Pages

### DIFF
--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -362,7 +362,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
                 result.withTotalItems((int) baseQuery.count());
             }
         } else {
-            result.withTotalItems(result.getEnd());
+            result.withTotalItems(items.size());
         }
     }
 


### PR DESCRIPTION
result.getEnd() is not yet filled and therefore is always 0

Fixes: OX-5521