### PR TITLE
Handles additional actions to blobs and directories

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobCreatedRenamedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobCreatedRenamedHandler.java
@@ -19,7 +19,7 @@ import javax.annotation.Nonnull;
  */
 public interface BlobCreatedRenamedHandler extends Priorized {
     /**
-     * Method executed when a blob is inserted or some of its metadata (such as file name) is modified.
+     * Executed when a blob is inserted or some of its metadata (such as file name) is modified.
      *
      * @param blob the modified blob
      */

--- a/src/main/java/sirius/biz/storage/layer2/BlobParentChangedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobParentChangedHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.layer2;
+
+import sirius.kernel.di.std.Priorized;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Defines handlers to process {@link Blob blobs} which parent have been moved between {@link Directory directories}.
+ *
+ * @see ProcessBlobChangesLoop
+ */
+public interface BlobParentChangedHandler extends Priorized {
+    /**
+     * Method executed when a blob has its parent {@link Directory} changed.
+     *
+     * @param blob the modified blob
+     */
+    void execute(@Nonnull Blob blob);
+}

--- a/src/main/java/sirius/biz/storage/layer2/BlobParentChangedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobParentChangedHandler.java
@@ -19,7 +19,7 @@ import javax.annotation.Nonnull;
  */
 public interface BlobParentChangedHandler extends Priorized {
     /**
-     * Method executed when a blob has its parent {@link Directory} changed.
+     * Executed when a blob has its parent {@link Directory} changed.
      *
      * @param blob the modified blob
      */

--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
 
     private static final double FREQUENCY_EVERY_FIFTEEN_SECONDS = 1 / 15d;
+    protected static final int CURSOR_LIMIT = 1024;
 
     @PriorityParts(BlobCreatedRenamedHandler.class)
     private List<BlobCreatedRenamedHandler> createdOrRenamedHandlers;

--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -24,8 +24,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  **/
 public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
 
-    private static final double FREQUENCY_EVERY_FIFTEEN_SECONDS = 1 / 15d;
+    /**
+     * Defines the block size used for queries to propagate and handle various change flags.
+     */
     protected static final int CURSOR_LIMIT = 1024;
+
+    private static final double FREQUENCY_EVERY_FIFTEEN_SECONDS = 1 / 15d;
 
     @PriorityParts(BlobCreatedRenamedHandler.class)
     private List<BlobCreatedRenamedHandler> createdOrRenamedHandlers;

--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -29,6 +29,9 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
     @PriorityParts(BlobCreatedRenamedHandler.class)
     private List<BlobCreatedRenamedHandler> createdOrRenamedHandlers;
 
+    @PriorityParts(BlobParentChangedHandler.class)
+    private List<BlobParentChangedHandler> parentChangedHandlers;
+
     @Nonnull
     @Override
     public String getName() {
@@ -44,21 +47,32 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
     @Override
     protected String doWork() throws Exception {
         AtomicInteger deletedDirectories = new AtomicInteger();
+        AtomicInteger renamedDirectories = new AtomicInteger();
         AtomicInteger deletedBlobs = new AtomicInteger();
         AtomicInteger createdRenamedBlobs = new AtomicInteger();
+        AtomicInteger parentChangedBlobs = new AtomicInteger();
 
         deleteDirectories(deletedDirectories::incrementAndGet);
+        processRenamedDirectories(renamedDirectories::incrementAndGet);
         deleteBlobs(deletedBlobs::incrementAndGet);
+        processParentChangedBlobs(parentChangedBlobs::incrementAndGet);
         processCreatedOrRenamedBlobs(createdRenamedBlobs::incrementAndGet);
 
-        if (deletedDirectories.get() == 0 && deletedBlobs.get() == 0 && createdRenamedBlobs.get() == 0) {
+        if (deletedDirectories.get()
+            + renamedDirectories.get()
+            + deletedBlobs.get()
+            + createdRenamedBlobs.get()
+            + parentChangedBlobs.get() == 0) {
             return null;
         }
 
-        return Strings.apply("Deleted %s directories and %s blobs. Processed %s new or renamed blobs.",
-                             deletedDirectories.get(),
-                             deletedBlobs.get(),
-                             createdRenamedBlobs.get());
+        return Strings.apply(
+                "Directories: deleted (%s), renamed (%s). Blobs: deleted (%s), created/renamed (%s), moved (%s)",
+                deletedDirectories.get(),
+                renamedDirectories.get(),
+                deletedBlobs.get(),
+                createdRenamedBlobs.get(),
+                parentChangedBlobs.get());
     }
 
     protected void deletePhysicalObject(@Nonnull Blob blob) {
@@ -82,6 +96,21 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
         });
     }
 
+    protected void invokeParentChangedHandlers(Blob blob) {
+        parentChangedHandlers.forEach(handler -> {
+            try {
+                handler.execute(blob);
+            } catch (Exception e) {
+                buildStorageException(e).withSystemErrorMessage(
+                        "Layer 2: %s failed to process parent change for blob %s (%s) in %s: (%s)",
+                        handler.getClass().getSimpleName(),
+                        blob.getBlobKey(),
+                        blob.getFilename(),
+                        blob.getSpaceName()).handle();
+            }
+        });
+    }
+
     protected void handleBlobDeletionException(@Nonnull Blob blob, Exception e) {
         buildStorageException(e).withSystemErrorMessage("Layer 2: Failed to finally delete the blob %s (%s) in %s: (%s)",
                                                         blob.getBlobKey(),
@@ -92,6 +121,14 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
     protected void handleDirectoryDeletionException(@Nonnull Directory dir, Exception e) {
         buildStorageException(e).withSystemErrorMessage(
                 "Layer 2: Failed to finally delete the directory %s (%s) in %s: (%s)",
+                dir.getIdAsString(),
+                dir.getName(),
+                dir.getSpaceName()).handle();
+    }
+
+    protected void handleDirectoryRenameException(@Nonnull Directory dir, Exception e) {
+        buildStorageException(e).withSystemErrorMessage(
+                "Layer 2: Failed to process rename of directory %s (%s) in %s: (%s)",
                 dir.getIdAsString(),
                 dir.getName(),
                 dir.getSpaceName()).handle();
@@ -110,6 +147,8 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
 
     /**
      * Queries and physically delete all {@link Directory directories} marked as deleted.
+     * <p>
+     * Each directory is then processed by {@link #propagateDelete(Directory)}
      *
      * @param counter a {@link Runnable} to be called for each {@link Directory directory} deleted
      */
@@ -125,7 +164,34 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
     protected abstract void processCreatedOrRenamedBlobs(Runnable counter);
 
     /**
-     * Marks children items of a given  {@link Directory directory} as deleted.
+     * Marks children items of a given {@link Directory directory} as deleted.
+     *
+     * @param dir the parent {@link Directory} of the items to mark
      */
     protected abstract void propagateDelete(Directory dir);
+
+    /**
+     * Queries and processes {@link Directory directories} marked as renamed.
+     * <p>
+     * Each directory is then processed by {@link #propagateRename(Directory)}
+     *
+     * @param counter a {@link Runnable} to be called for each {@link Blob blob} processed
+     */
+    protected abstract void processRenamedDirectories(Runnable counter);
+
+    /**
+     * Notifies children items of a given {@link Directory directories} that its parent has been renamed.
+     *
+     * @param dir the parent {@link Directory} of the items to notify
+     */
+    protected abstract void propagateRename(Directory dir);
+
+    /**
+     * Queries and processes {@link Blob blobs} moved between {@link Directory directories}.
+     * <p>
+     * The processing is performed by the registered {@link BlobParentChangedHandler handlers}
+     *
+     * @param counter a {@link Runnable} to be called for each {@link Blob blob} processed
+     */
+    protected abstract void processParentChangedBlobs(Runnable counter);
 }

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 @Index(name = "blob_reference_lookup", columns = {"spaceName", "deleted", "reference", "referenceDesignator"})
 @Index(name = "blob_created_renamed_loop", columns = "createdOrRenamed")
 @Index(name = "blob_deleted_loop", columns = "deleted")
+@Index(name = "blob_parent_changed_loop", columns = "parentChanged")
 public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
     @Transient
@@ -148,6 +149,12 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
             SQLEntityRef.on(SQLDirectory.class, BaseEntityRef.OnDelete.IGNORE);
 
     /**
+     * Stores if the blob was moved into another folder.
+     */
+    public static final Mapping PARENT_CHANGED = Mapping.named("parentChanged");
+    private boolean parentChanged;
+
+    /**
      * Stores if the blob was (is still) marked as temporary.
      */
     public static final Mapping TEMPORARY = Mapping.named("temporary");
@@ -217,8 +224,13 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
             createdOrRenamed = true;
         }
 
+        if (!isNew() && isChanged(PARENT)) {
+            parentChanged = true;
+        }
+
         if (deleted) {
             createdOrRenamed = false;
+            parentChanged = false;
         }
     }
 
@@ -446,6 +458,10 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
     public boolean isCreatedOrRenamed() {
         return createdOrRenamed;
+    }
+
+    public boolean isParentChanged() {
+        return parentChanged;
     }
 
     public boolean isHidden() {

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
@@ -40,6 +40,7 @@ import java.util.function.Predicate;
 @Index(name = "directory_name_lookup", columns = {"spaceName", "parent", "deleted", "directoryName"})
 @Index(name = "directory_normalized_name_lookup",
         columns = {"spaceName", "parent", "deleted", "normalizedDirectoryName"})
+@Index(name = "directory_renamed_loop", columns = "renamed")
 public class SQLDirectory extends SQLEntity implements Directory, OptimisticCreate {
 
     /**
@@ -98,6 +99,12 @@ public class SQLDirectory extends SQLEntity implements Directory, OptimisticCrea
     public static final Mapping DELETED = Mapping.named("deleted");
     private boolean deleted;
 
+    /**
+     * Stores if the directory has been renamed.
+     */
+    public static final Mapping RENAMED = Mapping.named("renamed");
+    private boolean renamed;
+
     @Part
     private static BlobStorage layer2;
 
@@ -122,6 +129,10 @@ public class SQLDirectory extends SQLEntity implements Directory, OptimisticCrea
                 this.directoryName = null;
                 this.normalizedDirectoryName = null;
             }
+        }
+
+        if (!isNew() && isChanged(DIRECTORY_NAME)) {
+            renamed = true;
         }
     }
 
@@ -245,5 +256,9 @@ public class SQLDirectory extends SQLEntity implements Directory, OptimisticCrea
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public boolean isRenamed() {
+        return renamed;
     }
 }

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -27,7 +27,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void deleteBlobs(Runnable counter) {
-        oma.select(SQLBlob.class).eq(SQLBlob.DELETED, true).limit(256).iterateAll(blob -> {
+        oma.select(SQLBlob.class).eq(SQLBlob.DELETED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             try {
                 deletePhysicalObject(blob);
                 oma.delete(blob);
@@ -40,7 +40,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void deleteDirectories(Runnable counter) {
-        oma.select(SQLDirectory.class).eq(SQLDirectory.DELETED, true).limit(256).iterateAll(dir -> {
+        oma.select(SQLDirectory.class).eq(SQLDirectory.DELETED, true).limit(CURSOR_LIMIT).iterateAll(dir -> {
             try {
                 propagateDelete(dir);
                 oma.delete(dir);
@@ -53,7 +53,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processCreatedOrRenamedBlobs(Runnable counter) {
-        oma.select(SQLBlob.class).eq(SQLBlob.CREATED_OR_RENAMED, true).limit(256).iterateAll(blob -> {
+        oma.select(SQLBlob.class).eq(SQLBlob.CREATED_OR_RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             invokeChangedOrDeletedHandlers(blob);
             try {
                 oma.updateStatement(SQLBlob.class)
@@ -94,7 +94,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processRenamedDirectories(Runnable counter) {
-        oma.select(SQLDirectory.class).eq(SQLDirectory.RENAMED, true).limit(256).iterateAll(dir -> {
+        oma.select(SQLDirectory.class).eq(SQLDirectory.RENAMED, true).limit(CURSOR_LIMIT).iterateAll(dir -> {
             try {
                 propagateRename(dir);
                 oma.updateStatement(SQLDirectory.class)
@@ -131,7 +131,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processParentChangedBlobs(Runnable counter) {
-        oma.select(SQLBlob.class).eq(SQLBlob.PARENT_CHANGED, true).limit(256).iterateAll(blob -> {
+        oma.select(SQLBlob.class).eq(SQLBlob.PARENT_CHANGED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             invokeParentChangedHandlers(blob);
             try {
                 oma.updateStatement(SQLBlob.class)

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -99,7 +99,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
                 propagateRename(dir);
                 oma.updateStatement(SQLDirectory.class)
                    .set(SQLDirectory.RENAMED, false)
-                   .where(SQLDirectory.PARENT, dir.getId())
+                   .where(SQLDirectory.ID, dir.getId())
                    .executeUpdate();
             } catch (Exception e) {
                 handleDirectoryDeletionException(dir, e);

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -70,6 +70,7 @@ import java.util.Optional;
         columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
 @Index(name = "blob_created_renamed_loop", columns = "createdOrRenamed", columnSettings = Mango.INDEX_ASCENDING)
 @Index(name = "blob_deleted_loop", columns = "deleted", columnSettings = Mango.INDEX_ASCENDING)
+@Index(name = "blob_parent_changed_loop", columns = "parentChanged", columnSettings = Mango.INDEX_ASCENDING)
 public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
     @Transient
@@ -153,6 +154,12 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
     private final MongoRef<MongoDirectory> parent = MongoRef.on(MongoDirectory.class, BaseEntityRef.OnDelete.IGNORE);
 
     /**
+     * Stores if the blob was moved into another folder.
+     */
+    public static final Mapping PARENT_CHANGED = Mapping.named("parentChanged");
+    private boolean parentChanged;
+
+    /**
      * Stores if the blob was (is still) marked as temporary.
      */
     public static final Mapping TEMPORARY = Mapping.named("temporary");
@@ -222,8 +229,13 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
             createdOrRenamed = true;
         }
 
+        if (!isNew() && isChanged(PARENT)) {
+            parentChanged = true;
+        }
+
         if (deleted) {
             createdOrRenamed = false;
+            parentChanged = false;
         }
     }
 
@@ -447,6 +459,10 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
     public boolean isCreatedOrRenamed() {
         return createdOrRenamed;
+    }
+
+    public boolean isParentChanged() {
+        return parentChanged;
     }
 
     public boolean isHidden() {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
@@ -45,6 +45,7 @@ import java.util.function.Predicate;
 @Index(name = "directory_normalized_name_lookup",
         columns = {"spaceName", "parent", "deleted", "normalizedDirectoryName"},
         columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
+@Index(name = "directory_renamed_loop", columns = "renamed", columnSettings = Mango.INDEX_ASCENDING)
 public class MongoDirectory extends MongoEntity implements Directory, OptimisticCreate {
 
     /**
@@ -98,6 +99,12 @@ public class MongoDirectory extends MongoEntity implements Directory, Optimistic
     public static final Mapping DELETED = Mapping.named("deleted");
     private boolean deleted;
 
+    /**
+     * Stores if the directory has been renamed.
+     */
+    public static final Mapping RENAMED = Mapping.named("renamed");
+    private boolean renamed;
+
     @Part
     private static BlobStorage layer2;
 
@@ -122,6 +129,10 @@ public class MongoDirectory extends MongoEntity implements Directory, Optimistic
                 this.directoryName = null;
                 this.normalizedDirectoryName = null;
             }
+        }
+
+        if (!isNew() && isChanged(DIRECTORY_NAME)) {
+            renamed = true;
         }
     }
 
@@ -245,5 +256,9 @@ public class MongoDirectory extends MongoEntity implements Directory, Optimistic
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public boolean isRenamed() {
+        return renamed;
     }
 }

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
@@ -33,7 +33,7 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void deleteBlobs(Runnable counter) {
-        mango.select(MongoBlob.class).eq(MongoBlob.DELETED, true).limit(256).iterateAll(blob -> {
+        mango.select(MongoBlob.class).eq(MongoBlob.DELETED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             try {
                 deletePhysicalObject(blob);
                 counter.run();
@@ -46,7 +46,7 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void deleteDirectories(Runnable counter) {
-        mango.select(MongoDirectory.class).eq(MongoDirectory.DELETED, true).limit(256).iterateAll(dir -> {
+        mango.select(MongoDirectory.class).eq(MongoDirectory.DELETED, true).limit(CURSOR_LIMIT).iterateAll(dir -> {
             try {
                 propagateDelete(dir);
                 mango.delete(dir);
@@ -59,7 +59,7 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processCreatedOrRenamedBlobs(Runnable counter) {
-        mango.select(MongoBlob.class).eq(MongoBlob.CREATED_OR_RENAMED, true).limit(256).iterateAll(blob -> {
+        mango.select(MongoBlob.class).eq(MongoBlob.CREATED_OR_RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             invokeChangedOrDeletedHandlers(blob);
             mongo.update()
                  .set(MongoBlob.CREATED_OR_RENAMED, false)
@@ -81,7 +81,7 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processRenamedDirectories(Runnable counter) {
-        mango.select(MongoDirectory.class).eq(MongoDirectory.RENAMED, true).limit(256).iterateAll(dir -> {
+        mango.select(MongoDirectory.class).eq(MongoDirectory.RENAMED, true).limit(CURSOR_LIMIT).iterateAll(dir -> {
             try {
                 propagateRename(dir);
                 mongo.update()
@@ -110,7 +110,7 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processParentChangedBlobs(Runnable counter) {
-        mango.select(MongoBlob.class).eq(MongoBlob.PARENT_CHANGED, true).limit(256).iterateAll(blob -> {
+        mango.select(MongoBlob.class).eq(MongoBlob.PARENT_CHANGED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             invokeParentChangedHandlers(blob);
             mongo.update()
                  .set(MongoBlob.PARENT_CHANGED, false)


### PR DESCRIPTION
- Moving a blob to another folder triggers a new handler which can be implemented to process a parent change
- Renaming a directory marks all child blobs as parent changes and propagates it to child directories

Fixes: OX-6076