### PR TITLE
Prevent BlobSoftRef#getPath from clearing the URL

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRef.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRef.java
@@ -57,6 +57,16 @@ public class BlobSoftRef extends BlobHardRef {
         return super.getFilename();
     }
 
+    @Override
+    @Nullable
+    public String getPath() {
+        if (isURL()) {
+            return null;
+        }
+
+        return super.getFilename();
+    }
+
     /**
      * Determines if a URL was stored instead of an object key.
      *


### PR DESCRIPTION
BlobHardRef#getPath calls #getBlob which clears the key if the blob can't be resolved. As URLs are not real blob keys, calling #getPath on a BlobSoftRef with a referenced URL would clear the URL.