### PR TITLE
Fixes the output of a not required SelectStringParameter

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/SelectStringParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/SelectStringParameter.java
@@ -64,9 +64,6 @@ public class SelectStringParameter extends SelectParameter<String, SelectStringP
 
     @Override
     protected Optional<String> resolveFromString(@Nonnull Value input) {
-        if (input.isEmptyString()) {
-            return Optional.empty();
-        }
-        return Optional.of(input.asString());
+        return input.asOptionalString();
     }
 }

--- a/src/main/java/sirius/biz/jobs/params/SelectStringParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/SelectStringParameter.java
@@ -64,6 +64,9 @@ public class SelectStringParameter extends SelectParameter<String, SelectStringP
 
     @Override
     protected Optional<String> resolveFromString(@Nonnull Value input) {
+        if (input.isEmptyString()) {
+            return Optional.empty();
+        }
         return Optional.of(input.asString());
     }
 }


### PR DESCRIPTION
Selecting no value at all was actually delivering an Optional of a blank string and so isPresent() would always return true.