### PR TITLE
Import Handler: smartGet over languages

### DIFF
--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -367,7 +367,7 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
                                       alias);
                 }
 
-                field.addAlias(alias);
+                field.addTranslatedAliases(alias);
             });
         }
 

--- a/src/main/java/sirius/biz/importer/format/FieldDefinition.java
+++ b/src/main/java/sirius/biz/importer/format/FieldDefinition.java
@@ -13,6 +13,7 @@ import sirius.kernel.commons.Value;
 import sirius.kernel.commons.Values;
 import sirius.kernel.nls.NLS;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -288,11 +289,43 @@ public class FieldDefinition {
      * Aliases are used by {@link ImportDictionary#determineMappingFromHeadings(Values, boolean)} to "learn" which
      * field is provided in which column.
      *
-     * @param alias the alias to add
+     * @param alias the alias to add, which will be {@link sirius.kernel.nls.NLS#smartGet(String) auto translated
      * @return the field itself for fluent method calls
      */
     public FieldDefinition addAlias(String alias) {
         aliases.add(NLS.smartGet(alias));
+
+        return this;
+    }
+
+    /**
+     * Adds an alias for the field resolving all available translations.
+     * <p>
+     * Aliases are used by {@link ImportDictionary#determineMappingFromHeadings(Values, boolean)} to "learn" which
+     * field is provided in which column.
+     * <p>
+     * Opposed to {@link #addAlias(String)}, this method resolves all available translations and not only
+     * the one in the current language context.
+     *
+     * @param alias the alias to add, which will be expanced to all available translations
+     * @return the field itself for fluent method calls
+     */
+    public FieldDefinition addTranslatedAliases(@Nonnull String alias) {
+        if (alias.charAt(0) != '$') {
+            aliases.add(alias);
+            return this;
+        }
+
+        NLS.getSupportedLanguages()
+           .stream()
+           .map(lang -> NLS.smartGet(alias, lang))
+           .filter(text -> !text.equals(getLabel()))
+           .filter(text -> !aliases.stream()
+                                   .map(String::toLowerCase)
+                                   .collect(Collectors.toSet())
+                                   .contains(text.toLowerCase()))
+           .distinct()
+           .forEach(aliases::add);
 
         return this;
     }


### PR DESCRIPTION
Adds all defined translations as possible field aliases. This way, defining a single key in the configuration is enough to cope with various headings. Typical scenario: user front end language = de, file to import uses 'en' headers.

Example: this configuration
```
code: [ "$Product.code", "item number", "Nummer", "Article number" ]
```
with keys:
```
de: Product.code = Artikelnummer
en: Product.code = Article number
pl: Product.code = Numer przedmiotu 
```
resolves to (front end = 'de'):
![image](https://user-images.githubusercontent.com/54799255/102487208-7810a580-406a-11eb-8e8b-559ff6e4390c.png)

**Note:** the `Article number` in the sample configuration doesn't cause any harm, but can be removed since a translation for it exists.

Fixes: OX-6355