### PR TITLE
Ensures that subclasses of parameters are also handled correctly

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/Parameter.java
+++ b/src/main/java/sirius/biz/jobs/params/Parameter.java
@@ -46,7 +46,11 @@ public class Parameter<V> extends Composable {
 
     protected Parameter(ParameterBuilder<V, ?> delegate) {
         this.delegate = delegate;
-        attach(delegate);
+        Class<?> delegateClass = delegate.getClass();
+        while (delegateClass != null && delegateClass != ParameterBuilder.class) {
+            attach(delegateClass, delegate);
+            delegateClass = delegateClass.getSuperclass();
+        }
     }
 
     /**


### PR DESCRIPTION
Attaches all superclasses for the delegate to ensure that subclasses of parameters are also handled correctly.
This fixes issues when rendering templates for jobs with such parameters (e.g. extending from SelectStringParameter).