### PR TITLE
Fixes a NPE trying to close a never opened stream

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveExportJob.java
@@ -63,7 +63,9 @@ public abstract class ArchiveExportJob extends FileExportJob {
 
     @Override
     public void close() throws IOException {
-        zipOutputStream.close();
+        if (zipOutputStream != null) {
+            zipOutputStream.close();
+        }
         super.close();
     }
 


### PR DESCRIPTION
Scenario is a non archive export job such as .xlsx, which is aborted due to export errors thus having no export file to pack in a zip archive.

Fixes: OX-6189