### PR TITLE
Always add the name and the label as alias

### DIFF
--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -306,9 +306,6 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
     }
 
     protected FieldDefinition expandAliases(FieldDefinition field, Extension aliases) {
-        field.addAlias(field.getName());
-        field.addAlias(field.getLabel());
-
         if (aliases != null && aliases.getConfig().hasPath(field.getName())) {
             aliases.getStringList(field.getName()).forEach(alias -> {
                 if (Sirius.isDev() && field.getAliases().contains(alias)) {

--- a/src/main/java/sirius/biz/importer/format/FieldDefinition.java
+++ b/src/main/java/sirius/biz/importer/format/FieldDefinition.java
@@ -48,6 +48,8 @@ public class FieldDefinition {
     public FieldDefinition(String name, String type) {
         this.name = name;
         this.type = type;
+
+        addAlias(getName());
     }
 
     /**
@@ -227,8 +229,7 @@ public class FieldDefinition {
      * @return the field itself for fluent method calls
      */
     public FieldDefinition withLabel(String constantLabel) {
-        this.label = () -> NLS.smartGet(constantLabel);
-        return this;
+        return withLabel(() -> NLS.smartGet(constantLabel));
     }
 
     /**
@@ -239,6 +240,7 @@ public class FieldDefinition {
      */
     public FieldDefinition withLabel(Supplier<String> labelFunction) {
         this.label = labelFunction;
+        addAlias(getLabel());
         return this;
     }
 


### PR DESCRIPTION
We tried to fix this issue in SIRI-136 but we provided the fix only for autoImported fields.
This solution will also work if the FieldDefinition is added manually, e.g. if it was added by an overridden method
of EntityImportJobFactory#enhanceDictionary

This will prevent us from writing code looking like:
`dictionary.addField(FieldDefinition.stringField(FIELD_NAME, 1).addAlias(FIELD_NAME);`

- Fixes: SE-9397