### PR TITLE
Multilanguage field modal: Adjusts the height of the modal and the language options

### DIFF
--- a/src/main/resources/default/assets/javascript/multiLanguageField.js
+++ b/src/main/resources/default/assets/javascript/multiLanguageField.js
@@ -59,11 +59,12 @@ MultiLanguageField.prototype.buildSingleline = function () {
     const me = this;
     this._addLanguageButton.addEventListener('click', function () {
         const langOptionCount = me._addLanguageOptions.querySelectorAll('li:not(.hidden)').length;
-        const totalRowsHeight = (langOptionCount * 27);
-        const maxHeight = window.innerHeight - 182;
+        // 12px are reserved for border and padding of the language selection menu
+        const totalRowsHeight = (langOptionCount * 27) + 12;
 
-        if ((me._modalBody.clientHeight < maxHeight) && (totalRowsHeight > me._modalBody.style.height)) {
-            me._modalBody.style.height = (totalRowsHeight - me._modalBody.style.height) + 'px';
+        if (totalRowsHeight > me._modalBody.clientHeight) {
+            me._addLanguageOptions.style.maxHeight = me._modalBody.clientHeight + 'px';
+        } else {
             me._addLanguageOptions.style.maxHeight = totalRowsHeight + 'px';
         }
     });

--- a/src/main/resources/default/assets/stylesheets/multiLanguageField.scss
+++ b/src/main/resources/default/assets/stylesheets/multiLanguageField.scss
@@ -5,6 +5,7 @@ input.form-control.mls-input {
 .mls-modal {
   .modal-body {
     max-height: calc(100vh - 182px);
+    min-height: 250px;
     overflow: auto;
   }
 


### PR DESCRIPTION
The modal now opens with a fixed height, which could fit 5 input fields:
![Bildschirmfoto 2021-03-08 um 15 54 50](https://user-images.githubusercontent.com/42942954/110341382-8eefe400-802a-11eb-85a2-f07f76bcf199.png)

The selection menu only uses the available space:
![Bildschirmfoto 2021-03-08 um 15 55 08](https://user-images.githubusercontent.com/42942954/110341452-a202b400-802a-11eb-83fc-33de79a523fc.png)

And it renders without the need to scroll when possible:
![Bildschirmfoto 2021-03-08 um 15 56 57](https://user-images.githubusercontent.com/42942954/110341518-b34bc080-802a-11eb-84aa-5e50ef866ffc.png)


Fixes: SIRI-334