### PR TITLE
BREAKING: Only loads fields from requests when matching param is given

### DIFF
--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -254,7 +254,7 @@ public class BizController extends BasicController {
         for (Mapping columnProperty : properties) {
             Property property = entity.getDescriptor().getProperty(columnProperty);
 
-            if (tryLoadProperty(webContext, entity, property)) {
+            if (!tryLoadProperty(webContext, entity, property)) {
                 hasError = true;
             }
         }
@@ -270,7 +270,7 @@ public class BizController extends BasicController {
         Value parameterValue = webContext.get(propertyName);
         if (parameterValue.isNull()) {
             // If the parameter is not present in the request we just skip it to prevent resetting the field to null
-            return false;
+            return true;
         }
 
         try {
@@ -281,9 +281,9 @@ public class BizController extends BasicController {
         } catch (HandledException exception) {
             UserContext.setFieldError(propertyName, parameterValue);
             UserContext.setErrorMessage(propertyName, exception.getMessage());
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
     private void ensureTenantMatch(BaseEntity<?> entity, Property property) {

--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -255,9 +255,9 @@ public class BizController extends BasicController {
             Property property = entity.getDescriptor().getProperty(columnProperty);
             String propertyName = property.getName();
 
-            // If the parameter is not present in the request we just skip it to prevent resetting the field to null
             final Value parameterValue = webContext.get(propertyName);
             if (parameterValue.isNull()) {
+                // If the parameter is not present in the request we just skip it to prevent resetting the field to null
                 continue;
             }
 


### PR DESCRIPTION
We dont want to reset a field to null when no parameter is given in the request that matches the field.
We also use `get` instead of `getParameters` here as it takes the `WebContext::attributes` into account which allows to semi-inject parameters before loading (e.g. for providing a default value when no parameter is given).

Fixes: OX-6055