### PR TITLE
Delivers downloads not cached

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -1188,7 +1188,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                 return;
             }
 
-            tunnelHandler.accept(this, webContext.respondWith().download(name()));
+            tunnelHandler.accept(this, webContext.respondWith().download(name()).notCached());
         } catch (Exception e) {
             webContext.respondWith()
                       .error(HttpResponseStatus.INTERNAL_SERVER_ERROR, handleErrorInCallback(e, "tunnelHandler"));
@@ -1207,7 +1207,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                 return;
             }
 
-            tunnelHandler.accept(this, webContext.respondWith().named(name()));
+            tunnelHandler.accept(this, webContext.respondWith().named(name()).notCached());
         } catch (Exception e) {
             webContext.respondWith()
                       .error(HttpResponseStatus.INTERNAL_SERVER_ERROR, handleErrorInCallback(e, "tunnelHandler"));


### PR DESCRIPTION
Paths were being delivered from the web-server's cache. This caused the effect that updated blob contents weren't being transmitted in the response.

Another nasty effect was to deliver contents belonging to other tenants if a similar path were found in the cache.