### PR TITLE
Optimizes journal entries in import jobs.

### DIFF
--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -11,6 +11,7 @@ package sirius.biz.importer;
 import sirius.biz.importer.format.FieldDefinition;
 import sirius.biz.importer.format.FieldDefinitionSupplier;
 import sirius.biz.importer.format.ImportDictionary;
+import sirius.biz.protocol.Journaled;
 import sirius.biz.web.TenantAware;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.EntityDescriptor;
@@ -196,6 +197,10 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
         if (entity instanceof TenantAware) {
             ((TenantAware) entity).setOrVerifyCurrentTenant();
         }
+
+        if (entity instanceof Journaled) {
+            ((Journaled) entity).getJournal().enableBatchLog();
+        }
     }
 
     /**
@@ -209,9 +214,8 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
      * @param entity the entity to check
      */
     protected void enforcePreDeleteConstraints(E entity) {
-        if (entity instanceof TenantAware) {
-            ((TenantAware) entity).setOrVerifyCurrentTenant();
-        }
+        // By default the constraints are the same as when the entity is saved...
+        enforcePreSaveConstraints(entity);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Under heavy load, updating the journal becomes quite an overhead.
Therefore this change permits to enable batch inserts of journal entries,
if requested.

By default the BaseImportHandler will enable this when updating or
deleting Journaled entities.