### PR TITLE
Doesn't update TraceData fields when running a resave job.

### DIFF
--- a/src/main/java/sirius/biz/model/ResaveEntitiesJobFactory.java
+++ b/src/main/java/sirius/biz/model/ResaveEntitiesJobFactory.java
@@ -18,6 +18,8 @@ import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.PersistencePeriod;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.logs.ProcessLog;
+import sirius.biz.protocol.Journaled;
+import sirius.biz.protocol.Traced;
 import sirius.biz.tenants.TenantUserManager;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.EntityDescriptor;
@@ -92,6 +94,15 @@ public class ResaveEntitiesJobFactory extends DefaultBatchProcessFactory {
             Watch watch = Watch.start();
             try {
                 if (executeSave) {
+                    // We do not want to update the tracing infos here as we most probably don't change anything.
+                    //
+                    // We do not suppress the Journal (if there is any) because we do not
+                    // expect any journalled changes. If there still are any, we have to log them
+                    // for traceability reasons.
+                    if (entity instanceof Traced) {
+                        ((Traced) entity).getTrace().setSilent(true);
+                    }
+
                     descriptor.getMapper().update(entity);
                 }
                 if (performValidation) {


### PR DESCRIPTION
Most commonly one doesn't want to change the data in these fields,
as the job is mainly intended to be used for checks rather than for
real updates.