### PR TITLE
Adds non-null getters to PermissionData and TenantData for the config

### DIFF
--- a/src/main/java/sirius/biz/model/PermissionData.java
+++ b/src/main/java/sirius/biz/model/PermissionData.java
@@ -179,19 +179,17 @@ public class PermissionData extends Composite {
     /**
      * Returns the parsed settings for the associated entity
      *
-     * @param strict determines if the config is strict. A strict config will log an error if an unkown path is
-     *               requested
      * @return the parsed configuration
      */
     @Nonnull
-    public Settings getSettings(boolean strict) {
+    public Settings getSettings() {
         Config config = getConfig();
 
         if (config != null) {
-            return new Settings(config, strict);
+            return new Settings(config, false);
         }
 
-        return new Settings(ConfigFactory.empty(), strict);
+        return new Settings(ConfigFactory.empty(), false);
     }
 
     /**

--- a/src/main/java/sirius/biz/model/PermissionData.java
+++ b/src/main/java/sirius/biz/model/PermissionData.java
@@ -24,6 +24,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Exceptions;
 import sirius.web.security.Permissions;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
@@ -149,7 +150,7 @@ public class PermissionData extends Composite {
     /**
      * Returns the parsed config for the associated entity.
      *
-     * @return the parsed configuration
+     * @return the parsed configuration, or <tt>null</tt> if the config is empty
      */
     @Nullable
     public Config getConfig() {
@@ -172,6 +173,22 @@ public class PermissionData extends Composite {
         }
 
         return config;
+    }
+
+    /**
+     * Returns the parsed config for the associated entity
+     *
+     * @return the parsed configuration
+     */
+    @Nonnull
+    public Config getSafeConfig() {
+        Config config = getConfig();
+
+        if (config != null) {
+            return config;
+        }
+
+        return ConfigFactory.empty();
     }
 
     /**

--- a/src/main/java/sirius/biz/model/PermissionData.java
+++ b/src/main/java/sirius/biz/model/PermissionData.java
@@ -22,6 +22,7 @@ import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.types.StringList;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Exceptions;
+import sirius.kernel.settings.Settings;
 import sirius.web.security.Permissions;
 
 import javax.annotation.Nonnull;
@@ -176,19 +177,21 @@ public class PermissionData extends Composite {
     }
 
     /**
-     * Returns the parsed config for the associated entity
+     * Returns the parsed settings for the associated entity
      *
+     * @param strict determines if the config is strict. A strict config will log an error if an unkown path is
+     *               requested
      * @return the parsed configuration
      */
     @Nonnull
-    public Config getSafeConfig() {
+    public Settings getSettings(boolean strict) {
         Config config = getConfig();
 
         if (config != null) {
-            return config;
+            return new Settings(config, strict);
         }
 
-        return ConfigFactory.empty();
+        return new Settings(ConfigFactory.empty(), strict);
     }
 
     /**

--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -34,6 +34,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
+import sirius.kernel.settings.Settings;
 import sirius.web.http.IPRange;
 import sirius.web.http.WebContext;
 
@@ -390,19 +391,21 @@ public class TenantData extends Composite implements Journaled {
     }
 
     /**
-     * Returns the parsed config for the tenant
+     * Returns the parsed settings for the tenant
      *
+     * @param strict determines if the config is strict. A strict config will log an error if an unkown path is
+     *               requested
      * @return the parsed configuration
      */
     @Nonnull
-    public Config getSafeConfig() {
+    public Settings getSettings(boolean strict) {
         Config config = getConfig();
 
         if (config != null) {
-            return config;
+            return new Settings(config, strict);
         }
 
-        return ConfigFactory.empty();
+        return new Settings(ConfigFactory.empty(), strict);
     }
 
     /**

--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -393,19 +393,17 @@ public class TenantData extends Composite implements Journaled {
     /**
      * Returns the parsed settings for the tenant
      *
-     * @param strict determines if the config is strict. A strict config will log an error if an unkown path is
-     *               requested
      * @return the parsed configuration
      */
     @Nonnull
-    public Settings getSettings(boolean strict) {
+    public Settings getSettings() {
         Config config = getConfig();
 
         if (config != null) {
-            return new Settings(config, strict);
+            return new Settings(config, false);
         }
 
-        return new Settings(ConfigFactory.empty(), strict);
+        return new Settings(ConfigFactory.empty(), false);
     }
 
     /**

--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -37,6 +37,7 @@ import sirius.kernel.nls.NLS;
 import sirius.web.http.IPRange;
 import sirius.web.http.WebContext;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Set;
@@ -363,7 +364,7 @@ public class TenantData extends Composite implements Journaled {
     /**
      * Returns the parsed config for the tenant.
      *
-     * @return the parsed configuration
+     * @return the parsed configuration, or <tt>null</tt> if the config is empty
      */
     @Nullable
     public Config getConfig() {
@@ -386,6 +387,22 @@ public class TenantData extends Composite implements Journaled {
         }
 
         return config;
+    }
+
+    /**
+     * Returns the parsed config for the tenant
+     *
+     * @return the parsed configuration
+     */
+    @Nonnull
+    public Config getSafeConfig() {
+        Config config = getConfig();
+
+        if (config != null) {
+            return config;
+        }
+
+        return ConfigFactory.empty();
     }
 
     /**

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -722,11 +722,11 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
     @Override
     protected UserSettings getUserSettings(UserSettings scopeSettings, UserInfo userInfo) {
         U user = userInfo.getUserObject(getUserClass());
-        Config userAccountConfig = user.getUserAccountData().getPermissions().getSafeConfig();
-        Config tenantConfig = user.getTenant().fetchValue().getTenantData().getSafeConfig();
+        Config userAccountConfig = user.getUserAccountData().getPermissions().getConfig();
+        Config tenantConfig = user.getTenant().fetchValue().getTenantData().getConfig();
 
-        if (userAccountConfig.isEmpty()) {
-            if (tenantConfig.isEmpty()) {
+        if (userAccountConfig == null) {
+            if (tenantConfig == null) {
                 return scopeSettings;
             }
 

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -722,22 +722,25 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
     @Override
     protected UserSettings getUserSettings(UserSettings scopeSettings, UserInfo userInfo) {
         U user = userInfo.getUserObject(getUserClass());
-        if (user.getUserAccountData().getPermissions().getConfig() == null) {
-            if (user.getTenant().fetchValue().getTenantData().getConfig() == null) {
+        Config userAccountConfig = user.getUserAccountData().getPermissions().getSafeConfig();
+        Config tenantConfig = user.getTenant().fetchValue().getTenantData().getSafeConfig();
+
+        if (userAccountConfig.isEmpty()) {
+            if (tenantConfig.isEmpty()) {
                 return scopeSettings;
             }
 
             return configCache.get(user.getTenant().getUniqueObjectName(), i -> {
                 Config cfg = scopeSettings.getConfig();
-                cfg = user.getTenant().fetchValue().getTenantData().getConfig().withFallback(cfg);
+                cfg = tenantConfig.withFallback(cfg);
                 return Tuple.create(new UserSettings(cfg, false), user.getTenant().getUniqueObjectName());
             }).getFirst();
         }
 
         return configCache.get(user.getUniqueName(), i -> {
             Config cfg = scopeSettings.getConfig();
-            cfg = user.getTenant().fetchValue().getTenantData().getConfig().withFallback(cfg);
-            cfg = user.getUserAccountData().getPermissions().getConfig().withFallback(cfg);
+            cfg = tenantConfig.withFallback(cfg);
+            cfg = userAccountConfig.withFallback(cfg);
             return Tuple.create(new UserSettings(cfg, false), user.getTenant().getUniqueObjectName());
         }).getFirst();
     }


### PR DESCRIPTION
The use of getConfig always requires a null-check. This is quite cumbersome and easily forgotten. This adds a second getter that will return an empty config instead.