### PR TITLE
Fix the retry mechanism of variants

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1207,7 +1207,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     @Nullable
     private V attemptToFindOrCreateVariant(B blob, String variantName, boolean nonblocking, int retries)
             throws Exception {
-        V variant = findVariant(blob, variantName);
+        V variant = findAnyVariant(blob, variantName);
         if (variant != null && Strings.isFilled(variant.getPhysicalObjectKey())) {
             // We hit the nail on the head - we found a variant which has successfully been converted already.
             // -> use it
@@ -1248,8 +1248,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
                 invokeConversionPipelineAsync(blob, variant);
             }
 
-            // ...and no we wait on either our or another conversion task to finish so that we can use
-            // the result
+            // ...and now we wait on either our or another conversion task to finish so that we can use the result
             return retryToFindOrCreateVariant(blob, variantName, retries);
         }
 
@@ -1276,14 +1275,26 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     }
 
     /**
-     * Tries to find the requeted variant in the database.
+     * Tries to find the requested and converted variant in the database.
      *
      * @param blob        the blob for which the variant is to be resolved
      * @param variantName the variant of the blob to find
      * @return the variant or <tt>null</tt> if no matching variant exists
      */
     @Nullable
-    protected abstract V findVariant(B blob, String variantName);
+    protected abstract V findCompletedVariant(B blob, String variantName);
+
+    /**
+     * Tries to find the requested variant in the database.
+     * <p>
+     * Note: This will also return variants where the conversion is not completed yet.
+     *
+     * @param blob        the blob for which the variant is to be resolved
+     * @param variantName the variant of the blob to find
+     * @return the variant or <tt>null</tt> if no matching variant exists
+     */
+    @Nullable
+    protected abstract V findAnyVariant(B blob, String variantName);
 
     /**
      * Marks the variant as queued for conversion.

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -310,7 +310,7 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
     @Override
     public Optional<BlobVariant> findVariant(String name) {
-        return Optional.ofNullable(getStorageSpace().findVariant(this, name));
+        return Optional.ofNullable(getStorageSpace().findCompletedVariant(this, name));
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -11,7 +11,6 @@ package sirius.biz.storage.layer2.jdbc;
 import sirius.biz.storage.layer2.BasicBlobStorageSpace;
 import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.layer2.Directory;
-import sirius.biz.storage.layer2.mongo.MongoBlob;
 import sirius.biz.storage.layer2.variants.BlobVariant;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.db.jdbc.OMA;
@@ -685,10 +684,18 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
     }
 
     @Override
-    protected SQLVariant findVariant(SQLBlob blob, String variantName) {
+    protected SQLVariant findCompletedVariant(SQLBlob blob, String variantName) {
         return oma.select(SQLVariant.class)
                   .eq(SQLVariant.SOURCE_BLOB, blob)
                   .ne(SQLVariant.PHYSICAL_OBJECT_KEY, null)
+                  .eq(SQLVariant.VARIANT_NAME, variantName)
+                  .queryFirst();
+    }
+
+    @Override
+    protected SQLVariant findAnyVariant(SQLBlob blob, String variantName) {
+        return oma.select(SQLVariant.class)
+                  .eq(SQLVariant.SOURCE_BLOB, blob)
                   .eq(SQLVariant.VARIANT_NAME, variantName)
                   .queryFirst();
     }

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -313,7 +313,7 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
     @Override
     public Optional<BlobVariant> findVariant(String name) {
-        return Optional.ofNullable(getStorageSpace().findVariant(this, name));
+        return Optional.ofNullable(getStorageSpace().findCompletedVariant(this, name));
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -614,10 +614,18 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
     }
 
     @Override
-    protected MongoVariant findVariant(MongoBlob blob, String variantName) {
+    protected MongoVariant findCompletedVariant(MongoBlob blob, String variantName) {
         return mango.select(MongoVariant.class)
                     .eq(MongoVariant.BLOB, blob)
                     .ne(MongoVariant.PHYSICAL_OBJECT_KEY, null)
+                    .eq(MongoVariant.VARIANT_NAME, variantName)
+                    .queryFirst();
+    }
+
+    @Override
+    protected MongoVariant findAnyVariant(MongoBlob blob, String variantName) {
+        return mango.select(MongoVariant.class)
+                    .eq(MongoVariant.BLOB, blob)
                     .eq(MongoVariant.VARIANT_NAME, variantName)
                     .queryFirst();
     }


### PR DESCRIPTION
BasicBlobStorageSpace#findVariant would only return completed variants,
which lead to BasicBlobStorageSpace#attemptToFindOrCreateVariant never
actually retrying the conversion if it failed before.