### PR TITLE
Fixes backend search for Mongo codelists + codelist entries

### DIFF
--- a/src/main/java/sirius/biz/codelists/CodeListController.java
+++ b/src/main/java/sirius/biz/codelists/CodeListController.java
@@ -59,7 +59,7 @@ public abstract class CodeListController<I, L extends BaseEntity<I> & CodeList, 
     public void codeLists(WebContext ctx) {
         BasePageHelper<L, ?, ?, ?> pageHelper = getListsAsPage();
         pageHelper.withContext(ctx);
-        setCodeListSearchFields(pageHelper);
+        applyCodeListSearchFields(pageHelper);
         ctx.respondWith().template("/templates/biz/codelists/code-lists.html.pasta", pageHelper.asPage());
     }
 
@@ -108,15 +108,15 @@ public abstract class CodeListController<I, L extends BaseEntity<I> & CodeList, 
     private void renderCodeList(WebContext ctx, L codeList) {
         BasePageHelper<E, ?, ?, ?> pageHelper = getEntriesAsPage(codeList);
         pageHelper.withContext(ctx);
-        setCodeListEntrySearchFields(pageHelper);
+        applyCodeListEntrySearchFields(pageHelper);
         ctx.respondWith().template("/templates/biz/codelists/code-list-entries.html.pasta", codeList, pageHelper.asPage());
     }
 
     protected abstract BasePageHelper<E, ?, ?, ?> getEntriesAsPage(L codeList);
 
-    protected abstract void setCodeListSearchFields(BasePageHelper<L, ?, ?, ?> pageHelper);
+    protected abstract void applyCodeListSearchFields(BasePageHelper<L, ?, ?, ?> pageHelper);
 
