### PR TITLE
Adds some methods to re-use PageHelpers in processes to iterate over total items

### DIFF
--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -316,7 +316,13 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
         return addSortFacet(Arrays.asList(sortOptions), null);
     }
 
-    private String getParameterValue(String name) {
+    /**
+     * Extracts the value from the given context.
+     *
+     * @param name the name of the parameter to extract
+     * @return the value stored in either {@link #webContext or #processContext}
+     */
+    protected String getParameterValue(String name) {
         if (webContext != null) {
             return webContext.get(name).getString();
         }

--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -362,11 +362,11 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     /**
      * Calls the given function on all items in the result ignoring {@link #pageSize}, as long as it returns <tt>true</tt>.
      * <p>
-     * While this is not the purpose of this helper, this can be used to easily re-use code that is inteded for page views.
+     * While this is not the purpose of this helper, this can be used to easily re-use code that is intended for page views.
      * For example, together with {@link #withParameterProvider(Function)} this can be used to export the same page view in a process,
      * using the same query and facet suppliers as the view that is to be exported.
      *
-     * @param resultHandler the handle to be invoked for each item in the result
+     * @param resultHandler the handler to be invoked for each item in the result
      */
     public void iterateTotalItems(Function<E, Boolean> resultHandler) {
         String query = getParameterValue("query").getString();
@@ -379,11 +379,11 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     /**
      * Calls the given consumer on all items in the result ignoring {@link #pageSize}.
      * <p>
-     * While this is not the purpose of this helper, this can be used to easily re-use code that is inteded for page views.
+     * While this is not the purpose of this helper, this can be used to easily re-use code that is intended for page views.
      * For example, together with {@link #withParameterProvider(Function)} this can be used to export the same page view in a process,
      * using the same query and facet suppliers as the view that is to be exported.
      *
-     * @param consumer the handle to be invoked for each item in the result
+     * @param consumer the handler to be invoked for each item in the result
      */
     public void iterateAllTotalItems(Consumer<E> consumer) {
         iterateTotalItems(r -> {

--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.web;
 
+import sirius.biz.process.ProcessContext;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.DateRange;
 import sirius.db.mixing.Mapping;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Helper class to build a query, bind it to values given in a {@link WebContext} and create a resulting {@link Page}
@@ -47,7 +49,8 @@ import java.util.function.Consumer;
 public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constraint, Q extends Query<Q, E, C>, B extends BasePageHelper<E, C, Q, B>> {
 
     protected static final int DEFAULT_PAGE_SIZE = 25;
-    protected WebContext ctx;
+    protected WebContext webContext;
+    protected ProcessContext processContext;
     protected Q baseQuery;
     protected List<QueryField> searchFields = Collections.emptyList();
     protected List<Tuple<Facet, BiConsumer<Facet, Q>>> facets = new ArrayList<>();
@@ -61,12 +64,25 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     /**
      * Attaches a web context to the helper, to fetch filter and pagination values from.
      *
-     * @param ctx the request to attach
+     * @param webContext the request to attach
      * @return the helper itself for fluent method calls
      */
     @SuppressWarnings("unchecked")
-    public B withContext(WebContext ctx) {
-        this.ctx = ctx;
+    public B withContext(WebContext webContext) {
+        this.webContext = webContext;
+        return (B) this;
+    }
+
+    /**
+     * Attaches a process context to the helper, to fetch filter values from.
+     * This can be used intead of supplying a webContext via {@link #withContext(WebContext)}.
+     *
+     * @param processContext the context where filter values are fetched from
+     * @return the helper itself for fluent method calls
+     */
+    @SuppressWarnings("unchecked")
+    public B withProcessContext(ProcessContext processContext) {
+        this.processContext = processContext;
         return (B) this;
     }
 
@@ -128,11 +144,9 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     @SuppressWarnings("unchecked")
     public B addFacet(Facet facet, BiConsumer<Facet, Q> filter, BiConsumer<Facet, Q> itemsComputer) {
         Objects.requireNonNull(baseQuery);
-        Objects.requireNonNull(ctx);
 
-        facet.withValue(ctx.get(facet.getName()).getString());
+        facet.withValue(getParameterValue(facet.getName()));
         filter.accept(facet, baseQuery);
-
         facets.add(Tuple.create(facet, itemsComputer));
 
         return (B) this;
@@ -177,9 +191,8 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
      * @return the helper itself for fluent method calls
      */
     public B addBooleanFacet(String name, String title) {
-        Objects.requireNonNull(ctx);
-
-        Facet facet = new Facet(title, name, ctx.get(name).asString(), null);
+        String facetValue = getParameterValue(name);
+        Facet facet = new Facet(title, name, facetValue, null);
         facet.addItem("true", NLS.get("NLS.yes"), -1);
         facet.addItem("false", NLS.get("NLS.no"), -1);
 
@@ -202,9 +215,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
      * @return the helper itself for fluent method calls
      */
     public B addEnumFacet(String name, String title, Class<? extends Enum<?>> enumType) {
-        Objects.requireNonNull(ctx);
-
-        Facet facet = new Facet(title, name, ctx.get(name).asString(), null);
+        Facet facet = new Facet(title, name, getParameterValue(name), null);
         Arrays.stream(enumType.getEnumConstants()).forEach(e -> facet.addItem(e.name(), e.toString(), -1));
 
         return addFilterFacet(facet);
@@ -230,13 +241,11 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
                                @Nonnull Mapping filterField,
                                @Nonnull String title,
                                @Nullable ValueComputer<String, String> translator) {
-        Objects.requireNonNull(ctx);
-
-        String value = ctx.get(parameterName).asString();
+        String value = getParameterValue(parameterName);
 
         if (Strings.isFilled(value)) {
             Facet facet = new Facet(title, parameterName, value, translator);
-            Value labelAsValue = ctx.get(labelParameterName);
+            Value labelAsValue = webContext.get(labelParameterName);
             facet.addItem(value, labelAsValue.getString(), -1);
             addFacet(facet, (f, q) -> q.eqIgnoreNull(filterField, f.getValue()));
             if (labelAsValue.isFilled()) {
@@ -307,6 +316,16 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
         return addSortFacet(Arrays.asList(sortOptions), null);
     }
 
+    private String getParameterValue(String name) {
+        if (webContext != null) {
+            return webContext.get(name).getString();
+        }
+        if (processContext != null) {
+            return processContext.get(name).getString();
+        }
+        throw new IllegalStateException("A context needs to be provided to the page helper first!");
+    }
+
     /**
      * Specifies the number of items shown on the page that gets rendered using this pageHelper.
      *
@@ -325,10 +344,10 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
      * @return the given data wrapped as <tt>Page</tt>
      */
     public Page<E> asPage() {
-        Objects.requireNonNull(ctx);
+        Objects.requireNonNull(webContext);
         Watch w = Watch.start();
         Page<E> result = new Page<E>().withStart(1).withPageSize(pageSize);
-        result.bindToRequest(ctx);
+        result.bindToRequest(webContext);
 
         if (Strings.isFilled(result.getQuery()) && !searchFields.isEmpty()) {
             baseQuery.where(baseQuery.filters()
@@ -375,12 +394,49 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
         baseQuery.limit(pageSize + 1);
     }
 
-    protected void applyFacets(Page<E> result) {
+    /**
+     * Calls the given function on all items in the result ignoring {@link #pageSize}, as long as it returns <tt>true</tt>.
+     * <p>
+     * While this is not the purpose of this helper, this can be used to easily re-use code that is inteded for page views.
+     * For example, together with {@link #withProcessContext(ProcessContext)} this can be used to export the same page view in a process,
+     * using the same query and facet suppliers as the view that is to be exported.
+     *
+     * @param resultHandler the handle to be invoked for each item in the result
+     */
+    public void iterateTotalItems(Function<E, Boolean> resultHandler) {
+        String query = getParameterValue("query");
+        if (Strings.isFilled(query) && !searchFields.isEmpty()) {
+            baseQuery.where(baseQuery.filters().queryString(baseQuery.getDescriptor(), query, searchFields));
+        }
+
+        applyFacets(null);
+        baseQuery.iterate(resultHandler);
+    }
+
+    /**
+     * Calls the given consumer on all items in the result ignoring {@link #pageSize}.
+     * <p>
+     * While this is not the purpose of this helper, this can be used to easily re-use code that is inteded for page views.
+     * For example, together with {@link #withProcessContext(ProcessContext)} this can be used to export the same page view in a process,
+     * using the same query and facet suppliers as the view that is to be exported.
+     *
+     * @param consumer the handle to be invoked for each item in the result
+     */
+    public void iterateAllTotalItems(Consumer<E> consumer) {
+        iterateTotalItems(r -> {
+            consumer.accept(r);
+            return true;
+        });
+    }
+
+    protected void applyFacets(@Nullable Page<E> result) {
         for (Tuple<Facet, BiConsumer<Facet, Q>> f : facets) {
             if (f.getSecond() != null) {
                 f.getSecond().accept(f.getFirst(), baseQuery);
             }
-            result.addFacet(f.getFirst());
+            if (result != null) {
+                result.addFacet(f.getFirst());
+            }
         }
     }
 

--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.web;
 
-import sirius.biz.process.ProcessContext;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.DateRange;
 import sirius.db.mixing.Mapping;
@@ -50,7 +49,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
 
     protected static final int DEFAULT_PAGE_SIZE = 25;
     protected WebContext webContext;
-    protected ProcessContext processContext;
+    protected Function<String, Value> parameterProvider;
     protected Q baseQuery;
     protected List<QueryField> searchFields = Collections.emptyList();
     protected List<Tuple<Facet, BiConsumer<Facet, Q>>> facets = new ArrayList<>();
@@ -70,19 +69,22 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     @SuppressWarnings("unchecked")
     public B withContext(WebContext webContext) {
         this.webContext = webContext;
+        this.parameterProvider = webContext::get;
         return (B) this;
     }
 
     /**
-     * Attaches a process context to the helper, to fetch filter values from.
-     * This can be used intead of supplying a webContext via {@link #withContext(WebContext)}.
+     * Defines a custom parameter provider to fetch filter and pagination values from.
+     * <p>
+     * This can be used instead of supplying a webContext via {@link #withContext(WebContext)}, but if you want to create a page
+     * using {@link #asPage()}, a web context is still needed.
      *
-     * @param processContext the context where filter values are fetched from
+     * @param parameterProvider the context where filter values are fetched from
      * @return the helper itself for fluent method calls
      */
     @SuppressWarnings("unchecked")
-    public B withProcessContext(ProcessContext processContext) {
-        this.processContext = processContext;
+    public B withParameterProvider(Function<String, Value> parameterProvider) {
+        this.parameterProvider = parameterProvider;
         return (B) this;
     }
 
@@ -145,7 +147,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     public B addFacet(Facet facet, BiConsumer<Facet, Q> filter, BiConsumer<Facet, Q> itemsComputer) {
         Objects.requireNonNull(baseQuery);
 
-        facet.withValue(getParameterValue(facet.getName()));
+        facet.withValue(getParameterValue(facet.getName()).getString());
         filter.accept(facet, baseQuery);
         facets.add(Tuple.create(facet, itemsComputer));
 
@@ -191,7 +193,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
      * @return the helper itself for fluent method calls
      */
     public B addBooleanFacet(String name, String title) {
-        String facetValue = getParameterValue(name);
+        String facetValue = getParameterValue(name).getString();
         Facet facet = new Facet(title, name, facetValue, null);
         facet.addItem("true", NLS.get("NLS.yes"), -1);
         facet.addItem("false", NLS.get("NLS.no"), -1);
@@ -215,7 +217,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
      * @return the helper itself for fluent method calls
      */
     public B addEnumFacet(String name, String title, Class<? extends Enum<?>> enumType) {
-        Facet facet = new Facet(title, name, getParameterValue(name), null);
+        Facet facet = new Facet(title, name, getParameterValue(name).getString(), null);
         Arrays.stream(enumType.getEnumConstants()).forEach(e -> facet.addItem(e.name(), e.toString(), -1));
 
         return addFilterFacet(facet);
@@ -241,7 +243,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
                                @Nonnull Mapping filterField,
                                @Nonnull String title,
                                @Nullable ValueComputer<String, String> translator) {
-        String value = getParameterValue(parameterName);
+        String value = getParameterValue(parameterName).getString();
 
         if (Strings.isFilled(value)) {
             Facet facet = new Facet(title, parameterName, value, translator);
@@ -317,22 +319,6 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     }
 
     /**
-     * Extracts the value from the given context.
-     *
-     * @param name the name of the parameter to extract
-     * @return the value stored in either {@link #webContext or #processContext}
-     */
-    protected String getParameterValue(String name) {
-        if (webContext != null) {
-            return webContext.get(name).getString();
-        }
-        if (processContext != null) {
-            return processContext.get(name).getString();
-        }
-        throw new IllegalStateException("A context needs to be provided to the page helper first!");
-    }
-
-    /**
      * Specifies the number of items shown on the page that gets rendered using this pageHelper.
      *
      * @param pageSize the number of items shown per page
@@ -346,6 +332,8 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
 
     /**
      * Wraps the given data into a {@link Page} which can be used to render a table, filterbox and support pagination.
+     * <p>
+     * This can only be done if a web context has been provided via {@link #withContext(WebContext)}.
      *
      * @return the given data wrapped as <tt>Page</tt>
      */
@@ -355,10 +343,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
         Page<E> result = new Page<E>().withStart(1).withPageSize(pageSize);
         result.bindToRequest(webContext);
 
-        if (Strings.isFilled(result.getQuery()) && !searchFields.isEmpty()) {
-            baseQuery.where(baseQuery.filters()
-                                     .queryString(baseQuery.getDescriptor(), result.getQuery(), searchFields));
-        }
+        applyQuery(result.getQuery());
 
         applyFacets(result);
 
@@ -372,6 +357,53 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
         }
 
         return result;
+    }
+
+    /**
+     * Calls the given function on all items in the result ignoring {@link #pageSize}, as long as it returns <tt>true</tt>.
+     * <p>
+     * While this is not the purpose of this helper, this can be used to easily re-use code that is inteded for page views.
+     * For example, together with {@link #withParameterProvider(Function)} this can be used to export the same page view in a process,
+     * using the same query and facet suppliers as the view that is to be exported.
+     *
+     * @param resultHandler the handle to be invoked for each item in the result
+     */
+    public void iterateTotalItems(Function<E, Boolean> resultHandler) {
+        String query = getParameterValue("query").getString();
+        applyQuery(query);
+
+        applyFacets(null);
+        baseQuery.iterate(resultHandler);
+    }
+
+    /**
+     * Calls the given consumer on all items in the result ignoring {@link #pageSize}.
+     * <p>
+     * While this is not the purpose of this helper, this can be used to easily re-use code that is inteded for page views.
+     * For example, together with {@link #withParameterProvider(Function)} this can be used to export the same page view in a process,
+     * using the same query and facet suppliers as the view that is to be exported.
+     *
+     * @param consumer the handle to be invoked for each item in the result
+     */
+    public void iterateAllTotalItems(Consumer<E> consumer) {
+        iterateTotalItems(r -> {
+            consumer.accept(r);
+            return true;
+        });
+    }
+
+    private void applyQuery(String query) {
+        if (Strings.isFilled(query) && !searchFields.isEmpty()) {
+            baseQuery.where(baseQuery.filters().queryString(baseQuery.getDescriptor(), query, searchFields));
+        }
+    }
+
+    protected Value getParameterValue(String name) {
+        if (parameterProvider == null) {
+            throw new IllegalStateException(
+                    "A parameter provider or web context needs to be attached to the page helper first!");
+        }
+        return parameterProvider.apply(name);
     }
 
     protected void fillPage(Watch w, Page<E> result, List<E> items) {
@@ -398,41 +430,6 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     protected void setupPaging(Page<E> result) {
         baseQuery.skip(result.getStart() - 1);
         baseQuery.limit(pageSize + 1);
-    }
-
-    /**
-     * Calls the given function on all items in the result ignoring {@link #pageSize}, as long as it returns <tt>true</tt>.
-     * <p>
-     * While this is not the purpose of this helper, this can be used to easily re-use code that is inteded for page views.
-     * For example, together with {@link #withProcessContext(ProcessContext)} this can be used to export the same page view in a process,
-     * using the same query and facet suppliers as the view that is to be exported.
-     *
-     * @param resultHandler the handle to be invoked for each item in the result
-     */
-    public void iterateTotalItems(Function<E, Boolean> resultHandler) {
-        String query = getParameterValue("query");
-        if (Strings.isFilled(query) && !searchFields.isEmpty()) {
-            baseQuery.where(baseQuery.filters().queryString(baseQuery.getDescriptor(), query, searchFields));
-        }
-
-        applyFacets(null);
-        baseQuery.iterate(resultHandler);
-    }
-
-    /**
-     * Calls the given consumer on all items in the result ignoring {@link #pageSize}.
-     * <p>
-     * While this is not the purpose of this helper, this can be used to easily re-use code that is inteded for page views.
-     * For example, together with {@link #withProcessContext(ProcessContext)} this can be used to export the same page view in a process,
-     * using the same query and facet suppliers as the view that is to be exported.
-     *
-     * @param consumer the handle to be invoked for each item in the result
-     */
-    public void iterateAllTotalItems(Consumer<E> consumer) {
-        iterateTotalItems(r -> {
-            consumer.accept(r);
-            return true;
-        });
     }
 
     protected void applyFacets(@Nullable Page<E> result) {

--- a/src/main/java/sirius/biz/web/ElasticPageHelper.java
+++ b/src/main/java/sirius/biz/web/ElasticPageHelper.java
@@ -237,7 +237,7 @@ public class ElasticPageHelper<E extends ElasticEntity>
             // If we didn't find any aggregation value we have to check if a filter for this
             // facet is active and artificially create an "0" item for this so that it can be
             // disabled...
-            String filterValue = ctx.get(facet.getName()).asString();
+            String filterValue = webContext.get(facet.getName()).asString();
             if (Strings.isFilled(filterValue)) {
                 facet.addItem(filterValue, translator.compute(filterValue), 0);
             }

--- a/src/main/java/sirius/biz/web/ElasticPageHelper.java
+++ b/src/main/java/sirius/biz/web/ElasticPageHelper.java
@@ -237,7 +237,7 @@ public class ElasticPageHelper<E extends ElasticEntity>
             // If we didn't find any aggregation value we have to check if a filter for this
             // facet is active and artificially create an "0" item for this so that it can be
             // disabled...
-            String filterValue = getParameterValue(facet.getName());
+            String filterValue = getParameterValue(facet.getName()).getString();
             if (Strings.isFilled(filterValue)) {
                 facet.addItem(filterValue, translator.compute(filterValue), 0);
             }

--- a/src/main/java/sirius/biz/web/ElasticPageHelper.java
+++ b/src/main/java/sirius/biz/web/ElasticPageHelper.java
@@ -237,7 +237,7 @@ public class ElasticPageHelper<E extends ElasticEntity>
             // If we didn't find any aggregation value we have to check if a filter for this
             // facet is active and artificially create an "0" item for this so that it can be
             // disabled...
-            String filterValue = webContext.get(facet.getName()).asString();
+            String filterValue = getParameterValue(facet.getName());
             if (Strings.isFilled(filterValue)) {
                 facet.addItem(filterValue, translator.compute(filterValue), 0);
             }

--- a/src/main/java/sirius/biz/web/MongoPageHelper.java
+++ b/src/main/java/sirius/biz/web/MongoPageHelper.java
@@ -197,7 +197,7 @@ public class MongoPageHelper<E extends MongoEntity>
                 // If we didn't find any aggregation value we have to check if a filter for this
                 // facet is active and artificially create an "0" item for this so that it can be
                 // disabled...
-                String filterValue = getParameterValue(facet.getName());
+                String filterValue = getParameterValue(facet.getName()).getString();
                 if (Strings.isFilled(filterValue)) {
                     facet.addItem(filterValue, nonNullTranslator.compute(filterValue), 0);
                 }

--- a/src/main/java/sirius/biz/web/MongoPageHelper.java
+++ b/src/main/java/sirius/biz/web/MongoPageHelper.java
@@ -198,7 +198,7 @@ public class MongoPageHelper<E extends MongoEntity>
                 // If we didn't find any aggregation value we have to check if a filter for this
                 // facet is active and artificially create an "0" item for this so that it can be
                 // disabled...
-                String filterValue = ctx.get(facet.getName()).asString();
+                String filterValue = webContext.get(facet.getName()).asString();
                 if (Strings.isFilled(filterValue)) {
                     facet.addItem(filterValue, nonNullTranslator.compute(filterValue), 0);
                 }

--- a/src/main/java/sirius/biz/web/MongoPageHelper.java
+++ b/src/main/java/sirius/biz/web/MongoPageHelper.java
@@ -163,9 +163,8 @@ public class MongoPageHelper<E extends MongoEntity>
             Iterator<FacetItem> iter = facet.getAllItems().iterator();
             while (iter.hasNext()) {
                 FacetItem item = iter.next();
-                int numberOfHits = Strings.areEqual(item.getKey(), "true") ?
-                                   mongoFacet.getNumTrue() :
-                                   mongoFacet.getNumFalse();
+                int numberOfHits =
+                        Strings.areEqual(item.getKey(), "true") ? mongoFacet.getNumTrue() : mongoFacet.getNumFalse();
                 if (numberOfHits > 0 || item.isActive()) {
                     item.setCount(numberOfHits);
                 } else {
@@ -198,7 +197,7 @@ public class MongoPageHelper<E extends MongoEntity>
                 // If we didn't find any aggregation value we have to check if a filter for this
                 // facet is active and artificially create an "0" item for this so that it can be
                 // disabled...
-                String filterValue = webContext.get(facet.getName()).asString();
+                String filterValue = getParameterValue(facet.getName());
                 if (Strings.isFilled(filterValue)) {
                     facet.addItem(filterValue, nonNullTranslator.compute(filterValue), 0);
                 }


### PR DESCRIPTION
While this is not really the purpose of these helpers, this prevents a lot of duplicate code when building processes that are linked to page views, for example export processes.

Fixes: SIRI-146