### PR TITLE
Fixes to Indicators

### DIFF
--- a/src/main/java/sirius/biz/analytics/indicators/IndicatorData.java
+++ b/src/main/java/sirius/biz/analytics/indicators/IndicatorData.java
@@ -15,7 +15,6 @@ import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.types.StringList;
-import sirius.kernel.commons.Explain;
 import sirius.kernel.di.PartCollection;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.health.Exceptions;
@@ -58,10 +57,12 @@ public class IndicatorData extends Composite {
      * @param newState  <tt>true</tt> to set the indicator, <tt>false</tt> to clear it
      * @return <tt>true</tt> if the indicator was not yet present
      */
-    @SuppressWarnings("squid:S2250")
-    @Explain("There should only be some indicators present, so there is no performance hotspot expected.")
     public boolean updateIndication(String indicator, boolean newState) {
-        return newState ? indications.modify().add(indicator) : indications.modify().remove(indicator);
+        if (newState) {
+            return !indications.contains(indicator) && indications.modify().add(indicator);
+        } else {
+            return indications.contains(indicator) && indications.modify().remove(indicator);
+        }
     }
 
     @BeforeSave

--- a/src/main/java/sirius/biz/analytics/scheduler/MongoAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/MongoAnalyticalTaskScheduler.java
@@ -65,7 +65,7 @@ public abstract class MongoAnalyticalTaskScheduler extends BaseAnalyticalTaskSch
 
     @Override
     protected boolean isMatchingEntityType(AnalyticalTask<?> task) {
-        return MongoQuery.class.isAssignableFrom(task.getType());
+        return MongoEntity.class.isAssignableFrom(task.getType());
     }
 
     @Override


### PR DESCRIPTION
Indicators could be stored more than once for an entity
Batch indicators weren't validating properly against the target entity

Fixes: OX-5734