### PR TITLE
Uses a list query in favor of an iterateAll.

### DIFF
--- a/src/main/java/sirius/biz/analytics/scheduler/BaseEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/BaseEntityBatchEmitter.java
@@ -124,6 +124,6 @@ public abstract class BaseEntityBatchEmitter<I, C extends Constraint, B extends 
             queryExtender.accept(query);
         }
 
-        ((Query<?, E, C>) query).iterateAll(entityConsumer);
+        ((Query<?, E, C>) query).queryList().forEach(entityConsumer);
     }
 }

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
@@ -187,6 +187,7 @@ public class SQLReplicationTaskStorage implements ReplicationTaskStorage {
                 task.setLastExecution(LocalDateTime.now());
                 task.setEarliestExecution(LocalDateTime.now().plus(retryReplicationDelay));
                 task.setFailureCounter(task.getFailureCounter() + 1);
+                task.setScheduled(null);
                 if (task.getFailureCounter() > maxReplicationAttempts) {
                     task.setFailed(true);
                     Exceptions.handle()

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
@@ -194,6 +194,7 @@ public class MongoReplicationTaskStorage implements ReplicationTaskStorage {
                 Updater updater = mongo.update()
                                        .where(MongoReplicationTask.ID, task.getId())
                                        .set(MongoReplicationTask.LAST_EXECUTION, LocalDateTime.now())
+                                       .set(MongoReplicationTask.SCHEDULED, null)
                                        .set(MongoReplicationTask.EARLIEST_EXECUTION,
                                             LocalDateTime.now().plus(retryReplicationDelay))
                                        .inc(MongoReplicationTask.FAILURE_COUNTER, 1);


### PR DESCRIPTION
As a single batch is most probably a "small" and manageable
we prefer this. Otherwise iterateAll might keep a cursor open
(e.g. when targeting MongoDB) which in turn might time out
when our processing takes too long.