### PR TITLE
Increases zip length to support more formats

### DIFF
--- a/src/main/java/sirius/biz/model/AddressData.java
+++ b/src/main/java/sirius/biz/model/AddressData.java
@@ -88,7 +88,7 @@ public class AddressData extends Composite {
     @NullAllowed
     @Autoloaded
     @AutoImport
-    @Length(9)
+    @Length(16)
     private String zip;
 
     /**


### PR DESCRIPTION
As correctness of the zip is not checked or enforced here anyway, we might as well support more input values.
Also, full U.S. zips use 9 digits and a dash(length 10) and country codes may be prefixed.