### PR TITLE
Prevent a NPE

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
@@ -73,8 +73,8 @@ public class BlobSoftRefProperty extends BlobRefProperty {
 
     @Override
     protected void onBeforeSaveChecks(Object entity) {
-        BlobHardRef ref = getRef(entity);
-        if (isChanged(entity) && ref.isFilled() && ref.getBlob().isTemporary()) {
+        BlobSoftRef ref = (BlobSoftRef) getRef(entity);
+        if (isChanged(entity) && ref.isFilled() && !ref.isURL() && ref.getBlob().isTemporary()) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage(


### PR DESCRIPTION
BlobSoftRef extends from BlobHardRef and adds logic for external URLs. If a URL is set #isFilled returns true but #getBlob returns null. This leads to a NPE.