### PR TITLE
Fix the vfs modal when querying big directories

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VFSController.java
+++ b/src/main/java/sirius/biz/storage/layer3/VFSController.java
@@ -277,7 +277,7 @@ public class VFSController extends BizController {
         }
 
         search.withPrefixFilter(ctx.get("filter").asString());
-        search.withLimit(new Limit(0, 1000));
+        search.withLimit(new Limit(0, 100));
         out.beginArray("path");
         for (VirtualFile element : parent.pathList()) {
             out.beginObject("element");


### PR DESCRIPTION
The JSON response of /fs/list is limited to 32k characters, which equates to around 150 files. Anything bigger than this leads to a broken modal. The proper fix for this would be to introduce paging and a search bar. As a quick fix we now limit the number of files to 100.