### PR TITLE
Displays the node state infos sorted by node name

### DIFF
--- a/src/main/java/sirius/biz/cluster/InterconnectClusterManager.java
+++ b/src/main/java/sirius/biz/cluster/InterconnectClusterManager.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -197,6 +198,7 @@ public class InterconnectClusterManager implements ClusterManager, InterconnectH
         }
 
         return callEachNode("/system/cluster/state/" + getClusterAPIToken()).map(this::parseNodeState)
+                                                                            .sorted(Comparator.comparing(NodeInfo::getName))
                                                                             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
This change ensures a constant sorting (as in it doesnt change on every refresh of the page) for the /system/state page, making it much easier to skim by eye.