### PR TITLE
Corrects NLS property name to actually see the progress while the ext…

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -197,7 +197,7 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
     private void updateState(ExtractedFile extractedFile) {
         TaskContext taskContext = TaskContext.get();
         if (taskContext.shouldUpdateState().check()) {
-            taskContext.setState(NLS.fmtr("$ExtractArchiveJob.progress")
+            taskContext.setState(NLS.fmtr("ExtractArchiveJob.progress")
                                     .set("progress", extractedFile.getProgressInPercent().toPercentString())
                                     .format());
         }


### PR DESCRIPTION
…raction of bigger archives happens.

Fixes: OX-6245

<img width="879" alt="fix" src="https://user-images.githubusercontent.com/8539026/109680576-edc1e300-7b7c-11eb-9141-755f3e3121ce.png">
<img width="869" alt="finish" src="https://user-images.githubusercontent.com/8539026/109680817-2792e980-7b7d-11eb-8b71-0e15c4b7cb1c.png">
