### PR TITLE
Implement a handler to replace blob:// URIs in PDFs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-20.4</sirius.kernel>
-        <sirius.web>dev-31.6.2</sirius.web>
-        <sirius.db>dev-24.0</sirius.db>
+        <sirius.kernel>dev-20.5</sirius.kernel>
+        <sirius.web>dev-32.0</sirius.web>
+        <sirius.db>dev-24.1</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1639,7 +1639,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * @param variant  the variant of the blob to deliver
      * @param response the response to populate
      */
-    private void delegateConversion(String blobKey, @Nullable String variant, Response response) {
+    private void delegateConversion(String blobKey, String variant, Response response) {
         Optional<URL> url = determineDelegateConversionUrl(blobKey, variant);
 
         if (!url.isPresent()) {

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.storage.layer2;
 
+import sirius.biz.storage.layer1.FileHandle;
 import sirius.biz.storage.layer1.ObjectStorageSpace;
 import sirius.biz.tenants.Tenants;
 import sirius.web.http.Response;
@@ -250,6 +251,16 @@ public interface BlobStorageSpace {
      * @return <tt>true</tt> if this space is readonly, <tt>false</tt> otherwise
      */
     boolean isReadonly();
+
+    /**
+     * Downloads and provides the contents of the requested blob with the given variant.
+     *
+     * @param blobKey the blob key of the blob to download
+     * @param variant the variant of the blob to download. Use {@link URLBuilder#VARIANT_RAW} to download the blob itself
+     * @return a handle to the given object wrapped as optional or an empty one if the object doesn't exist or couldn't
+     * be converted
+     */
+    Optional<FileHandle> download(String blobKey, String variant);
 
     /**
      * Resolves the filename of the given blob.

--- a/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
+++ b/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.web;
+
+import org.xhtmlrenderer.extend.FSImage;
+import org.xhtmlrenderer.extend.UserAgentCallback;
+import sirius.biz.storage.layer1.FileHandle;
+import sirius.biz.storage.layer2.BlobStorage;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Register;
+import sirius.web.templates.pdf.handlers.PdfReplaceHandler;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/**
+ * Responsible for resolving blob:// URIs and resizing the image while maintaining the image ratio.
+ * <p>
+ * The format of the URI needs to match blob://space/variant/blobKey.
+ */
+@Register
+public class BlobPdfReplaceHandler extends PdfReplaceHandler {
+
+    @Part
+    private BlobStorage storage;
+
+    @Override
+    public boolean accepts(String protocol) {
+        return "blob".equals(protocol);
+    }
+
+    @Nullable
+    @Override
+    public FSImage resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight)
+            throws Exception {
+        String[] blobInfo = Strings.split(uri, "://").getSecond().split("/");
+
+        if (blobInfo.length != 3) {
+            throw new IllegalArgumentException("The URI is required to match the format 'blob://space/variant/blobKey'");
+        }
+
+        Optional<FileHandle> fileHandle = storage.getSpace(blobInfo[0]).download(blobInfo[2], blobInfo[1]);
+
+        if (fileHandle.isPresent()) {
+            FSImage image = resolveResource(userAgentCallback, fileHandle.get().getFile().toURI().toURL());
+
+            return resizeImage(image, cssWidth, cssHeight);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
+++ b/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
- * Responsible for resolving blob:// URIs and resizing the image while maintaining the image ratio.
+ * Resolves blob:// URIs to resized images while maintaining the image ratios.
  * <p>
  * The format of the URI needs to match blob://space/variant/blobKey.
  */

--- a/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
+++ b/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
@@ -54,12 +54,14 @@ public class BlobPdfReplaceHandler extends PdfReplaceHandler {
             variant = blobInfo[2];
         }
 
-        Optional<FileHandle> fileHandle = storage.getSpace(blobInfo[0]).download(blobInfo[1], variant);
+        Optional<FileHandle> optionalFileHandle = storage.getSpace(blobInfo[0]).download(blobInfo[1], variant);
 
-        if (fileHandle.isPresent()) {
-            FSImage image = resolveResource(userAgentCallback, fileHandle.get().getFile().toURI().toURL());
+        if (optionalFileHandle.isPresent()) {
+            try (FileHandle fileHandle = optionalFileHandle.get()) {
+                FSImage image = resolveResource(userAgentCallback, fileHandle.getFile().toURI().toURL());
 
-            return resizeImage(image, cssWidth, cssHeight);
+                return resizeImage(image, cssWidth, cssHeight);
+            }
         }
 
         return null;


### PR DESCRIPTION
This can be used instead of referencing the blobs via http in case the server is having problems resolving its own domain.