### PR TITLE
Improves roles setup for user / tenant management...

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/VirtualFileExtractionJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/VirtualFileExtractionJob.java
@@ -49,9 +49,6 @@ public class VirtualFileExtractionJob extends SimpleBatchProcessJobFactory {
     @Part
     private VirtualFileSystem vfs;
 
-    @Part
-    private ArchiveHelper archiveHelper;
-
     private static final FileParameter SOURCE_PARAMETER = new FileParameter("sourceParameter",
                                                                             "$VirtualFileExtractionJob.sourceParameter")
             .withAcceptedExtensionsList(ArchiveHelper.getSupportedFileExtensions())

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -81,7 +81,7 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
     /**
      * This flag permission is granted to <b>all users</b> which belong to the system tenant.
      * <p>
-     * The id of the system tenant can be set in the scope config. The system tenant usually is the administrative
+     * The id of the system tenant can be set in the system config. The system tenant usually is the administrative
      * company which owns / runs the system, this flag is kept when the user has taken control over another tenant,
      * but is removed if the user has taken control over another user directly.
      */
@@ -90,7 +90,7 @@ public abstract class TenantUserManager<I, T extends BaseEntity<I> & Tenant<I>, 
     /**
      * This flag permission is granted to <b>all users</b> which originally belong to the system tenant.
      * <p>
-     * The id of the system tenant can be set in the scope config. The system tenant usually is the administrative
+     * The id of the system tenant can be set in the system config. The system tenant usually is the administrative
      * company which owns / runs the system.
      * Unlike {@link #PERMISSION_SYSTEM_TENANT_MEMBER}, this flag is kept always,
      * even when the user either has taken control over another tenant or user account.

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -635,7 +635,7 @@ public abstract class UserAccountController<I, T extends BaseEntity<I> & Tenant<
         }
 
         // If the target user belongs to the system tenant, our current user has to have highest user management
-        // permission as otherwise we would perform an unwanted roles delegation (given the current user higher
+        // permission as otherwise we would perform an unwanted roles delegation (giving the current user higher
         // access rights - right up to the system management level...)
         if (Strings.areEqual(tenants.getTenantUserManager().getSystemTenantId(), user.getTenant().getIdAsString())
             && !getUser().hasPermission(PERMISSION_MANAGE_SYSTEM_USERS)) {

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -633,6 +633,15 @@ public abstract class UserAccountController<I, T extends BaseEntity<I> & Tenant<
             return;
         }
 
+        // If the target user belongs to the system tenant, our current user has to have highest user management
+        // permission as otherwise we would perform an unwanted roles delegation (given the current user higher
+        // access rights - right up to the system management level...)
+        if (Strings.areEqual(tenants.getTenantUserManager().getSystemTenantId(), user.getTenant().getIdAsString())
+            && !getUser().hasPermission(PERMISSION_MANAGE_SYSTEM_USERS)) {
+            UserContext.get().addMessage(Message.error(NLS.get("UserAccountController.cannotBecomeUser")));
+            selectUserAccounts(webContext);
+            return;
+        }
         if (!getUser().hasPermission(TenantUserManager.PERMISSION_SYSTEM_TENANT_AFFILIATE)) {
             assertTenant(user);
         }

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -624,6 +624,7 @@ public abstract class UserAccountController<I, T extends BaseEntity<I> & Tenant<
             return;
         }
 
+        // Check that the user is generally permitted to "select / become" another user...
         assertPermission(TenantUserManager.PERMISSION_SELECT_USER_ACCOUNT);
 
         U user = mixing.getDescriptor(getUserClass()).getMapper().find(getUserClass(), accountId).orElse(null);
@@ -642,6 +643,8 @@ public abstract class UserAccountController<I, T extends BaseEntity<I> & Tenant<
             selectUserAccounts(webContext);
             return;
         }
+
+        // If we're not part of the system tenant, ensure that we can only select users from the same tenant...
         if (!getUser().hasPermission(TenantUserManager.PERMISSION_SYSTEM_TENANT_AFFILIATE)) {
             assertTenant(user);
         }

--- a/src/main/java/sirius/biz/util/ArchiveHelper.java
+++ b/src/main/java/sirius/biz/util/ArchiveHelper.java
@@ -67,7 +67,8 @@ public class ArchiveHelper {
      * Iterates over the items of an archive file
      *
      * @param archiveFile             the archive file to extract
-     * @param filter                  will be called for each archive item. {@code unzipItemCallback} will be only called for this item if this filter unzipItemCallback returns true
+     * @param filter                  will be called for each archive item. {@code unzipItemCallback} will be only
+     *                                called for this item if this filter unzipItemCallback returns true
      * @param progressAndStopProvider will be called for each archive item until it returns false
      * @throws IOException on extraction failure
      */

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -996,7 +996,7 @@ security {
 
         # Grants the system administration and system user management permissions and flags to the role
         # "system-administrator"...
-        "system-administrator+flag-system-tenant" {
+        "system-administrator+flag-system-tenant-affiliate" {
             priority = 60
             flag-system-administrator = true
             permission-manage-system-users = true

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1029,6 +1029,11 @@ security {
             permission-select-user-account = true
         }
 
+        "user-administrator+flag-system-tenant-affiliate" {
+            permission-manage-tenants = true
+            permission-select-tenant = true
+        }
+
         administrator {
             priority = 130
             permission-select-tenant = true

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -996,7 +996,7 @@ security {
 
         # Grants the system administration and system user management permissions and flags to the role
         # "system-administrator"...
-        system-administrator {
+        "system-administrator+flag-system-tenant" {
             priority = 60
             flag-system-administrator = true
             permission-manage-system-users = true
@@ -1077,7 +1077,7 @@ security {
         # permissions which have no requirements can be omitted
         # have to be key-value pairs, in which the key is the permission in question and the value is the required permission
         required-permissions-for-permission {
-
+            system-administrator : "flag-system-tenant"
         }
     }
 }


### PR DESCRIPTION
* A user of the system tenant, which is permitted to manage users can now also manage and switch tenants.
* Only users of the system tenant can be granted the role "system-administrator" - granting this to non-system-tenants is now rejected on two levels to preven any mis-use / mis-configuration of systems
* A user cannot become/select a fellow user of the system tenant unless the role PERMISSION_MANAGE_SYSTEM_USERS is granted to prevent an unwanted privilege escalation.
