### PR TITLE
Revert "Set length of tennantId and userId to 26"

### DIFF
--- a/src/main/java/sirius/biz/analytics/events/UserData.java
+++ b/src/main/java/sirius/biz/analytics/events/UserData.java
@@ -27,7 +27,7 @@ public class UserData extends Composite {
      * Stores the ID of the current user.
      */
     public static final Mapping USER_ID = Mapping.named("userId");
-    @Length(26)
+    @Length(255)
     @NullAllowed
     private String userId;
 
@@ -35,7 +35,7 @@ public class UserData extends Composite {
      * Stores the ID of the current tenant.
      */
     public static final Mapping TENANT_ID = Mapping.named("tenantId");
-    @Length(26)
+    @Length(255)
     @NullAllowed
     private String tenantId;
 

--- a/src/main/java/sirius/biz/analytics/events/UserData.java
+++ b/src/main/java/sirius/biz/analytics/events/UserData.java
@@ -27,7 +27,6 @@ public class UserData extends Composite {
      * Stores the ID of the current user.
      */
     public static final Mapping USER_ID = Mapping.named("userId");
-    @Length(255)
     @NullAllowed
     private String userId;
 
@@ -35,7 +34,6 @@ public class UserData extends Composite {
      * Stores the ID of the current tenant.
      */
     public static final Mapping TENANT_ID = Mapping.named("tenantId");
-    @Length(255)
     @NullAllowed
     private String tenantId;
 


### PR DESCRIPTION
This reverts commit 6cdf803d

As the user_id for users created by MongoTenantUserManager has a length of 43 this composite did not work.
This composite should provide a more loose length for ids and not restrict it as its has no connection to a specific UserManager Implementation and therefore should handle a variety of sensible lengths for ids.