### PR TITLE
Adds an export button for /system/sql AND fixes a bug concrening default values for jobs.

### DIFF
--- a/src/main/java/sirius/biz/jdbc/DatabaseController.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseController.java
@@ -107,13 +107,13 @@ public class DatabaseController extends BasicController {
                          UserContext.getCurrentUser().getUserName(),
                          sqlStatement);
 
-            if (isDDSStatement(sqlStatement)) {
+            if (isDDLStatement(sqlStatement)) {
                 // To prevent accidential damage, we try to filter DDL queries (modifying the database structure) and
                 // only permit them against our system database.
                 if (!Strings.areEqual(database, defaultDatabase)) {
                     throw Exceptions.createHandled()
                                     .withSystemErrorMessage(
-                                            "Cannot execute a DDS query against this database. This can be only done for '%s'",
+                                            "Cannot execute a DDL statement against this database. This can be only done for '%s'",
                                             database)
                                     .handle();
                 }
@@ -152,8 +152,8 @@ public class DatabaseController extends BasicController {
         String database = webContext.get("db").asString(defaultDatabase);
         String sqlStatement = webContext.get("exportQuery").asString();
 
-        if (isDDSStatement(sqlStatement)) {
-            throw Exceptions.createHandled().withDirectMessage("A DDS statement cannot be exported.").handle();
+        if (isDDLStatement(sqlStatement)) {
+            throw Exceptions.createHandled().withDirectMessage("A DDL statement cannot be exported.").handle();
         } else {
             ExportQueryResultJobFactory jobFactory =
                     jobs.findFactory(ExportQueryResultJobFactory.FACTORY_NAME, ExportQueryResultJobFactory.class);
@@ -195,7 +195,7 @@ public class DatabaseController extends BasicController {
                 "delete");
     }
 
-    private boolean isDDSStatement(String qry) {
+    private boolean isDDLStatement(String qry) {
         String lowerCaseQuery = qry.toLowerCase().trim();
         return lowerCaseQuery.startsWith("alter") || lowerCaseQuery.startsWith("drop") || lowerCaseQuery.startsWith(
                 "create");

--- a/src/main/java/sirius/biz/jdbc/DatabaseController.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseController.java
@@ -55,9 +55,6 @@ public class DatabaseController extends BasicController {
      */
     private static final int DEFAULT_LIMIT = 1000;
 
-    private static final String PARAM_DB = "db";
-    private static final String PARAM_QUERY = "query";
-
     @Part
     private Schema schema;
 
@@ -102,9 +99,9 @@ public class DatabaseController extends BasicController {
         Watch w = Watch.start();
 
         try {
-            String database = ctx.get(PARAM_DB).asString(defaultDatabase);
+            String database = ctx.get("db").asString(defaultDatabase);
             Database db = determineDatabase(database);
-            String sqlStatement = ctx.get(PARAM_QUERY).asString();
+            String sqlStatement = ctx.get("query").asString();
             SQLQuery qry = db.createQuery(sqlStatement).markAsLongRunning();
 
             OMA.LOG.INFO("Executing SQL (via /system/sql, authored by %s): %s",
@@ -152,15 +149,15 @@ public class DatabaseController extends BasicController {
             throw Exceptions.createHandled().withSystemErrorMessage("Unsafe or missing POST detected!").handle();
         }
 
-        String database = ctx.get(PARAM_DB).asString(defaultDatabase);
-        String sqlStatement = ctx.get(PARAM_QUERY).asString();
+        String database = ctx.get("db").asString(defaultDatabase);
+        String sqlStatement = ctx.get("exportQuery").asString();
 
         if (isDDSStatement(sqlStatement)) {
             throw Exceptions.createHandled().withDirectMessage("A DDS statement cannot be exported.").handle();
         } else {
             Map<String, String> params = new HashMap<>();
             params.put("database", database);
-            params.put(PARAM_QUERY, sqlStatement);
+            params.put("query", sqlStatement);
             ExportQueryResultJobFactory jobFactory =
                     jobs.findFactory(ExportQueryResultJobFactory.FACTORY_NAME, ExportQueryResultJobFactory.class);
             String processId = jobFactory.startInBackground(param -> Value.of(params.getOrDefault(param, null)));

--- a/src/main/java/sirius/biz/jdbc/ExportQueryResultJobFactory.java
+++ b/src/main/java/sirius/biz/jdbc/ExportQueryResultJobFactory.java
@@ -21,11 +21,13 @@ import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
 import sirius.web.security.Permission;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.function.Consumer;
 
 /**
@@ -35,8 +37,13 @@ import java.util.function.Consumer;
 @Permission(TenantUserManager.PERMISSION_SYSTEM_ADMINISTRATOR)
 public class ExportQueryResultJobFactory extends LineBasedExportJobFactory {
 
-    private Parameter<Database> databaseParameter = new DatabaseParameter().markRequired().build();
-    private Parameter<String> sqlParameter = new TextareaParameter("query", "Query").markRequired().build();
+    /**
+     * Contains the part-name of this factory.
+     */
+    public static final String FACTORY_NAME = "export-query-result";
+    
+    private final Parameter<Database> databaseParameter = new DatabaseParameter().markRequired().build();
+    private final Parameter<String> sqlParameter = new TextareaParameter("query", "Query").markRequired().build();
 
     private class ExportQueryResultJob extends LineBasedExportJob {
 
@@ -57,7 +64,13 @@ public class ExportQueryResultJobFactory extends LineBasedExportJobFactory {
         @Override
         protected void executeIntoExport() throws Exception {
             Monoflop monoflop = Monoflop.create();
-            db.createQuery(query).iterateAll(row -> exportRow(row, monoflop), Limit.UNLIMITED);
+            try {
+                db.createQuery(query).markAsLongRunning().iterateAll(row -> exportRow(row, monoflop), Limit.UNLIMITED);
+            } catch (SQLException exception) {
+                // In case of an invalid query, we do not want to log this into the syslog but
+                // rather just directly output the message to the user....
+                throw Exceptions.createHandled().error(exception).withDirectMessage(exception.getMessage()).handle();
+            }
         }
 
         private void exportRow(Row row, Monoflop monoflop) {
@@ -105,6 +118,6 @@ public class ExportQueryResultJobFactory extends LineBasedExportJobFactory {
     @Nonnull
     @Override
     public String getName() {
-        return "export-query-result";
+        return FACTORY_NAME;
     }
 }

--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -276,13 +276,14 @@ public abstract class BasicJobFactory implements JobFactory {
         for (Parameter<?> parameter : getParameters()) {
             try {
                 Value contextValue = parameterProvider.apply(parameter.getName());
-                if (enforceRequiredParameters && contextValue.isEmptyString() && parameter.isRequired()) {
+                String value = parameter.checkAndTransform(contextValue);
+                if (enforceRequiredParameters && Strings.isEmpty(value) && parameter.isRequired()) {
                     errorConsumer.accept(Exceptions.createHandled()
                                                    .withNLSKey("Parameter.required")
                                                    .set("name", parameter.getLabel())
                                                    .handle());
                 } else {
-                    String value = parameter.checkAndTransform(contextValue);
+
                     context.put(parameter.getName(), value);
                 }
             } catch (HandledException e) {

--- a/src/main/java/sirius/biz/jobs/batch/file/ExportXLSX.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ExportXLSX.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 public class ExportXLSX implements LineBasedExport {
 
     private final ExcelExport export;
-    private Supplier<OutputStream> outputStreamSupplier;
+    private final Supplier<OutputStream> outputStreamSupplier;
 
     /**
      * Creates a new export which writes to the given output stream.

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -156,6 +156,7 @@ DatabaseController.reason = Grund
 DatabaseController.schema = Datenbank Schema
 DatabaseController.sql = SQL
 DatabaseController.unknownChange = Unbekannte Änderung
+DatabaseController.export = Ergebnis exportieren
 DateRangeParameter.label = Zeitraum
 DateTimeFormatCheck.errorMsg = Der Wert '${value}' entspricht nicht dem Datumsformat '${format}'.
 DateTimeFormatCheck.remark = Datumsformat: ${format}

--- a/src/main/resources/default/templates/biz/model/sql.html.pasta
+++ b/src/main/resources/default/templates/biz/model/sql.html.pasta
@@ -7,13 +7,24 @@
         </li>
     </i:block>
 
-    <w:pageHeader titleKey="DatabaseController.sql"/>
+    <w:pageHeader>
+        <div class="row">
+            <div class="col-md-8">
+                @i18n("DatabaseController.sql")
+            </div>
+            <div class="col-md-4 align-right">
+                <a id="exportBtn" class="btn btn-default" href="#"><i class="fa fa-save"></i> Export</a>
+            </div>
+        </div>
+    </w:pageHeader>
 
     <div class="well">
+        <form id="exportForm" action="/system/sql/export" method="post">
         <div class="row">
             <div class="col-md-10">
                 <div class="input-group">
-                    <input type="text" id="query" class="form-control" placeholder="@i18n('NLS.searchkey')" autofocus />
+                    <input name="CSRFToken" value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken()" type="hidden"/>
+                    <input type="text" id="query" name="query" class="form-control" placeholder="@i18n('NLS.searchkey')" autofocus />
                     <span class="input-group-addon" onclick="execute()"><i class="fa fa-search"></i></span>
                 </div>
             </div>
@@ -23,6 +34,7 @@
                 </i:for>
             </w:singleSelect>
         </div>
+        </form>
     </div>
 
     <table class="table table-striped">
@@ -109,6 +121,14 @@
                 if (e.keyCode === 13) {
                     execute();
                     return false;
+                }
+            });
+
+            $('#exportBtn').click(function() {
+                if ($('#query').val() === "") {
+                    addError("Cannot export empty query");
+                } else {
+                    $('#exportForm').submit();
                 }
             });
         });

--- a/src/main/resources/default/templates/biz/model/sql.html.pasta
+++ b/src/main/resources/default/templates/biz/model/sql.html.pasta
@@ -13,7 +13,9 @@
                 @i18n("DatabaseController.sql")
             </div>
             <div class="col-md-4 align-right">
-                <a id="exportBtn" class="btn btn-default" href="#"><i class="fa fa-save"></i> Export</a>
+                <a id="exportBtn" class="btn btn-default" style="display: none" href="#">
+                    <i class="fa fa-save"></i> @i18n("DatabaseController.export")
+                </a>
             </div>
         </div>
     </w:pageHeader>
@@ -24,6 +26,7 @@
             <div class="col-md-10">
                 <div class="input-group">
                     <input name="CSRFToken" value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken()" type="hidden"/>
+                    <input type="hidden" id="exportQuery" name="exportQuery" />
                     <input type="text" id="query" name="query" class="form-control" placeholder="@i18n('NLS.searchkey')" autofocus />
                     <span class="input-group-addon" onclick="execute()"><i class="fa fa-search"></i></span>
                 </div>
@@ -54,6 +57,9 @@
             var $columns = $('#columns');
             var $rows = $('#rows');
             var $info = $('#info');
+            var exportBtn = $('#exportBtn');
+
+            exportBtn.hide();
             $info.html('');
             $rows.html('<tr><td class="align-center"><i class="fa fa-spin fa-spinner"></i></td></tr>');
             $.getJSON('/system/sql/api/execute',
@@ -69,6 +75,11 @@
                         addError(data.message);
                         return;
                     }
+                    if (data.rows.length > 0) {
+                        $('#exportQuery').val($('#query').val());
+                        exportBtn.show();
+                    }
+
                     if (data.rows !== null && data.rows.length === 1 && data.columns !== null) {
                         outputDetails($rows, data);
                     } else {
@@ -125,7 +136,7 @@
             });
 
             $('#exportBtn').click(function() {
-                if ($('#query').val() === "") {
+                if ($('#exportQuery').val() === "") {
                     addError("Cannot export empty query");
                 } else {
                     $('#exportForm').submit();

--- a/src/main/resources/default/templates/biz/model/sql.html.pasta
+++ b/src/main/resources/default/templates/biz/model/sql.html.pasta
@@ -31,7 +31,7 @@
                     <span class="input-group-addon" onclick="execute()"><i class="fa fa-search"></i></span>
                 </div>
             </div>
-            <w:singleSelect name="db" id="db" span="2">
+            <w:singleSelect name="database" id="db" span="2">
                 <i:for type="String" var="db" items="dbs">
                     <option value="@db" @selected="defaultDB == db">@db</option>
                 </i:for>


### PR DESCRIPTION
If previously a job had a parameter with a default value, we would not pik this up, but rather complain and crash.

Even worse, if a scheduled job exists and is supplied with an addition parameter - for which a default value is provied - the scheduled job still stops working as the value was not picked up.

This has now been fixed.