-    protected abstract void setCodeListEntrySearchFields(BasePageHelper<E, ?, ?, ?> pageHelper);
+    protected abstract void applyCodeListEntrySearchFields(BasePageHelper<E, ?, ?, ?> pageHelper);
 
     /**
      * Provides an editor for a code list entry.

--- a/src/main/java/sirius/biz/codelists/CodeListController.java
+++ b/src/main/java/sirius/biz/codelists/CodeListController.java
@@ -11,7 +11,6 @@ package sirius.biz.codelists;
 import sirius.biz.web.BasePageHelper;
 import sirius.biz.web.BizController;
 import sirius.db.mixing.BaseEntity;
-import sirius.db.mixing.query.QueryField;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Priorized;
 import sirius.kernel.nls.Formatter;
@@ -58,13 +57,10 @@ public abstract class CodeListController<I, L extends BaseEntity<I> & CodeList, 
     @Permission(PERMISSION_MANAGE_CODELISTS)
     @Routed("/code-lists")
     public void codeLists(WebContext ctx) {
-        BasePageHelper<L, ?, ?, ?> ph = getListsAsPage();
-        ph.withContext(ctx);
-        ph.withSearchFields(QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.CODE)),
-                            QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.NAME)),
-                            QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.DESCRIPTION)));
-
-        ctx.respondWith().template("/templates/biz/codelists/code-lists.html.pasta", ph.asPage());
+        BasePageHelper<L, ?, ?, ?> pageHelper = getListsAsPage();
+        pageHelper.withContext(ctx);
+        setCodeListSearchFields(pageHelper);
+        ctx.respondWith().template("/templates/biz/codelists/code-lists.html.pasta", pageHelper.asPage());
     }
 
     protected abstract BasePageHelper<L, ?, ?, ?> getListsAsPage();
@@ -110,17 +106,17 @@ public abstract class CodeListController<I, L extends BaseEntity<I> & CodeList, 
     }
 
     private void renderCodeList(WebContext ctx, L codeList) {
-        BasePageHelper<E, ?, ?, ?> ph = getEntriesAsPage(codeList);
-        ph.withContext(ctx);
-        ph.withSearchFields(QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.CODE)),
-                            QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.VALUE)),
-                            QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.ADDITIONAL_VALUE)),
-                            QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.DESCRIPTION)));
-
-        ctx.respondWith().template("/templates/biz/codelists/code-list-entries.html.pasta", codeList, ph.asPage());
+        BasePageHelper<E, ?, ?, ?> pageHelper = getEntriesAsPage(codeList);
+        pageHelper.withContext(ctx);
+        setCodeListEntrySearchFields(pageHelper);
+        ctx.respondWith().template("/templates/biz/codelists/code-list-entries.html.pasta", codeList, pageHelper.asPage());
     }
 
     protected abstract BasePageHelper<E, ?, ?, ?> getEntriesAsPage(L codeList);
+
+    protected abstract void setCodeListSearchFields(BasePageHelper<L, ?, ?, ?> pageHelper);
+
+    protected abstract void setCodeListEntrySearchFields(BasePageHelper<E, ?, ?, ?> pageHelper);
 
     /**
      * Provides an editor for a code list entry.

--- a/src/main/java/sirius/biz/codelists/CodeListData.java
+++ b/src/main/java/sirius/biz/codelists/CodeListData.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.codelists;
 
+import sirius.biz.mongo.PrefixSearchContent;
 import sirius.biz.protocol.TraceData;
 import sirius.biz.web.Autoloaded;
 import sirius.db.mixing.BaseEntity;
@@ -44,6 +45,7 @@ public class CodeListData extends Composite {
     @Autoloaded
     @Length(50)
     @Unique(within = "tenant")
+    @PrefixSearchContent
     private String code;
 
     /**
@@ -54,6 +56,7 @@ public class CodeListData extends Composite {
     @Autoloaded
     @NullAllowed
     @Length(150)
+    @PrefixSearchContent
     private String name;
 
     /**
@@ -64,6 +67,7 @@ public class CodeListData extends Composite {
     @Autoloaded
     @NullAllowed
     @Length(1024)
+    @PrefixSearchContent
     private String description;
 
     /**

--- a/src/main/java/sirius/biz/codelists/CodeListEntryData.java
+++ b/src/main/java/sirius/biz/codelists/CodeListEntryData.java
@@ -9,6 +9,7 @@
 package sirius.biz.codelists;
 
 import sirius.biz.importer.AutoImport;
+import sirius.biz.mongo.PrefixSearchContent;
 import sirius.biz.protocol.TraceData;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.Composite;
@@ -45,6 +46,7 @@ public class CodeListEntryData extends Composite {
     @Length(50)
     @Unique(within = "codeList")
     @AutoImport
+    @PrefixSearchContent
     private String code;
 
     /**
@@ -62,6 +64,7 @@ public class CodeListEntryData extends Composite {
     @Length(512)
     @NullAllowed
     @AutoImport
+    @PrefixSearchContent
     private String value;
 
     /**
@@ -71,6 +74,7 @@ public class CodeListEntryData extends Composite {
     @Length(512)
     @NullAllowed
     @AutoImport
+    @PrefixSearchContent
     private String additionalValue;
 
     /**
@@ -80,6 +84,7 @@ public class CodeListEntryData extends Composite {
     @Length(1024)
     @NullAllowed
     @AutoImport
+    @PrefixSearchContent
     private String description;
 
     @Part

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListController.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListController.java
@@ -42,14 +42,14 @@ public class SQLCodeListController extends CodeListController<Long, SQLCodeList,
     }
 
     @Override
-    protected void setCodeListSearchFields(@Nonnull BasePageHelper<SQLCodeList, ?, ?, ?> pageHelper) {
+    protected void applyCodeListSearchFields(@Nonnull BasePageHelper<SQLCodeList, ?, ?, ?> pageHelper) {
         pageHelper.withSearchFields(QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.CODE)),
                                     QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.NAME)),
                                     QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.DESCRIPTION)));
     }
 
     @Override
-    protected void setCodeListEntrySearchFields(@Nonnull BasePageHelper<SQLCodeListEntry, ?, ?, ?> pageHelper) {
+    protected void applyCodeListEntrySearchFields(@Nonnull BasePageHelper<SQLCodeListEntry, ?, ?, ?> pageHelper) {
         pageHelper.withSearchFields(QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.CODE)),
                                     QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.VALUE)),
                                     QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.ADDITIONAL_VALUE)),

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListController.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListController.java
@@ -8,12 +8,17 @@
 
 package sirius.biz.codelists.jdbc;
 
+import sirius.biz.codelists.CodeList;
 import sirius.biz.codelists.CodeListController;
 import sirius.biz.codelists.CodeListData;
+import sirius.biz.codelists.CodeListEntry;
 import sirius.biz.codelists.CodeListEntryData;
 import sirius.biz.web.BasePageHelper;
 import sirius.biz.web.SQLPageHelper;
+import sirius.db.mixing.query.QueryField;
 import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nonnull;
 
 /**
  * Provides the JDBC/SQL implementation of the {@link CodeListController}.
@@ -34,6 +39,21 @@ public class SQLCodeListController extends CodeListController<Long, SQLCodeList,
                                           .eq(SQLCodeListEntry.CODE_LIST, codeList)
                                           .orderAsc(SQLCodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.PRIORITY))
                                           .orderAsc(SQLCodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.CODE)));
+    }
+
+    @Override
+    protected void setCodeListSearchFields(@Nonnull BasePageHelper<SQLCodeList, ?, ?, ?> pageHelper) {
+        pageHelper.withSearchFields(QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.CODE)),
+                                    QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.NAME)),
+                                    QueryField.contains(CodeList.CODE_LIST_DATA.inner(CodeListData.DESCRIPTION)));
+    }
+
+    @Override
+    protected void setCodeListEntrySearchFields(@Nonnull BasePageHelper<SQLCodeListEntry, ?, ?, ?> pageHelper) {
+        pageHelper.withSearchFields(QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.CODE)),
+                                    QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.VALUE)),
+                                    QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.ADDITIONAL_VALUE)),
+                                    QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.DESCRIPTION)));
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListController.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListController.java
@@ -42,12 +42,12 @@ public class MongoCodeListController extends CodeListController<String, MongoCod
     }
 
     @Override
-    protected void setCodeListSearchFields(@Nonnull BasePageHelper<MongoCodeList, ?, ?, ?> pageHelper) {
+    protected void applyCodeListSearchFields(@Nonnull BasePageHelper<MongoCodeList, ?, ?, ?> pageHelper) {
         pageHelper.withSearchFields(QueryField.startsWith(PrefixSearchableEntity.SEARCH_PREFIXES));
     }
 
     @Override
-    protected void setCodeListEntrySearchFields(@Nonnull BasePageHelper<MongoCodeListEntry, ?, ?, ?> pageHelper) {
+    protected void applyCodeListEntrySearchFields(@Nonnull BasePageHelper<MongoCodeListEntry, ?, ?, ?> pageHelper) {
         pageHelper.withSearchFields(QueryField.startsWith(PrefixSearchableEntity.SEARCH_PREFIXES));
     }
 

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListController.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListController.java
@@ -11,9 +11,13 @@ package sirius.biz.codelists.mongo;
 import sirius.biz.codelists.CodeListController;
 import sirius.biz.codelists.CodeListData;
 import sirius.biz.codelists.CodeListEntryData;
+import sirius.biz.mongo.PrefixSearchableEntity;
 import sirius.biz.web.BasePageHelper;
 import sirius.biz.web.MongoPageHelper;
+import sirius.db.mixing.query.QueryField;
 import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nonnull;
 
 /**
  * Provides the MongoDB implementation of the {@link CodeListController}.
@@ -35,6 +39,16 @@ public class MongoCodeListController extends CodeListController<String, MongoCod
                                               .eq(MongoCodeListEntry.CODE_LIST, codeList)
                                               .orderAsc(MongoCodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.PRIORITY))
                                               .orderAsc(MongoCodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.CODE)));
+    }
+
+    @Override
+    protected void setCodeListSearchFields(@Nonnull BasePageHelper<MongoCodeList, ?, ?, ?> pageHelper) {
+        pageHelper.withSearchFields(QueryField.startsWith(PrefixSearchableEntity.SEARCH_PREFIXES));
+    }
+
+    @Override
+    protected void setCodeListEntrySearchFields(@Nonnull BasePageHelper<MongoCodeListEntry, ?, ?, ?> pageHelper) {
+        pageHelper.withSearchFields(QueryField.startsWith(PrefixSearchableEntity.SEARCH_PREFIXES));
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntry.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntry.java
@@ -11,10 +11,10 @@ package sirius.biz.codelists.mongo;
 import sirius.biz.codelists.CodeListEntry;
 import sirius.biz.codelists.CodeListEntryData;
 import sirius.biz.importer.AutoImport;
+import sirius.biz.mongo.PrefixSearchableEntity;
 import sirius.db.mixing.annotations.Index;
 import sirius.db.mixing.annotations.TranslationSource;
 import sirius.db.mongo.Mango;
-import sirius.db.mongo.MongoEntity;
 import sirius.db.mongo.types.MongoRef;
 import sirius.kernel.di.std.Framework;
 
@@ -27,7 +27,7 @@ import sirius.kernel.di.std.Framework;
         columns = {"codeList", "codeListEntryData_code"},
         columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING},
         unique = true)
-public class MongoCodeListEntry extends MongoEntity implements CodeListEntry<String, MongoCodeList> {
+public class MongoCodeListEntry extends PrefixSearchableEntity implements CodeListEntry<String, MongoCodeList> {
 
     @AutoImport
     private final MongoRef<MongoCodeList> codeList =


### PR DESCRIPTION
Error: `Ein unerwarteter Fehler ist aufgetreten: MongoQueryCompiler only supports either a search in the FULLTEXT_FIELD or an equals or prefix search in a string field (java.lang.IllegalArgumentException)`

Note: Re-Save entities is needed for MongoCodeList and MongoCodeListEntry in order to update the search prefixes.

FIXES: SIRI-264