### PR TITLE
Permits to also use the AdditionalRolesProvider to extend Tenant::has…

### DIFF
--- a/src/main/java/sirius/biz/tenants/AdditionalRolesProvider.java
+++ b/src/main/java/sirius/biz/tenants/AdditionalRolesProvider.java
@@ -30,7 +30,7 @@ public interface AdditionalRolesProvider {
      * in order to be present for a user.
      * <p>
      * The main reason to implement this method is to toggle some flags which are used in role to permission
-     * maps which e.g. deciede which roles are offered for a user (based on the capabilities of its tenant).
+     * maps which e.g. decide which roles are offered for a user (based on the capabilities of its tenant).
      *
      * @param tenant       the tenant to compute roles / permissions / flags for
      * @param roleConsumer the consumer to be provided with additional roles / permissions / flags

--- a/src/main/java/sirius/biz/tenants/AdditionalRolesProvider.java
+++ b/src/main/java/sirius/biz/tenants/AdditionalRolesProvider.java
@@ -22,4 +22,20 @@ public interface AdditionalRolesProvider {
      * @param roleConsumer the consumer for the additonal roles
      */
     void addAdditionalRoles(UserAccount<?, ?> user, Consumer<String> roleConsumer);
+
+    /**
+     * Adds additional roles / permissions / flag specifically to {@link Tenant#hasPermission(String)}.
+     * <p>
+     * Note that permissions added here, still have to be reported by {@link #addAdditionalRoles(UserAccount, Consumer)}
+     * in order to be present for a user.
+     * <p>
+     * The main reason to implement this method is to toggle some flags which are used in role to permission
+     * maps which e.g. deciede which roles are offered for a user (based on the capabilities of its tenant).
+     *
+     * @param tenant       the tenant to compute roles / permissions / flags for
+     * @param roleConsumer the consumer to be provided with additional roles / permissions / flags
+     */
+    default void addAdditionalTenantRoles(Tenant<?> tenant, Consumer<String> roleConsumer) {
+        // The default implementation does intentionally nothing...
+    }
 }

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenant.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenant.java
@@ -14,6 +14,7 @@ import sirius.biz.jdbc.BizEntity;
 import sirius.biz.protocol.JournalData;
 import sirius.biz.tenants.Tenant;
 import sirius.biz.tenants.TenantData;
+import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.tenants.Tenants;
 import sirius.biz.web.Autoloaded;
 import sirius.db.jdbc.SQLEntityRef;
@@ -71,7 +72,12 @@ public class SQLTenant extends BizEntity implements Tenant<Long> {
                 permissions.add("tenant-" + tenantData.getAccountNumber());
             }
 
+            // We assign here, in case an AdditionalRolesProvider uses hasPermission recursively...
             effectivePermissions = permissions;
+
+            // and we assign again the final value after all AdditionalRolesProviders ran. Note that this is a
+            // NOOP if no AdditionalRolesProviders arep resent...
+            effectivePermissions = TenantUserManager.computeEffectiveTenantPermissions(this, effectivePermissions);
         }
 
         return effectivePermissions.contains(permission);

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenant.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenant.java
@@ -76,7 +76,7 @@ public class SQLTenant extends BizEntity implements Tenant<Long> {
             effectivePermissions = permissions;
 
             // and we assign again the final value after all AdditionalRolesProviders ran. Note that this is a
-            // NOOP if no AdditionalRolesProviders arep resent...
+            // NOOP if no AdditionalRolesProviders are present...
             effectivePermissions = TenantUserManager.computeEffectiveTenantPermissions(this, effectivePermissions);
         }
 

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
@@ -85,7 +85,7 @@ public class MongoTenant extends MongoBizEntity implements Tenant<String> {
             effectivePermissions = permissions;
 
             // and we assign again the final value after all AdditionalRolesProviders ran. Note that this is a
-            // NOOP if no AdditionalRolesProviders arep resent...
+            // NOOP if no AdditionalRolesProviders are present...
             effectivePermissions = TenantUserManager.computeEffectiveTenantPermissions(this, effectivePermissions);
         }
 

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
@@ -13,6 +13,7 @@ import sirius.biz.mongo.MongoBizEntity;
 import sirius.biz.protocol.JournalData;
 import sirius.biz.tenants.Tenant;
 import sirius.biz.tenants.TenantData;
+import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.tenants.Tenants;
 import sirius.biz.web.Autoloaded;
 import sirius.db.mixing.Mapping;
@@ -80,7 +81,12 @@ public class MongoTenant extends MongoBizEntity implements Tenant<String> {
                 permissions.add("tenant-" + tenantData.getAccountNumber());
             }
 
+            // We assign here, in case an AdditionalRolesProvider uses hasPermission recursively...
             effectivePermissions = permissions;
+
+            // and we assign again the final value after all AdditionalRolesProviders ran. Note that this is a
+            // NOOP if no AdditionalRolesProviders arep resent...
+            effectivePermissions = TenantUserManager.computeEffectiveTenantPermissions(this, effectivePermissions);
         }
 
         return effectivePermissions.contains(permission);


### PR DESCRIPTION
…Permission.

This is mainly useful to toggle / provide some feature flags so that the role to permission
maps can filter on these and only show useful roles for a user based on its tenants
capabilities.