### PR TITLE
Fixes a bug where the list files of a folder name with whitespace fails

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
@@ -76,7 +76,7 @@ public class FTPUplink extends ConfigBasedUplink {
 
         RemotePath relativeParent = parent.as(RemotePath.class);
         try (UplinkConnector<FTPClient> connector = connectorPool.obtain(ftpConfig)) {
-            for (FTPFile file : connector.connector().listFiles(relativeParent.getPath())) {
+            for (FTPFile file : connector.connector().listFiles(relativeParent.getWhiteSpaceEncodedPath())) {
                 if (!search.processResult(wrap(parent, file, file.getName()))) {
                     return;
                 }
@@ -137,7 +137,7 @@ public class FTPUplink extends ConfigBasedUplink {
 
         try (UplinkConnector<FTPClient> connector = connectorPool.obtain(ftpConfig)) {
             FTPFile[] ftpFiles = connector.connector()
-                                          .listFiles(file.parent().as(RemotePath.class).getPath(),
+                                          .listFiles(file.parent().as(RemotePath.class).getWhiteSpaceEncodedPath(),
                                                      ftpFile -> Strings.areEqual(ftpFile.getName(), file.name()));
             if (ftpFiles.length == 1) {
                 file.attach(ftpFiles[0]);

--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/RemotePath.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/RemotePath.java
@@ -18,6 +18,8 @@ public class RemotePath {
 
     private String path;
 
+    private String whiteSpaceEncodedPath;
+
     /**
      * Generates a new wrapper for the given path.
      *
@@ -25,6 +27,7 @@ public class RemotePath {
      */
     public RemotePath(String path) {
         this.path = path;
+        this.whiteSpaceEncodedPath = path.replace(" ", "\\ ");
     }
 
     /**
@@ -39,6 +42,10 @@ public class RemotePath {
         } else {
             return new RemotePath(this.path + "/" + file);
         }
+    }
+
+    public String getWhiteSpaceEncodedPath() {
+        return whiteSpaceEncodedPath;
     }
 
     /**


### PR DESCRIPTION
If the server has a folder structure like: "test test/test2"
then listFiles("test test") would not result in ["test2"]
we need to call listFiles("test\ test")
- Fixes: SIRI-132