### PR TITLE
Uses createNowOrUpdateInBatch as default way of updating entities.

### DIFF
--- a/src/main/java/sirius/biz/importer/Importer.java
+++ b/src/main/java/sirius/biz/importer/Importer.java
@@ -238,7 +238,7 @@ public class Importer implements Closeable {
     }
 
     /**
-     * Creates the entity immediatelly or updates the given entity in the underlying database using a batch update.
+     * Creates the entity immediately or updates the given entity in the underlying database using a batch update.
      * <p>
      * Uses the appropriate {@link ImportHandler} to determine if the entity already exists and then either updates
      * the entity or creates a new one.

--- a/src/main/java/sirius/biz/importer/Importer.java
+++ b/src/main/java/sirius/biz/importer/Importer.java
@@ -201,6 +201,9 @@ public class Importer implements Closeable {
      * <p>
      * Uses the appropriate {@link ImportHandler} to determine if the entity already exists and then either updates
      * the entity or creates a new one.
+     * <p>
+     * Note that this will execute an update per entity. Use {@link #createNowOrUpdateInBatch(BaseEntity)} or even
+     * {@link #createOrUpdateInBatch(BaseEntity)} to yield maximal performance by grouping changes into batch updates.
      *
      * @param entity the entity to update or create
      * @param <E>    the generic type of the entity
@@ -219,13 +222,37 @@ public class Importer implements Closeable {
      * <p>
      * Using a batch update will most probably yield substantial performance benefits with the downside, that the updated
      * entity cannot be returned by this method.
+     * <p>
+     * Note that {@link #createNowOrUpdateInBatch(BaseEntity)} is most probably a better choice, as it makes the entity
+     * immediatelly visible to the database and all internal consistency checks and still provides optimal performance
+     * when updating many objects.
      *
      * @param entity the entity to update or create
      * @param <E>    the generic type of the entity
+     * @see #createNowOrUpdateInBatch(BaseEntity)
+     * @see ImportHandler#createOrUpdateInBatch(BaseEntity)
      */
     @SuppressWarnings("unchecked")
     public <E extends BaseEntity<?>> void createOrUpdateInBatch(E entity) {
         context.findHandler((Class<E>) entity.getClass()).createOrUpdateInBatch(entity);
+    }
+
+    /**
+     * Creates the entity immediatelly or updates the given entity in the underlying database using a batch update.
+     * <p>
+     * Uses the appropriate {@link ImportHandler} to determine if the entity already exists and then either updates
+     * the entity or creates a new one.
+     * <p>
+     * Using a batch update will most probably yield substantial performance benefits with the downside, that the updated
+     * entity cannot be returned by this method.
+     *
+     * @param entity the entity to update or create
+     * @param <E>    the generic type of the entity
+     * @see ImportHandler#createNowOrUpdateInBatch(BaseEntity)
+     */
+    @SuppressWarnings("unchecked")
+    public <E extends BaseEntity<?>> void createNowOrUpdateInBatch(E entity) {
+        context.findHandler((Class<E>) entity.getClass()).createNowOrUpdateInBatch(entity);
     }
 
     @Override

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
@@ -32,8 +32,8 @@ import java.util.function.Consumer;
  * <p>
  * Utilizing {@link sirius.biz.importer.ImportHandler import handlers} this can be used as is in most cases.
  * <p>
- * Note that {@link #fillAndVerify(BaseEntity)} can be overwritten to perform any pre-save activities or
- * {@link #createOrUpdate(BaseEntity)} to use a custom way to persist data or to perform some post-save activities.
+ * Note that {@link #enforceSaveConstraints(BaseEntity, Context)} can be overwritten to perform any pre-save activities or
+ * {@link #createOrUpdate(BaseEntity, Context)} to use a custom way to persist data or to perform some post-save activities.
  *
  * @param <E> the type of entities being imported by this job
  */
@@ -180,8 +180,9 @@ public class EntityImportJob<E extends BaseEntity<?>> extends DictionaryBasedImp
      *
      * @param entity  the entity to persist
      * @param context the row represented as context
+     * @see sirius.biz.importer.Importer#createNowOrUpdateInBatch(BaseEntity)
      */
     protected void createOrUpdate(E entity, Context context) {
-        importer.createOrUpdateInBatch(entity);
+        importer.createNowOrUpdateInBatch(entity);
     }
 }


### PR DESCRIPTION
Otherwise "unique" checks might fail (at the database level) as the inserts are queued in the batch
and therefore not enforced by the framework. This adds too much trouble for outweight the performance improvements
of a batched insert.

If an entity is known to not have any unique constraints / such conflicts - which is probably very rare - this method
can be overwritten and changed back to a batched insert.