### PR TITLE
Multilanguage field modal: Adjusts the height of the language options dropup in the surrounding …

### DIFF
--- a/src/main/resources/default/assets/javascript/multiLanguageField.js
+++ b/src/main/resources/default/assets/javascript/multiLanguageField.js
@@ -53,7 +53,21 @@ MultiLanguageField.prototype.buildSingleline = function () {
         this._addLanguageOptions.classList.add('dropdown-menu-right');
     }
 
+    this._modalBody = this._modal.querySelector('.modal-body');
+    this._modalContent = this._modal.querySelector('.modal-content');
+
     const me = this;
+    this._addLanguageButton.addEventListener('click', function () {
+        const langOptionCount = me._addLanguageOptions.querySelectorAll('li:not(.hidden)').length;
+        const totalRowsHeight = (langOptionCount * 27);
+        const maxHeight = window.innerHeight - 182;
+
+        if ((me._modalBody.clientHeight < maxHeight) && (totalRowsHeight > me._modalBody.style.height)) {
+            me._modalBody.style.height = (totalRowsHeight - me._modalBody.style.height) + 'px';
+            me._addLanguageOptions.style.maxHeight = totalRowsHeight + 'px';
+        }
+    });
+
     // have to use jquery here as bootstrap modals only trigger jquery events
     $(me._modal).on('hidden.bs.modal', function () {
         me.updateHiddenFields();
@@ -459,7 +473,7 @@ MultiLanguageField.prototype.updateLanguageManagementOptions = function () {
         return;
     }
 
-    let me = this;
+    const me = this;
 
     if (this.multiline) {
         this._multilineContent.querySelectorAll('.tab-pane').forEach(function (_pane) {


### PR DESCRIPTION
…modal based on the available space.

Fixes: SIRI-334

Initial state:
<img width="614" alt="Bildschirmfoto 2021-02-26 um 19 17 11" src="https://user-images.githubusercontent.com/8539026/109339012-4e90a900-7867-11eb-8dbc-927d5bc26a2a.png">

Adjusts modal height to show all available language options:
<img width="606" alt="Bildschirmfoto 2021-02-26 um 19 17 24" src="https://user-images.githubusercontent.com/8539026/109339027-52bcc680-7867-11eb-9469-edf5d9886f63.png">

Modal height will not be expanded again so the add button stays at the same position:
<img width="605" alt="Bildschirmfoto 2021-02-26 um 19 17 33" src="https://user-images.githubusercontent.com/8539026/109339042-56e8e400-7867-11eb-8256-b468605750fb.png">
