### PR TITLE
Properly persists indicators

### DIFF
--- a/src/main/java/sirius/biz/analytics/indicators/IndicatorData.java
+++ b/src/main/java/sirius/biz/analytics/indicators/IndicatorData.java
@@ -14,6 +14,7 @@ import sirius.db.mixing.Composite;
 import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
+import sirius.db.mixing.types.StringList;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.di.PartCollection;
 import sirius.kernel.di.std.Parts;
@@ -21,8 +22,6 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -37,7 +36,7 @@ public class IndicatorData extends Composite {
     protected BaseEntity<?> owner;
 
     @NoJournal
-    private final List<String> indications = new ArrayList<>();
+    private final StringList indications = new StringList();
 
     @NoJournal
     @NullAllowed
@@ -62,7 +61,7 @@ public class IndicatorData extends Composite {
     @SuppressWarnings("squid:S2250")
     @Explain("There should only be some indicators present, so there is no performance hotspot expected.")
     public boolean updateIndication(String indicator, boolean newState) {
-        return newState ? indications.add(indicator) : indications.remove(indicator);
+        return newState ? indications.modify().add(indicator) : indications.modify().remove(indicator);
     }
 
     @BeforeSave
@@ -90,7 +89,7 @@ public class IndicatorData extends Composite {
      * @return a list of all indications being present
      */
     public List<String> getIndications() {
-        return Collections.unmodifiableList(indications);
+        return indications.original();
     }
 
     /**

--- a/src/test/java/sirius/biz/analytics/indicators/CheckValueIndicator.java
+++ b/src/test/java/sirius/biz/analytics/indicators/CheckValueIndicator.java
@@ -1,0 +1,34 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.analytics.indicators;
+
+import sirius.kernel.di.std.Register;
+
+@Register(classes = Indicator.class)
+public class CheckValueIndicator implements Indicator<IndicatorTestEntity> {
+    @Override
+    public Class<IndicatorTestEntity> getType() {
+        return IndicatorTestEntity.class;
+    }
+
+    @Override
+    public boolean isBatch() {
+        return false;
+    }
+
+    @Override
+    public boolean executeFor(IndicatorTestEntity entity) {
+        return "foo".equals(entity.getValue());
+    }
+
+    @Override
+    public String getName() {
+        return "checkvalue";
+    }
+}

--- a/src/test/java/sirius/biz/analytics/indicators/IndicatorSpec.groovy
+++ b/src/test/java/sirius/biz/analytics/indicators/IndicatorSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.analytics.indicators
+
+import sirius.db.mongo.Mango
+import sirius.kernel.BaseSpecification
+import sirius.kernel.di.std.Part
+
+class IndicatorSpec extends BaseSpecification {
+
+    @Part
+    private static Mango mango
+
+    def "execute non-batch indicator"() {
+        given:
+        IndicatorTestEntity entity = new IndicatorTestEntity()
+
+        when:
+        entity.setValue("foo")
+        mango.update(entity)
+
+        then:
+        entity.getIndicators().getIndications().contains("checkvalue")
+
+        when:
+        entity.setValue("bar")
+        mango.update(entity)
+
+        then:
+        entity.getIndicators().getIndications().size() == 0
+    }
+}

--- a/src/test/java/sirius/biz/analytics/indicators/IndicatorTestEntity.java
+++ b/src/test/java/sirius/biz/analytics/indicators/IndicatorTestEntity.java
@@ -13,11 +13,11 @@ import sirius.db.mongo.MongoEntity;
 public class IndicatorTestEntity extends MongoEntity implements IndicatedEntity {
 
     private String value;
-    private final IndicatorData indicatorData = new IndicatorData(this);
+    private final IndicatorData indicators = new IndicatorData(this);
 
     @Override
     public IndicatorData getIndicators() {
-        return this.indicatorData;
+        return this.indicators;
     }
 
     public String getValue() {

--- a/src/test/java/sirius/biz/analytics/indicators/IndicatorTestEntity.java
+++ b/src/test/java/sirius/biz/analytics/indicators/IndicatorTestEntity.java
@@ -1,0 +1,30 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.analytics.indicators;
+
+import sirius.db.mongo.MongoEntity;
+
+public class IndicatorTestEntity extends MongoEntity implements IndicatedEntity {
+
+    private String value;
+    private final IndicatorData indicatorData = new IndicatorData(this);
+
+    @Override
+    public IndicatorData getIndicators() {
+        return this.indicatorData;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
Fixes indicator composites so they can be persisted to the DB.
Also includes a simple test case to show how non-batch test cases work.