### PR TITLE
Multilanguage Field Modal: Adjusts the height of the language options dropup in the surrounding …

### DIFF
--- a/src/main/resources/default/assets/javascript/multiLanguageField.js
+++ b/src/main/resources/default/assets/javascript/multiLanguageField.js
@@ -54,6 +54,15 @@ MultiLanguageField.prototype.buildSingleline = function () {
     }
 
     const me = this;
+
+    this._addLanguageButton.addEventListener('click', function () {
+        let rowCount = me._modalInputs.querySelectorAll('.row').length;
+        const totalRowsHeight = (rowCount * 40) + 100;
+        if (totalRowsHeight) {
+            me._addLanguageOptions.style.maxHeight = totalRowsHeight + 'px';
+        }
+    });
+
     // have to use jquery here as bootstrap modals only trigger jquery events
     $(me._modal).on('hidden.bs.modal', function () {
         me.updateHiddenFields();


### PR DESCRIPTION
…modal based on the available space.

### Before, language option dropup had a fixed height:

<img width="608" alt="siri-334-before-1" src="https://user-images.githubusercontent.com/8539026/109286505-9a6d2f00-7822-11eb-9a92-07f1feedf929.png">

<img width="605" alt="siri-334-before-2" src="https://user-images.githubusercontent.com/8539026/109286511-9c36f280-7822-11eb-9015-f1cf70a9c888.png">

### Now the height of the language option dropup is dynamically set:

<img width="609" alt="siri-334-fixed-1" src="https://user-images.githubusercontent.com/8539026/109286517-9d681f80-7822-11eb-8076-20547db2f361.png">

<img width="602" alt="siri-334-fixed-2" src="https://user-images.githubusercontent.com/8539026/109286516-9d681f80-7822-11eb-8deb-631005a53e45.png">

<img width="604" alt="siri-334-fixed-3" src="https://user-images.githubusercontent.com/8539026/109286513-9ccf8900-7822-11eb-8c38-cd055064b4da.png">


Fixes: SIRI-334