### PR TITLE
Only handle upload as job file if it is not empty

### DIFF
--- a/src/main/java/sirius/biz/jobs/JobsRoot.java
+++ b/src/main/java/sirius/biz/jobs/JobsRoot.java
@@ -27,7 +27,6 @@ import sirius.biz.storage.layer3.TmpRoot;
 import sirius.biz.storage.layer3.VFSRoot;
 import sirius.biz.storage.layer3.VirtualFile;
 import sirius.biz.storage.layer3.VirtualFileSystem;
-import sirius.biz.tenants.Tenants;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
@@ -153,8 +152,10 @@ public class JobsRoot extends SingularVFSRoot {
             BlobStorageSpace temporaryStorageSpace = blobStorage.getSpace(TmpRoot.TMP_SPACE);
             Blob buffer = temporaryStorageSpace.createTemporaryBlob(UserContext.getCurrentUser().getTenantId());
             return buffer.createOutputStream(() -> {
-                temporaryStorageSpace.markAsUsed(buffer);
-                trigger(preset, buffer, filename);
+                if (buffer.getSize() > 0) {
+                    temporaryStorageSpace.markAsUsed(buffer);
+                    trigger(preset, buffer, filename);
+                }
             }, filename);
         } catch (Exception e) {
             throw Exceptions.handle(e);

--- a/src/main/java/sirius/biz/jobs/JobsRoot.java
+++ b/src/main/java/sirius/biz/jobs/JobsRoot.java
@@ -155,6 +155,8 @@ public class JobsRoot extends SingularVFSRoot {
                 if (buffer.getSize() > 0) {
                     temporaryStorageSpace.markAsUsed(buffer);
                     trigger(preset, buffer, filename);
+                } else {
+                    buffer.delete();
                 }
             }, filename);
         } catch (Exception e) {


### PR DESCRIPTION
- due to sftp changes jobsroot get now also gets supplied with empty files
- those get ignored
- reusage of blobs not desired here, as jobsroot isn't a regular filesystem with regards to uniqueness of filenames

Fixes: SE-10139