### PR TITLE
Fix an issue creating files in the storage

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -377,8 +377,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         Blob blob = blobByPathCache.get(key);
         if (blob == null) {
             blobByPathCache.remove(key);
-            blob = blobByPathCache.get(determinePathCacheKey(tenantId, path),
-                                       ignored -> fetchOrCreateByPath(tenantId, path));
+            blob = blobByPathCache.get(key, ignored -> fetchOrCreateByPath(tenantId, path));
         }
         return blob;
     }

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -373,8 +373,14 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             throw new IllegalArgumentException("An empty path was provided!");
         }
 
-        return blobByPathCache.get(determinePathCacheKey(tenantId, path),
-                                   ignored -> fetchOrCreateByPath(tenantId, path));
+        String key = determinePathCacheKey(tenantId, path);
+        Blob blob = blobByPathCache.get(key);
+        if (blob == null) {
+            blobByPathCache.remove(key);
+            blob = blobByPathCache.get(determinePathCacheKey(tenantId, path),
+                                       ignored -> fetchOrCreateByPath(tenantId, path));
+        }
+        return blob;
     }
 
     protected Blob fetchOrCreateByPath(String tenantId, @Nonnull String path) {


### PR DESCRIPTION
The `findOrCreateByPath` method was skipping the file creation if a previous find was issued which did not find any file (leaving the cache with `null` for the desired key).

This caused subsequent calls to the cache to deliver null instead of try calling the ValueComputer in order to create a new file.

Fixes: OX-5973