### PR TITLE
Fixes broken field error markings and uses the right method to add an…

### DIFF
--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -570,7 +570,7 @@ public class BizController extends BasicController {
      */
     protected void handle(Exception exception) {
         if (exception.getCause() instanceof InvalidFieldException) {
-            UserContext.get().signalFieldError(((InvalidFieldException) exception.getCause()).getField());
+            UserContext.get().addFieldError(((InvalidFieldException) exception.getCause()).getField(), "");
         }
 
         UserContext.handle(exception);


### PR DESCRIPTION
… error to the UserContext instead of just asking the context for an existing error.

Small fix, big impact.

Broken:
<img width="1176" alt="broken" src="https://user-images.githubusercontent.com/8539026/109175431-12394c00-7786-11eb-91df-03d7e361e0e8.png">

Fixed:
<img width="1171" alt="fixed" src="https://user-images.githubusercontent.com/8539026/109175434-136a7900-7786-11eb-98e3-39efeb440f56.png">

Fixes: SIRI-333
