### PR TITLE
Force updating search prefixes on entity resave job

### DIFF
--- a/src/main/java/sirius/biz/model/ResaveEntitiesJobFactory.java
+++ b/src/main/java/sirius/biz/model/ResaveEntitiesJobFactory.java
@@ -14,6 +14,7 @@ import sirius.biz.jobs.batch.DefaultBatchProcessFactory;
 import sirius.biz.jobs.params.BooleanParameter;
 import sirius.biz.jobs.params.EntityDescriptorParameter;
 import sirius.biz.jobs.params.Parameter;
+import sirius.biz.mongo.PrefixSearchableEntity;
 import sirius.biz.process.PersistencePeriod;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.logs.ProcessLog;
@@ -105,6 +106,10 @@ public class ResaveEntitiesJobFactory extends DefaultBatchProcessFactory {
                     // for traceability reasons.
                     if (entity instanceof Traced) {
                         ((Traced) entity).getTrace().setSilent(true);
+                    }
+
+                    if (entity instanceof PrefixSearchableEntity) {
+                        ((PrefixSearchableEntity) entity).forceUpdateOfSearchPrefixes();
                     }
 
                     descriptor.getMapper().update(entity);


### PR DESCRIPTION
Otherwise we cannot use this job to rebuild the search prefixes since a single update might not change any field and therefore skip the computation when not forced.