### PR TITLE
Defines a default Index including  the tenant and searchPrefixes

### DIFF
--- a/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 
 /**
  * Maintains a <tt>prefixSearchField</tt> in which all fields annotated with {@link PrefixSearchContent} are indexed.
- *
+ * <p>
  * Note that the <tt>searchPrefixes</tt> is not automatically indexed as it usually only makes sense if indexed
  * in combination with other field(s). Therefore make sure to include this field when extending this class into
  * other {@link MongoEntity entities} where applicable. {@link sirius.biz.tenants.mongo.MongoTenantAware} is a good

--- a/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
@@ -29,8 +29,12 @@ import java.util.regex.Pattern;
 
 /**
  * Maintains a <tt>prefixSearchField</tt> in which all fields annotated with {@link PrefixSearchContent} are indexed.
+ *
+ * Note that the <tt>searchPrefixes</tt> is not automatically indexed as it usually only make sense if indexed
+ * in combination with other field(s). Therefore make sure to include this field when extending this class into
+ * other {@link MongoEntity entities} where applicable. {@link sirius.biz.tenants.mongo.MongoTenantAware} is a good
+ * example.
  */
-@Index(name = "prefix_index", columns = "searchPrefixes", columnSettings = Mango.INDEX_ASCENDING)
 public abstract class PrefixSearchableEntity extends MongoEntity {
 
     /**

--- a/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 /**
  * Maintains a <tt>prefixSearchField</tt> in which all fields annotated with {@link PrefixSearchContent} are indexed.
  *
- * Note that the <tt>searchPrefixes</tt> is not automatically indexed as it usually only make sense if indexed
+ * Note that the <tt>searchPrefixes</tt> is not automatically indexed as it usually only makes sense if indexed
  * in combination with other field(s). Therefore make sure to include this field when extending this class into
  * other {@link MongoEntity entities} where applicable. {@link sirius.biz.tenants.mongo.MongoTenantAware} is a good
  * example.

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
@@ -16,9 +16,11 @@ import sirius.biz.tenants.Tenants;
 import sirius.biz.web.Autoloaded;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.BeforeSave;
+import sirius.db.mixing.annotations.Index;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.annotations.TranslationSource;
+import sirius.db.mongo.Mango;
 import sirius.db.mongo.types.MongoRef;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Framework;
@@ -32,6 +34,7 @@ import java.util.TreeSet;
  */
 @Framework(MongoTenants.FRAMEWORK_TENANTS_MONGO)
 @TranslationSource(Tenant.class)
+@Index(name = "index_prefixes", columns = "searchPrefixes", columnSettings = Mango.INDEX_ASCENDING)
 public class MongoTenant extends MongoBizEntity implements Tenant<String> {
 
     /**

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantAware.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantAware.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  * <p>
  * Note that an index is automatically created containing the tenant itself and the searchPrefixes,
  * which are added via {@link MongoBizEntity}. You can skip the index creation by defining an {@link Index}
- * without columns.
+ * with the same name and without columns.
  */
 @Index(name = "index_tenant_prefixes",
         columns = {"tenant", "searchPrefixes"},

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantAware.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantAware.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * which are added via {@link MongoBizEntity}. You can skip the index creation by defining an {@link Index}
  * without columns.
  */
-@Index(name = "tenant_searchPrefixes",
+@Index(name = "index_tenant_prefixes",
         columns = {"tenant", "searchPrefixes"},
         columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
 public abstract class MongoTenantAware extends MongoBizEntity implements TenantAware {

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantAware.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantAware.java
@@ -11,6 +11,8 @@ package sirius.biz.tenants.mongo;
 import sirius.biz.mongo.MongoBizEntity;
 import sirius.biz.tenants.Tenant;
 import sirius.biz.web.TenantAware;
+import sirius.db.mixing.annotations.Index;
+import sirius.db.mongo.Mango;
 import sirius.db.mongo.types.MongoRef;
 import sirius.kernel.di.std.Part;
 
@@ -18,7 +20,14 @@ import java.util.Optional;
 
 /**
  * Base class which marks subclasses as aware of their tenant they belong to.
+ * <p>
+ * Note that an index is automatically created containing the tenant itself and the searchPrefixes,
+ * which are added via {@link MongoBizEntity}. You can skip the index creation by defining an {@link Index}
+ * without columns.
  */
+@Index(name = "tenant_searchPrefixes",
+        columns = {"tenant", "searchPrefixes"},
+        columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
 public abstract class MongoTenantAware extends MongoBizEntity implements TenantAware {
 
     @Part

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
         columnSettings = Mango.INDEX_ASCENDING,
         unique = true)
 @TranslationSource(UserAccount.class)
+@Index(name = "index_prefixes", columns = "searchPrefixes", columnSettings = Mango.INDEX_ASCENDING)
 public class MongoUserAccount extends MongoTenantAware implements UserAccount<String, MongoTenant> {
 
     public static final Mapping USER_ACCOUNT_DATA = Mapping.named("userAccountData");


### PR DESCRIPTION
Which will be created for all MongoTenantAware entities.

⚠️ **MongoTenantAware entities must be checked for indexes including tenant and either dropped (to be recreated by this class) or have the creation suppressed by defining an index without columns.**

Fixes: SIRI-184