### PR TITLE
Aha/context aware import handlers

### DIFF
--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListEntryImportHandler.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListEntryImportHandler.java
@@ -37,7 +37,7 @@ public class SQLCodeListEntryImportHandler extends SQLEntityImportHandler<SQLCod
     public static class SQLCodeListImportHandlerFactory implements ImportHandlerFactory {
 
         @Override
-        public boolean accepts(Class<?> type) {
+        public boolean accepts(Class<?> type, ImporterContext context) {
             return type == SQLCodeListEntry.class;
         }
 

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntryImportHandler.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntryImportHandler.java
@@ -34,7 +34,7 @@ public class MongoCodeListEntryImportHandler extends MongoEntityImportHandler<Mo
     public static class MongoCodeListImportHandlerFactory implements ImportHandlerFactory {
 
         @Override
-        public boolean accepts(Class<?> type) {
+        public boolean accepts(Class<?> type, ImporterContext context) {
             return type == MongoCodeListEntry.class;
         }
 

--- a/src/main/java/sirius/biz/importer/ImportHandlerFactory.java
+++ b/src/main/java/sirius/biz/importer/ImportHandlerFactory.java
@@ -42,11 +42,12 @@ public interface ImportHandlerFactory extends Priorized {
     /**
      * Determines if this factory can create an appropriate {@link ImportHandler} for the given type.
      *
-     * @param type the type to check
+     * @param type    the type to check
+     * @param context the context of this import
      * @return <tt>true</tt> if {@link #create(Class, ImporterContext)} should be called for the given type
      * in order to create a new handler,<tt>false</tt> otherwise.
      */
-    boolean accepts(Class<?> type);
+    boolean accepts(Class<?> type, ImporterContext context);
 
     /**
      * Creates a new import handler for the given type and context.

--- a/src/main/java/sirius/biz/importer/ImporterContext.java
+++ b/src/main/java/sirius/biz/importer/ImporterContext.java
@@ -61,9 +61,10 @@ public class ImporterContext {
      * Resolves which {@link ImportHandler} to use for a given type.
      * <p>
      * Basically we iterate over all known {@link ImportHandlerFactory factories} (sorted by their priority ascending)
-     * and use the first which returns <tt>true</tt> when invoking {@link ImportHandlerFactory#accepts(Class)} with the
-     * given <tt>type</tt>. This factory is used to create a new handler which is then kept in a local lookup table
-     * so that it is re-used for all subsequent calls for this context and the given <tt>type</tt>.
+     * and use the first which returns <tt>true</tt> when invoking
+     * {@link ImportHandlerFactory#accepts(Class, ImporterContext)}  with the given <tt>type</tt>. This factory is used
+     * to create a new handler which is then kept in a local lookup table so that it is re-used for all subsequent
+     * calls for this context and the given <tt>type</tt>.
      * <p>
      * If no factory matches, we repeat the search using the superclass.
      *

--- a/src/main/java/sirius/biz/importer/ImporterContext.java
+++ b/src/main/java/sirius/biz/importer/ImporterContext.java
@@ -79,7 +79,7 @@ public class ImporterContext {
 
     private ImportHandler<?> lookupHandler(Class<?> type, Class<?> baseType) {
         for (ImportHandlerFactory factory : factories) {
-            if (factory.accepts(type)) {
+            if (factory.accepts(type, this)) {
                 return factory.create(type, this);
             }
         }

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountImportHandler.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountImportHandler.java
@@ -40,7 +40,7 @@ public class SQLUserAccountImportHandler extends SQLEntityImportHandler<SQLUserA
     public static class SQLUserAccountImportHandlerFactory implements ImportHandlerFactory {
 
         @Override
-        public boolean accepts(Class<?> type) {
+        public boolean accepts(Class<?> type, ImporterContext context) {
             return type == SQLUserAccount.class;
         }
 

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountImportHandler.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountImportHandler.java
@@ -41,7 +41,7 @@ public class MongoUserAccountImportHandler extends MongoEntityImportHandler<Mong
     public static class MongoUserAccountImportHandlerFactory implements ImportHandlerFactory {
 
         @Override
-        public boolean accepts(Class<?> type) {
+        public boolean accepts(Class<?> type, ImporterContext context) {
             return type == MongoUserAccount.class;
         }
 

--- a/src/test/java/sirius/biz/importer/SQLTenantImportHandler.java
+++ b/src/test/java/sirius/biz/importer/SQLTenantImportHandler.java
@@ -30,7 +30,7 @@ public class SQLTenantImportHandler extends SQLEntityImportHandler<SQLTenant> {
     public static class SQLTenantImportHandlerFactory implements ImportHandlerFactory {
 
         @Override
-        public boolean accepts(Class<?> type) {
+        public boolean accepts(Class<?> type, ImporterContext context) {
             return type == SQLTenant.class;
         }
 


### PR DESCRIPTION
This is used to realize SE-9024 (and friends). This will allow to keep legacy and refurbished handlers around at the same time so that we can migrate the code step by step.