### PR TITLE
Enhances the Importer to receive the job factory name used to initialize it

### DIFF
--- a/src/main/java/sirius/biz/importer/Importer.java
+++ b/src/main/java/sirius/biz/importer/Importer.java
@@ -30,6 +30,7 @@ public class Importer implements Closeable {
 
     protected ImporterContext context;
     protected String name;
+    protected String factoryName;
 
     /**
      * Import log which is accessible to all import jobs.
@@ -47,6 +48,22 @@ public class Importer implements Closeable {
     public Importer(String name) {
         this.name = name;
         this.context = new ImporterContext(this);
+    }
+
+    /**
+     * Returns the factory name given to this importer.
+     *
+     * @return the factory name
+     */
+    public String getFactoryName() {
+        return factoryName;
+    }
+
+    /**
+     * Sets the factory name used in context of an entity import or export job.
+     */
+    public void setFactoryName(String factoryName) {
+        this.factoryName = factoryName;
     }
 
     /**

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityExportJob.java
@@ -24,6 +24,7 @@ import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mixing;
 import sirius.db.mixing.query.Query;
 import sirius.kernel.commons.Context;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Values;
@@ -90,14 +91,18 @@ public class EntityExportJob<E extends BaseEntity<?>, Q extends Query<Q, E, ?>> 
      * @param dictionary            the export dictionary to use
      * @param defaultMapping        the default mapping (default column order) to use
      * @param process               the process context itself
+     * @param factoryName           the name of the factory which created this job
      */
+    @SuppressWarnings("squid:S00107")
+    @Explain("We rather have 8 parameters here and keep the logic properly encapsulated")
     public EntityExportJob(FileParameter templateFileParameter,
                            FileOrDirectoryParameter destinationParameter,
                            EnumParameter<ExportFileType> fileTypeParameter,
                            Class<E> type,
                            ImportDictionary dictionary,
                            List<String> defaultMapping,
-                           ProcessContext process) {
+                           ProcessContext process,
+                           String factoryName) {
         super(destinationParameter, fileTypeParameter, process);
         this.defaultMapping = new ArrayList<>(defaultMapping);
         this.templateFile = process.getParameter(templateFileParameter).orElse(null);
@@ -105,6 +110,7 @@ public class EntityExportJob<E extends BaseEntity<?>, Q extends Query<Q, E, ?>> 
         this.type = type;
         this.descriptor = mixing.getDescriptor(type);
         this.importer = new Importer(process.getTitle());
+        this.importer.setFactoryName(factoryName);
     }
 
     /**

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityExportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityExportJobFactory.java
@@ -62,9 +62,10 @@ public abstract class EntityExportJobFactory<E extends BaseEntity<?>, Q extends 
                                          getExportType(),
                                          getDictionary(),
                                          getDefaultMapping(),
-                                         process).withQueryExtender(query -> extendSelectQuery(query, process))
-                                                 .withContextExtender(context -> context.putAll(paramterContext))
-                                                 .withFileName(getCustomFileName());
+                                         process,
+                                         getName()).withQueryExtender(query -> extendSelectQuery(query, process))
+                                                   .withContextExtender(context -> context.putAll(paramterContext))
+                                                   .withFileName(getCustomFileName());
     }
 
     /**
@@ -83,7 +84,7 @@ public abstract class EntityExportJobFactory<E extends BaseEntity<?>, Q extends 
 
     /**
      * Permits to return a custom file name when exporting the entity.
-     *
+     * <p>
      * Otherwise the "end user friendly" plural of the entity is used as target file name
      */
     protected String getCustomFileName() {

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
@@ -59,14 +59,17 @@ public class EntityImportJob<E extends BaseEntity<?>> extends DictionaryBasedImp
      * @param type                 the type of entities being imported
      * @param dictionary           the import dictionary to use
      * @param process              the process context itself
+     * @param factoryName          the name of the factory which created this job
      */
     public EntityImportJob(FileParameter fileParameter,
                            BooleanParameter ignoreEmptyParameter,
                            EnumParameter<ImportMode> importModeParameter,
                            Class<E> type,
                            ImportDictionary dictionary,
-                           ProcessContext process) {
+                           ProcessContext process,
+                           String factoryName) {
         super(fileParameter, ignoreEmptyParameter, dictionary, process);
+        importer.setFactoryName(factoryName);
         this.mode = process.getParameter(importModeParameter).orElse(ImportMode.NEW_AND_UPDATES);
         this.type = type;
         this.descriptor = mixing.getDescriptor(type);

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -43,15 +43,15 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
     @Override
     protected DictionaryBasedImportJob createJob(ProcessContext process) {
         // We only resolve the parameters once and keep the final values around in a local context...
-        ImportContext paramterContext = new ImportContext();
-        transferParameters(paramterContext, process);
+        ImportContext parameterContext = new ImportContext();
+        transferParameters(parameterContext, process);
 
-        return createImportJob(process, paramterContext);
+        return createImportJob(process, parameterContext);
     }
 
     @SuppressWarnings("squid:S2095")
     @Explain("The job must not be closed here as it is returned and managed by the caller.")
-    protected DictionaryBasedImportJob createImportJob(ProcessContext process, ImportContext paramterContext) {
+    protected DictionaryBasedImportJob createImportJob(ProcessContext process, ImportContext parameterContext) {
         return new EntityImportJob<>(fileParameter,
                                      ignoreEmptyParameter,
                                      importModeParameter,

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -57,7 +57,8 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
                                      importModeParameter,
                                      getImportType(),
                                      getDictionary(),
-                                     process).withContextExtender(context -> context.putAll(paramterContext));
+                                     process,
+                                     getName()).withContextExtender(context -> context.putAll(parameterContext));
     }
 
     /**


### PR DESCRIPTION
Enhances the Importer to receive the job factory name used to initialize it

This opens the door for multiple ImportHandlers to be defined for the same target Entity.
Although in most cases only a single handler would exist for a given entity, there are some needs where a custom handler must be created for specific import or export tasks. In this case the handler can validate if its being used under the context of a specific factory in its accept method by using context.getImporter().getFactoryName().

Note that when using this feature, the **default mappings and dictionary must be defined exclusively by the job factory**, making the handler sort of exclusive to the factories.