### PR TITLE
Fixes file name in FileImportJob

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/FileImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/FileImportJob.java
@@ -52,7 +52,7 @@ public abstract class FileImportJob extends ImportJob {
         if (canHandleFileExtension(Value.of(file.fileExtension()).toLowerCase())) {
             try (FileHandle fileHandle = file.download()) {
                 backupInputFile(file.name(), fileHandle);
-                executeForSingleFile(fileHandle);
+                executeForSingleFile(file.name(), fileHandle);
             }
         } else if (FILE_EXTENSION_ZIP.equalsIgnoreCase(file.fileExtension())) {
             try (FileHandle fileHandle = file.download()) {
@@ -76,9 +76,9 @@ public abstract class FileImportJob extends ImportJob {
         attachFile(filename, input);
     }
 
-    protected void executeForSingleFile(FileHandle fileHandle) throws Exception {
+    protected void executeForSingleFile(String fileName, FileHandle fileHandle) throws Exception {
         try (InputStream in = fileHandle.getInputStream()) {
-            executeForStream(fileHandle.getFile().getName(), in);
+            executeForStream(fileName, in);
         }
     }
 


### PR DESCRIPTION
LineBasedProcessor for instance needs to know the actual file extension, but the file referenced by the filehandle is a temporary file with ".tmp" as extension.