### PR TITLE
Fix FTP Filetype and Upload bug

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/fs/LocalDirectoryUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/fs/LocalDirectoryUplink.java
@@ -101,7 +101,6 @@ public class LocalDirectoryUplink extends ConfigBasedUplink {
               .withInputStreamSupplier(this::inputStreamSupplier)
               .withCanProvideFileHandle(this::isExistingFile)
               .withFileHandleSupplier(this::fileHandleSupplier)
-              .withCanProvideOutputStream(this::isExistingFile)
               .withOutputStreamSupplier(this::outputStreamSupplier)
               .withRenameHandler(this::renameHandler)
               .withCreateDirectoryHandler(this::createDirectoryHandler)

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
@@ -186,7 +186,6 @@ public class FTPUplink extends ConfigBasedUplink {
               .withDeleteHandler(this::deleteHandler)
               .withCanProvideInputStream(this::isExistingFile)
               .withInputStreamSupplier(this::inputStreamSupplier)
-              .withCanProvideOutputStream(this::isExistingFile)
               .withOutputStreamSupplier(this::outputStreamSupplier)
               .withRenameHandler(this::renameHandler)
               .withCreateDirectoryHandler(this::createDirectoryHandler)

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.storage.layer3.uplink.ftp;
 
+import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import sirius.biz.storage.layer3.uplink.util.UplinkConnectorConfig;
 import sirius.biz.storage.util.StorageUtils;
@@ -42,6 +43,7 @@ class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {
             client.setDefaultTimeout(readTimeoutMillis);
             client.connect(host, port);
             client.login(user, password);
+            client.setFileType(FTP.BINARY_FILE_TYPE);
             client.enterLocalPassiveMode();
 
             return client;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplink.java
@@ -135,7 +135,6 @@ public class SFTPUplink extends ConfigBasedUplink {
               .withDeleteHandler(this::deleteHandler)
               .withCanProvideInputStream(this::isExistingFile)
               .withInputStreamSupplier(this::inputStreamSupplier)
-              .withCanProvideOutputStream(this::isExistingFile)
               .withOutputStreamSupplier(this::outputStreamSupplier)
               .withRenameHandler(this::renameHandler)
               .withCreateDirectoryHandler(this::createDirectoryHandler)


### PR DESCRIPTION
Remove local file exists check when creating OutputStreams for S/FTP
Set FTP FileType to Binary instead of default ASCII

Fixes: SIRI-194