### PR TITLE
Exposes the CSVWriter in ExportCSV

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/ExportCSV.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ExportCSV.java
@@ -45,4 +45,8 @@ public class ExportCSV implements LineBasedExport {
     public void close() throws IOException {
         writer.close();
     }
+
+    public CSVWriter getWriter() {
+        return writer;
+    }
 }


### PR DESCRIPTION
So export jobs have access to define things like separator, quotation etc.

Fixes: OX-6169