### PR TITLE
Allows for a BooleanParameter to be nullable/optional

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/BooleanParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/BooleanParameter.java
@@ -82,7 +82,7 @@ public class BooleanParameter extends Parameter<Boolean, BooleanParameter> {
 
     @Override
     protected Optional<Boolean> resolveFromString(@Nonnull Value input) {
-        if (nullable && !("true".equalsIgnoreCase(input.asString()) || "false".equalsIgnoreCase(input.asString()))) {
+        if (nullable && !input.isFilled()) {
             return Optional.empty();
         }
         return Optional.of(input.asBoolean());

--- a/src/main/java/sirius/biz/jobs/params/BooleanParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/BooleanParameter.java
@@ -72,7 +72,7 @@ public class BooleanParameter extends Parameter<Boolean, BooleanParameter> {
     @Override
     public BooleanParameter markRequired() {
         throw new UnsupportedOperationException(
-                "A boolean parameter must not be marked as required as it is inherently so. Use markNullable() to make the parameter optional");
+                "A boolean parameter must not be marked as required as it is inherently so. Use markNullable() to make the parameter optional.");
     }
 
     @Override

--- a/src/main/resources/default/templates/biz/jobs/params/selectBoolean.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/params/selectBoolean.html.pasta
@@ -1,9 +1,14 @@
-<i:arg type="sirius.biz.jobs.params.Parameter" name="param"/>
-<i:arg type="Map" name="context"/>
+<i:arg name="param" type="sirius.biz.jobs.params.Parameter"/>
+<i:arg name="context" type="Map"/>
 
-<w:booleanSelect span="12"
-                 smallSpan="12"
-                 name="@param.getName()"
-                 label="@param.getLabel()"
-                 help="@param.getDescription()"
-                 value="@param.get(context).orElse(false)"/>
+<w:singleSelect span="12"
+                smallSpan="12"
+                name="@param.getName()"
+                label="@param.getLabel()"
+                help="@param.getDescription()"
+                optional="@!param.isRequired()"
+                required="@param.isRequired()">
+
+    <option value="true" @selected="@param.get(context).orElse(null) == true">@i18n("NLS.yes")</option>
+    <option value="false" @selected="@param.get(context).orElse(null) == false">@i18n("NLS.no")</option>
+</w:singleSelect>


### PR DESCRIPTION
There are cases where we need to know if the parameter is selected at all and not always default to false.
Default value is false unless markNullable is used.

Fixes: OX-5522