### PR TITLE
Add an unique index to the blob key

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -47,6 +47,7 @@ import java.util.Optional;
  */
 @Framework(SQLBlobStorage.FRAMEWORK_JDBC_BLOB_STORAGE)
 @ComplexDelete(false)
+@Index(name = "blob_key_lookup", columns = "blobKey", unique = true)
 @Index(name = "blob_normalized_filename_lookup",
         columns = {"spaceName", "deleted", "normalizedFilename", "parent", "committed"})
 @Index(name = "blob_filename_lookup", columns = {"spaceName", "deleted", "filename", "parent", "committed"})

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -47,6 +47,7 @@ import java.util.Optional;
  */
 @Framework(MongoBlobStorage.FRAMEWORK_MONGO_BLOB_STORAGE)
 @ComplexDelete(false)
+@Index(name = "blob_key_lookup", columns = "blobKey", columnSettings = Mango.INDEX_ASCENDING, unique = true)
 @Index(name = "blob_normalized_filename_lookup",
         columns = {"spaceName", "deleted", "normalizedFilename", "parent", "committed"},
         columnSettings = {Mango.INDEX_ASCENDING,


### PR DESCRIPTION
This will speed up the unique check when saving blobs and more importantly accessing blobs via the key.