### PR TITLE
Adds getter for addressable name in a specific language

### DIFF
--- a/src/main/java/sirius/biz/model/PersonData.java
+++ b/src/main/java/sirius/biz/model/PersonData.java
@@ -23,6 +23,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.Formatter;
 import sirius.kernel.nls.NLS;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -137,11 +138,23 @@ public class PersonData extends Composite {
      * @return a short string (salutation, title and last name) used to address the person
      */
     public String getAddressableName() {
+        return getAddressableName(NLS.getCurrentLang());
+    }
+
+    /**
+     * Generates a string which is used to address the person in the given language.
+     * <p>
+     * An example would be <tt>Mr. Prof. Skip</tt>
+     *
+     * @param langCode the language code to translate to
+     * @return a short string (salutation, title and last name) used to address the person in the given language
+     */
+    public String getAddressableName(@Nonnull String langCode) {
         if (Strings.isEmpty(lastname)) {
             return "";
         }
         return Formatter.create("[${salutation} ][${title} ]${lastname}")
-                        .set("salutation", getTranslatedSalutation())
+                        .set("salutation", getTranslatedSalutation(langCode))
                         .set("title", title)
                         .set("lastname", lastname)
                         .smartFormat();


### PR DESCRIPTION
This is necessary for auto-generated mails using the recipient's language (such as password mails for portal users).

Fixes: OX-6361