### PR TITLE
SE-10129: VirtualFileExtractionJob - Remove deletion of file

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/VirtualFileExtractionJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/VirtualFileExtractionJob.java
@@ -87,20 +87,18 @@ public class VirtualFileExtractionJob extends SimpleBatchProcessJobFactory {
                                          FileHandle fileHandle,
                                          boolean shouldOverwriteExisting,
                                          VirtualFile targetDirectory) {
-        File tempFile = fileHandle.getFile();
+        File archiveFile = fileHandle.getFile();
+
         if (!TaskContext.get().isActive()) {
-            Files.delete(tempFile);
             return;
         }
 
         try {
-            ArchiveHelper.extract(tempFile,
+            ArchiveHelper.extract(archiveFile,
                                   null,
                                   handleFileInArchive(process, shouldOverwriteExisting, targetDirectory));
         } catch (IOException e) {
             process.handle(e);
-        } finally {
-            Files.delete(tempFile);
         }
     }
 

--- a/src/main/java/sirius/biz/jobs/batch/file/VirtualFileExtractionJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/VirtualFileExtractionJob.java
@@ -76,11 +76,9 @@ public class VirtualFileExtractionJob extends SimpleBatchProcessJobFactory {
         final VirtualFile targetDirectory =
                 destinationDirectory.orElseGet(() -> vfs.resolve(sourceFile.parent().path()));
 
-        sourceFile.tryDownload()
-                  .ifPresent(handle -> handleArchiveExtraction(process,
-                                                               handle,
-                                                               shouldOverwriteExisting,
-                                                               targetDirectory));
+        try (FileHandle handle = sourceFile.download()) {
+            handleArchiveExtraction(process, handle, shouldOverwriteExisting, targetDirectory);
+        }
     }
 
     private void handleArchiveExtraction(ProcessContext process,


### PR DESCRIPTION
Removes the deletion of the archive file as the "link" is still present and will point on a not present file and we want to keep the file after extraction.

- Fixes: SE-10129