### PR TITLE
No longer enforces a "." at the start of a bucketSuffix.

### DIFF
--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -145,11 +145,12 @@ public class ObjectStore {
                                                      .withS3Client(client)
                                                      .build();
 
-        if (Strings.isFilled(bucketSuffix) && !bucketSuffix.startsWith(".")) {
-            this.bucketSuffix = "." + bucketSuffix;
-        } else {
-            this.bucketSuffix = bucketSuffix;
+        if (Strings.isFilled(bucketSuffix) && bucketSuffix.contains(".") && !bucketSuffix.startsWith(".")) {
+            ObjectStores.LOG.WARN(
+                    "The bucketSuffix '%s' contains a '.' but does not start with one. This might lead to errors!",
+                    bucketSuffix);
         }
+        this.bucketSuffix = bucketSuffix;
     }
 
     /**

--- a/src/test/java/sirius/biz/translations/MongoTranslatableTestEntity.java
+++ b/src/test/java/sirius/biz/translations/MongoTranslatableTestEntity.java
@@ -14,7 +14,7 @@ import sirius.db.mongo.MongoEntity;
 
 public class MongoTranslatableTestEntity extends MongoEntity implements Translatable<MongoTranslations> {
 
-    private MongoTranslations translations = new MongoTranslations(this);
+    private final MongoTranslations translations = new MongoTranslations(this);
 
     public static final Mapping DESCRIPTION = Mapping.named("description");
 

--- a/src/test/java/sirius/biz/translations/SQLTranslatableTestEntity.java
+++ b/src/test/java/sirius/biz/translations/SQLTranslatableTestEntity.java
@@ -14,7 +14,7 @@ import sirius.db.mixing.Mapping;
 
 public class SQLTranslatableTestEntity extends SQLEntity implements Translatable<SQLTranslations> {
 
-    private SQLTranslations translations = new SQLTranslations(this);
+    private final SQLTranslations translations = new SQLTranslations(this);
 
     public static final Mapping DESCRIPTION = Mapping.named("description");
 


### PR DESCRIPTION
We need this so that our bucket names are covered by the S3 wildcard certificate.