### PR TITLE
Prevents error when transforming force failed query to page

### DIFF
--- a/src/main/java/sirius/biz/web/MongoPageHelper.java
+++ b/src/main/java/sirius/biz/web/MongoPageHelper.java
@@ -236,7 +236,9 @@ public class MongoPageHelper<E extends MongoEntity>
 
     @Override
     protected void fillPage(Watch w, Page<E> result, List<E> items) {
-        baseQuery.executeFacets();
+        if (!baseQuery.isForceFail()) {
+            baseQuery.executeFacets();
+        }
         super.fillPage(w, result, items);
     }
 


### PR DESCRIPTION
Force failing a query can be done to simplify logic that should not present a query result in some conditions. Facets can not be executed on a failed query and doing so results in an exception. When using the PageHelper to transforming a query into a Page for displaying it in a template we therefore should skip executing the facets when the query is marked as force failed.

Fixes: OX-6685