### PR TITLE
Uses a lambda instead of a method reference to prevent a jdk Bug

### DIFF
--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -213,12 +213,11 @@ public abstract class Tenants<I, T extends BaseEntity<I> & Tenant<I>, U extends 
 
         String currentTenantId = getCurrentTenant().map(tenant -> tenant.getIdAsString()).orElse(null);
         if (!Strings.areEqual(tenantAware.getTenantAsString(), currentTenantId)
-            && !Objects.equals(tenantAware.getTenantAsString(),
-                               getCurrentTenant().map(Tenant::getParent)
-                                                 .filter(BaseEntityRef::isFilled)
-                                                 .map(BaseEntityRef::getId)
-                                                 .map(String::valueOf)
-                                                 .orElse(null))) {
+                && !Objects.equals(tenantAware.getTenantAsString(),
+                getCurrentTenant().map(tenant -> tenant.getParent())
+                        .filter(BaseEntityRef::isFilled)
+                        .map(entityRef -> entityRef.getIdAsString())
+                        .orElse(null))) {
             throw Exceptions.createHandled().withNLSKey("Tenants.invalidTenant").handle();
         }
     }


### PR DESCRIPTION
Using a method reference can lead to a LambdaMetaFactory validate exception:

When trying to apply a map() using a Function over a multi-bounded intersection generic type, the JRE fails with error message
Caused by: java.lang.invoke.LambdaConversionException: Type mismatch for lambda argument 0: interface B is not convertible to interface A