### PR TITLE
Properly returns the item count in a query when paginating

### DIFF
--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -411,9 +411,9 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
         if (items.size() > pageSize) {
             result.withHasMore(true);
             items.remove(items.size() - 1);
-            if (fetchTotalCount) {
-                result.withTotalItems((int) baseQuery.count());
-            }
+        }
+        if (fetchTotalCount) {
+            result.withTotalItems((int) baseQuery.count());
         } else {
             result.withTotalItems(items.size());
         }

--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -413,7 +413,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
             result.withHasMore(true);
             items.remove(items.size() - 1);
         }
-        if (fetchTotalCount && (originalSize > pageSize || result.getStart() > 1)) {
+        if (fetchTotalCount && (originalSize > pageSize || result.getStart() > pageSize)) {
             result.withTotalItems((int) baseQuery.count());
         } else {
             result.withTotalItems(items.size());

--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -408,11 +408,12 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     }
 
     protected void enforcePaging(Page<E> result, List<E> items) {
-        if (items.size() > pageSize) {
+        int originalSize = items.size();
+        if (originalSize > pageSize) {
             result.withHasMore(true);
             items.remove(items.size() - 1);
         }
-        if (fetchTotalCount) {
+        if (fetchTotalCount && (originalSize > pageSize || result.getStart() > 1)) {
             result.withTotalItems((int) baseQuery.count());
         } else {
             result.withTotalItems(items.size());


### PR DESCRIPTION
When using Page.withTotalCount(), the last page will not show the amount of items in the query but the remaining items of the page.

Fixes: OX-6224