### PR TITLE
Outputs the translated value for CodeListEntries again

### DIFF
--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -205,20 +205,15 @@ public class MultiLanguageStringProperty extends BaseMapProperty
     @SuppressWarnings("unchecked")
     protected Object transformFromMongo(Value object) {
         Map<String, String> texts = new LinkedHashMap<>();
-
         Object valueObject = object.get();
-        if (valueObject == null) {
-            return texts;
-        }
         if (valueObject instanceof String) {
             texts.put(MultiLanguageString.FALLBACK_KEY, valueObject.toString());
-            return texts;
-        }
-
-        for (Document document : (List<Document>) valueObject) {
-            Object textValue = document.get(TEXT_PROPERTY);
-            if (textValue != null) {
-                texts.put(document.get(LANGUAGE_PROPERTY).toString(), textValue.toString());
+        } else if (valueObject instanceof List) {
+            for (Document document : (List<Document>) valueObject) {
+                Object textValue = document.get(TEXT_PROPERTY);
+                if (textValue != null) {
+                    texts.put(document.get(LANGUAGE_PROPERTY).toString(), textValue.toString());
+                }
             }
         }
         return texts;

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -205,7 +205,17 @@ public class MultiLanguageStringProperty extends BaseMapProperty
     @SuppressWarnings("unchecked")
     protected Object transformFromMongo(Value object) {
         Map<String, String> texts = new LinkedHashMap<>();
-        for (Document document : (List<Document>) object.get()) {
+
+        Object valueObject = object.get();
+        if (valueObject == null) {
+            return texts;
+        }
+        if (valueObject instanceof String) {
+            texts.put(MultiLanguageString.FALLBACK_KEY, valueObject.toString());
+            return texts;
+        }
+
+        for (Document document : (List<Document>) valueObject) {
             Object textValue = document.get(TEXT_PROPERTY);
             if (textValue != null) {
                 texts.put(document.get(LANGUAGE_PROPERTY).toString(), textValue.toString());

--- a/src/main/resources/default/taglib/w/codelistMultiSelect.html.pasta
+++ b/src/main/resources/default/taglib/w/codelistMultiSelect.html.pasta
@@ -21,7 +21,7 @@
            items="@Injector.context().getPart(CodeLists.class).getEntries(list)">
         <option value="@entry.getCodeListEntryData().getCode()"
                 @selected="value.contains(entry.getCodeListEntryData().getCode())">
-            @entry.getCodeListEntryData().getValue()
+            @entry.getCodeListEntryData().getTranslatedValue(NLS.getCurrentLang())
         </option>
     </i:for>
 </w:multiSelect>

--- a/src/main/resources/default/taglib/w/codelistSelect.html.pasta
+++ b/src/main/resources/default/taglib/w/codelistSelect.html.pasta
@@ -19,7 +19,7 @@
     <i:for var="entry" type="sirius.biz.codelists.CodeListEntry" items="@Injector.context().getPart(CodeLists.class).getEntries(list)">
         <option value="@entry.getCodeListEntryData().getCode()"
                 @selected="entry.getCodeListEntryData().getCode().equals(value)">
-            @entry.getCodeListEntryData().getValue()
+            @entry.getCodeListEntryData().getTranslatedValue(NLS.getCurrentLang())
         </option>
     </i:for>
 </w:singleSelect>

--- a/src/main/resources/default/templates/biz/jobs/params/codelistentry.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/params/codelistentry.html.pasta
@@ -9,6 +9,8 @@
                 optional="@!param.isRequired()"
                 required="@param.isRequired()">
     <i:for var="value" type="sirius.biz.codelists.CodeListEntry" items="@param.as(sirius.biz.jobs.params.CodeListEntryParameter.class).getValues()">
-        <option value="@value.getCodeListEntryData().getCode()" @selected="value == param.get(context).orElse(null)">@value.getCodeListEntryData().getValue()</option>
+        <option value="@value.getCodeListEntryData().getCode()" @selected="value == param.get(context).orElse(null)">
+            @value.getCodeListEntryData().getTranslatedValue(NLS.getCurrentLang())
+        </option>
     </i:for>
 </w:singleSelect>


### PR DESCRIPTION
to prevent list entries like `$Country.de`

Fixes: OX-6731