### PR TITLE
SIRI-315 Prevent lookups in too many entities when a blob is deleted

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
@@ -141,6 +141,10 @@ public class BlobSoftRefProperty extends BlobRefProperty {
     }
 
     protected void onDeleteCascade(Object entity) {
+        if (!Strings.areEqual(blobSoftRef.getSpace(), ((Blob) entity).getSpaceName())) {
+            return;
+        }
+
         TaskContext taskContext = TaskContext.get();
 
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeDelete")
@@ -159,6 +163,10 @@ public class BlobSoftRefProperty extends BlobRefProperty {
     }
 
     protected void onDeleteSetNull(Object entity) {
+        if (!Strings.areEqual(blobSoftRef.getSpace(), ((Blob) entity).getSpaceName())) {
+            return;
+        }
+
         TaskContext taskContext = TaskContext.get();
         taskContext.smartLogLimited(() -> NLS.fmtr("BaseEntityRefProperty.cascadeSetNull")
                                              .set(PARAM_TYPE, getDescriptor().getPluralLabel())

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -783,19 +783,12 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
         }
 
         try {
-            SmartQuery<SQLBlob> deleteQuery = oma.select(SQLBlob.class)
-                                                 .eq(SQLBlob.SPACE_NAME, spaceName)
-                                                 .where(OMA.FILTERS.lt(SQLBlob.LAST_MODIFIED,
-                                                                       LocalDateTime.now().minusDays(retentionDays)))
-                                                 .where(OMA.FILTERS.ltOrEmpty(SQLBlob.LAST_TOUCHED,
-                                                                              LocalDateTime.now()
-                                                                                           .minusDays(retentionDays)));
-            if (isTouchTracking()) {
-                deleteQuery.where(OMA.FILTERS.ltOrEmpty(SQLBlob.LAST_TOUCHED,
-                                                        LocalDateTime.now().minusDays(retentionDays)));
-            }
-
-            deleteQuery.limit(256).delete();
+            oma.select(SQLBlob.class)
+               .eq(SQLBlob.SPACE_NAME, spaceName)
+               .where(OMA.FILTERS.lt(SQLBlob.LAST_MODIFIED, LocalDateTime.now().minusDays(retentionDays)))
+               .where(OMA.FILTERS.ltOrEmpty(SQLBlob.LAST_TOUCHED, LocalDateTime.now().minusDays(retentionDays)))
+               .limit(256)
+               .delete();
         } catch (Exception e) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -785,10 +785,11 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
         try {
             oma.select(SQLBlob.class)
                .eq(SQLBlob.SPACE_NAME, spaceName)
+               .eq(SQLBlob.DELETED, false)
                .where(OMA.FILTERS.lt(SQLBlob.LAST_MODIFIED, LocalDateTime.now().minusDays(retentionDays)))
                .where(OMA.FILTERS.ltOrEmpty(SQLBlob.LAST_TOUCHED, LocalDateTime.now().minusDays(retentionDays)))
                .limit(256)
-               .delete();
+               .iterateAll(this::markBlobAsDeleted);
         } catch (Exception e) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)
@@ -802,10 +803,11 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
         try {
             oma.select(SQLBlob.class)
                .eq(SQLBlob.SPACE_NAME, spaceName)
+               .eq(SQLBlob.DELETED, false)
                .eq(SQLBlob.TEMPORARY, true)
                .where(OMA.FILTERS.lt(SQLBlob.LAST_MODIFIED, LocalDateTime.now().minusHours(4)))
                .limit(256)
-               .delete();
+               .iterateAll(this::markBlobAsDeleted);
         } catch (Exception e) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -719,11 +719,12 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
         try {
             mango.select(MongoBlob.class)
                  .eq(MongoBlob.SPACE_NAME, spaceName)
+                 .eq(MongoBlob.DELETED, false)
                  .where(QueryBuilder.FILTERS.lt(MongoBlob.LAST_MODIFIED, LocalDateTime.now().minusDays(retentionDays)))
                  .where(QueryBuilder.FILTERS.ltOrEmpty(MongoBlob.LAST_TOUCHED,
                                                        LocalDateTime.now().minusDays(retentionDays)))
                  .limit(256)
-                 .delete();
+                 .iterateAll(this::markBlobAsDeleted);
         } catch (Exception e) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)
@@ -737,10 +738,11 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
         try {
             mango.select(MongoBlob.class)
                  .eq(MongoBlob.SPACE_NAME, spaceName)
+                 .eq(MongoBlob.DELETED, false)
                  .eq(MongoBlob.TEMPORARY, true)
                  .where(QueryBuilder.FILTERS.lt(MongoBlob.LAST_MODIFIED, LocalDateTime.now().minusHours(4)))
                  .limit(256)
-                 .delete();
+                 .iterateAll(this::markBlobAsDeleted);
         } catch (Exception e) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)


### PR DESCRIPTION
Every BlobSoftRef adds a cascade delete handler to the Blob entity. If a blob is deleted every handler is executed, disregarding whether the blobRefs and the blobs spaces match. This leads to excessive lookups in the DB.