### PR TITLE
Permits to control the sort order of blobs when shown in the VFS (lay…

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -133,6 +133,11 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     private static final String CONFIG_KEY_TOUCH_TRACKING = "touchTracking";
 
     /**
+     * Determines if we should sort by the last modification date instead of "by name".
+     */
+    private static final String CONFIG_KEY_SORT_BY_LAST_MODIFIED = "sortByLastModified";
+
+    /**
      * Contains the name of the executor in which requests are moved which might be blocked while waiting for
      * a conversion to happen. We do not want to jam our main executor of the web server for this, therefore
      * a separator one is used.
@@ -199,6 +204,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     protected boolean useNormalizedNames;
     protected int retentionDays;
     protected boolean touchTracking;
+    protected boolean sortByLastModified;
     protected ObjectStorageSpace objectStorageSpace;
 
     /**
@@ -217,6 +223,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         this.description = config.get(CONFIG_KEY_DESCRIPTION).getString();
         this.retentionDays = config.get(CONFIG_KEY_RETENTION_DAYS).asInt(0);
         this.touchTracking = config.get(CONFIG_KEY_TOUCH_TRACKING).asBoolean();
+        this.sortByLastModified = config.get(CONFIG_KEY_SORT_BY_LAST_MODIFIED).asBoolean();
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -49,7 +49,9 @@ import java.util.Optional;
 @ComplexDelete(false)
 @Index(name = "blob_key_lookup", columns = "blobKey", unique = true)
 @Index(name = "blob_normalized_filename_lookup",
-        columns = {"spaceName", "deleted", "normalizedFilename", "parent", "committed"})
+        columns = {"spaceName", "deleted", "parent", "normalizedFilename", "committed"})
+@Index(name = "blob_sort_by_last_modified",
+        columns = {"spaceName", "deleted", "parent", "lastModified"})
 @Index(name = "blob_filename_lookup", columns = {"spaceName", "deleted", "filename", "parent", "committed"})
 @Index(name = "blob_reference_lookup", columns = {"spaceName", "deleted", "reference", "referenceDesignator"})
 public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -49,14 +49,21 @@ import java.util.Optional;
 @ComplexDelete(false)
 @Index(name = "blob_key_lookup", columns = "blobKey", columnSettings = Mango.INDEX_ASCENDING, unique = true)
 @Index(name = "blob_normalized_filename_lookup",
-        columns = {"spaceName", "deleted", "normalizedFilename", "parent", "committed"},
+        columns = {"spaceName", "deleted", "parent", "normalizedFilename", "committed"},
+        columnSettings = {Mango.INDEX_ASCENDING,
+                          Mango.INDEX_ASCENDING,
+                          Mango.INDEX_ASCENDING,
+                          Mango.INDEX_ASCENDING,
+                          Mango.INDEX_ASCENDING})
+@Index(name = "blob_sort_by_last_modified",
+        columns = {"spaceName", "deleted", "parent", "lastModified"},
         columnSettings = {Mango.INDEX_ASCENDING,
                           Mango.INDEX_ASCENDING,
                           Mango.INDEX_ASCENDING,
                           Mango.INDEX_ASCENDING,
                           Mango.INDEX_ASCENDING})
 @Index(name = "blob_filename_lookup",
-        columns = {"spaceName", "deleted", "filename", "parent", "committed"},
+        columns = {"spaceName", "deleted", "parent", "filename", "committed"},
         columnSettings = {Mango.INDEX_ASCENDING,
                           Mango.INDEX_ASCENDING,
                           Mango.INDEX_ASCENDING,

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -11,6 +11,7 @@ package sirius.biz.storage.layer2.mongo;
 import sirius.biz.storage.layer2.BasicBlobStorageSpace;
 import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.layer2.Directory;
+import sirius.biz.storage.layer2.jdbc.SQLBlob;
 import sirius.biz.storage.layer2.variants.BlobVariant;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.db.mixing.Mapping;
@@ -492,6 +493,7 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
              .eq(MongoDirectory.DELETED, false)
              .where(QueryBuilder.FILTERS.prefix(MongoDirectory.NORMALIZED_DIRECTORY_NAME, prefixFilter))
              .limit(maxResults)
+             .orderAsc(MongoDirectory.NORMALIZED_DIRECTORY_NAME)
              .iterate(childProcessor::test);
     }
 
@@ -602,6 +604,7 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
              .where(QueryBuilder.FILTERS.prefix(MongoBlob.NORMALIZED_FILENAME, prefixFilter))
              .where(QueryBuilder.FILTERS.containsOne(MongoBlob.FILE_EXTENSION, fileTypes.toArray()).build())
              .limit(maxResults)
+             .orderAsc(sortByLastModified ? MongoBlob.LAST_MODIFIED : MongoBlob.NORMALIZED_FILENAME)
              .iterate(childProcessor::test);
     }
 

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -714,6 +714,10 @@ storage {
                 # If a space is heavily used, it might be necessary to turn this off (especially of the generated
                 # data isn't used).
                 touchTracking = true
+
+                # Determines if files are sorted by their name ascending (false) or by their last modification
+                # timestamp descending. Note that directories will always be sorted by name ascending.
+                sortByLastModified = false
             }
 
             # Defines a work space which is shared by all users of a tenant and can be used to provide
@@ -721,6 +725,7 @@ storage {
             work {
                 description = "$BlobStorageSpace.work.description"
                 retentionDays = 30
+                sortByLastModified = true
             }
 
             # Provides a temporary storage location which will be cleaned up every once in a while.
@@ -734,6 +739,7 @@ storage {
             # This space is used to store files which are attached to Processes
             processes {
                 readPermission = "disabled"
+                touchTracking = false
             }
         }
     }


### PR DESCRIPTION
…er3).

This can be controlled per storage space and is either by name ascending
or by last modification date descending (which is used for /work).

Note that some indices where modified so also support these queries.