### PR TITLE
Improves the default timeout settings for ftp/sftp uplinks.

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnectorConfig.java
@@ -12,6 +12,8 @@ import com.google.common.base.Objects;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.settings.Extension;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Provides a configuration which tells the {@link UplinkConnectorPool} how to create and maintain a
  * {@link UplinkConnector}.
@@ -22,10 +24,10 @@ public abstract class UplinkConnectorConfig<C> {
 
     private static final int DEFAULT_MAX_IDLE = 1;
     private static final int DEFAULT_MAX_ACTIVE = 5;
-    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 10_000;
-    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 10_000;
-    private static final int DEFAULT_IDLE_TIMEOUT_MILLIS = 60_000;
-    private static final int DEFAULT_MAX_WAIT_MILLIS = 10_000;
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = (int) TimeUnit.SECONDS.toMillis(10);
+    private static final int DEFAULT_READ_TIMEOUT_MILLIS = (int) TimeUnit.SECONDS.toMillis(10);
+    private static final int DEFAULT_IDLE_TIMEOUT_MILLIS = (int) TimeUnit.MINUTES.toMillis(10);
+    private static final int DEFAULT_MAX_WAIT_MILLIS = (int) TimeUnit.SECONDS.toMillis(10);
 
     protected String label;
     protected String host;

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -795,8 +795,8 @@ storage {
             #    # readTimeoutMillis = 10000
             #
             #    # Specifies the idle timeout in milliseconds. This is the maximal duration for with an unused
-            #    # connection is kept open. (Default is 60000)
-            #    # idleTimeoutMillis = 60000
+            #    # connection is kept open. (Default is 600_000 = 600s = 10 min)
+            #    # idleTimeoutMillis = 600000
             #
             #    # Specifies the wait time in milliseconds. If the connection pool is exhaused, the is the maximal
             #    # duration we wait for a connection to become available. (Default is 10000)
@@ -845,8 +845,8 @@ storage {
             #    # readTimeoutMillis = 10000
             #
             #    # Specifies the idle timeout in milliseconds. This is the maximal duration for with an unused
-            #    # connection is kept open. (Default is 60000)
-            #    # idleTimeoutMillis = 60000
+            #    # connection is kept open. (Default is 600_000 = 600s = 10 min)
+            #    # idleTimeoutMillis = 600000
             #
             #    # Specifies the wait time in milliseconds. If the connection pool is exhaused, the is the maximal
             #    # duration we wait for a connection to become available. (Default is 10000)


### PR DESCRIPTION
By default we chose quite a low idle timeout which seems to be
in conflict with the keepalive implementation in the apache ssh client.

We now use the default idle timeout of 10m, which is still a reasonable value.