### PR TITLE
Returns the raw object instead of cache contents

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -377,7 +377,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         Blob blob = blobByPathCache.get(key);
         if (blob == null) {
             blobByPathCache.remove(key);
-            blob = blobByPathCache.get(key, ignored -> fetchOrCreateByPath(tenantId, path));
+            blob = fetchOrCreateByPath(tenantId, path);
         }
         return blob;
     }


### PR DESCRIPTION
Removing from the coherent cache does not mean that it's deleted right away.

Fixes: OX-5973