### PR TITLE
Avoids logging duplicated journal entries via TenantData and main entity

### DIFF
--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenant.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenant.java
@@ -46,12 +46,6 @@ public class SQLTenant extends BizEntity implements Tenant<Long> {
     private final TenantData tenantData = new TenantData(this);
 
     /**
-     * Used to record changes on fields of the user.
-     */
-    public static final Mapping JOURNAL = Mapping.named("journal");
-    private final JournalData journal = new JournalData(this);
-
-    /**
      * Contains the effectively enabled features / permissions for this tenant.
      */
     @Transient
@@ -90,7 +84,7 @@ public class SQLTenant extends BizEntity implements Tenant<Long> {
 
     @Override
     public JournalData getJournal() {
-        return journal;
+        return tenantData.getJournal();
     }
 
     @Override

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
@@ -45,12 +45,6 @@ public class MongoTenant extends MongoBizEntity implements Tenant<String> {
     private final TenantData tenantData = new TenantData(this);
 
     /**
-     * Used to record changes on fields of the user.
-     */
-    public static final Mapping JOURNAL = Mapping.named("journal");
-    private final JournalData journal = new JournalData(this);
-
-    /**
      * Contains the effectively enabled features / permissions for this tenant.
      */
     @Transient
@@ -96,7 +90,7 @@ public class MongoTenant extends MongoBizEntity implements Tenant<String> {
 
     @Override
     public JournalData getJournal() {
-        return journal;
+        return tenantData.getJournal();
     }
 
     @Override


### PR DESCRIPTION
@AfterSave on JournalData.onSave() was being registered (and triggered) twice.

Fixes: OX-5566