### PR TITLE
Misc Fixes: Replication, Conversion Engine, Processes

### DIFF
--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -484,6 +484,7 @@ public class Processes {
                                     @Nullable Map<String, Average> adminTimings) {
         return modify(processId, process -> process.getState() != ProcessState.TERMINATED, process -> {
             if (process.getState() != ProcessState.STANDBY) {
+                process.setErrorneous(process.isErrorneous() || !TaskContext.get().isActive());
                 process.setState(ProcessState.TERMINATED);
                 process.setCompleted(LocalDateTime.now());
                 process.setExpires(process.getPersistencePeriod().plus(LocalDate.now()));

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
@@ -166,7 +166,7 @@ public class SQLReplicationTaskStorage implements ReplicationTaskStorage {
     public int countNumberOfExecutableTasks() {
         return (int) oma.select(SQLReplicationTask.class)
                         .eq(SQLReplicationTask.FAILED, false)
-                        .where(OMA.FILTERS.gt(SQLReplicationTask.EARLIEST_EXECUTION, LocalDateTime.now()))
+                        .where(OMA.FILTERS.lt(SQLReplicationTask.EARLIEST_EXECUTION, LocalDateTime.now()))
                         .count();
     }
 

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
@@ -173,7 +173,7 @@ public class MongoReplicationTaskStorage implements ReplicationTaskStorage {
     public int countNumberOfExecutableTasks() {
         return (int) mango.select(MongoReplicationTask.class)
                           .eq(MongoReplicationTask.FAILED, false)
-                          .where(QueryBuilder.FILTERS.gt(MongoReplicationTask.EARLIEST_EXECUTION, LocalDateTime.now()))
+                          .where(QueryBuilder.FILTERS.lt(MongoReplicationTask.EARLIEST_EXECUTION, LocalDateTime.now()))
                           .count();
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -15,6 +15,7 @@ import sirius.kernel.Sirius;
 import sirius.kernel.async.Promise;
 import sirius.kernel.async.Tasks;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Part;
@@ -169,8 +170,8 @@ public class ConversionEngine {
      * @return a promise which will either be fullfilled with the generated file or be failed with an appropriate
      * error message
      */
-    public Promise<FileHandle> performConversion(Blob blob, String variant) {
-        Promise<FileHandle> result = new Promise<>();
+    public Promise<Tuple<FileHandle, Watch>> performConversion(Blob blob, String variant) {
+        Promise<Tuple<FileHandle, Watch>> result = new Promise<>();
 
         tasks.executor(EXECUTOR_STORAGE_CONVERSION).dropOnOverload(() -> {
             result.fail(new IllegalStateException("Conversion subsystem overloaded!"));
@@ -197,7 +198,7 @@ public class ConversionEngine {
                 }
 
                 conversionDuration.addValue(watch.elapsedMillis());
-                result.success(convertedFile);
+                result.success(Tuple.create(convertedFile, watch));
             } catch (Exception e) {
                 result.fail(e);
             }

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -240,9 +240,9 @@ health.limits {
     storage-replication-tasks.error = 0
 
     # Reports the duration of replication tasks executed by this node.
-    storage-replication-tasks.gray = 1
-    storage-replication-tasks.warning = 0
-    storage-replication-tasks.error = 0
+    storage-replication-duration.gray = 1
+    storage-replication-duration.warning = 0
+    storage-replication-duration.error = 0
 
     # Reports the number of conversions executed by this node.
     storage-conversions.gray = 1

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1303,7 +1303,7 @@ async.executor {
     # This executor is used by the storage framework (layer 2) to actually perform the conversion / generation of
     # a variant of a blob.
     storage-conversion {
-        poolSize = 2
+        poolSize = 8
         queueLength = 1024
     }
 }


### PR DESCRIPTION
* The replication task storages now properly compute the executable tasks.
* The conversion engine runs more tasks in parallel and also measures the actual conversion performance properly.
* Some cleanup in the default configs.
* If a Process get terminated due to a system restart, we now mark it as erroneous.

Fixes: SIRI-294