### PR TITLE
Fixes Im- and Export of CodeLists

### DIFF
--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListEntryImportHandler.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListEntryImportHandler.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.codelists.jdbc;
 
+import sirius.biz.codelists.CodeListEntry;
 import sirius.biz.codelists.CodeListEntryData;
 import sirius.biz.importer.ImportHandler;
 import sirius.biz.importer.ImportHandlerFactory;
@@ -19,6 +20,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -52,6 +54,18 @@ public class SQLCodeListEntryImportHandler extends SQLEntityImportHandler<SQLCod
      */
     protected SQLCodeListEntryImportHandler(Class<?> clazz, ImporterContext context) {
         super(clazz, context);
+    }
+
+    @Override
+    public Function<? super SQLCodeListEntry, ?> createExtractor(String fieldToExport) {
+        if (fieldToExport.equals(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.VALUE).getName())) {
+            return codeListEntry -> codeListEntry.getCodeListEntryData().getValue().getFallback();
+        }
+        if (fieldToExport.equals(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.ADDITIONAL_VALUE)
+                                                                   .getName())) {
+            return codeListEntry -> codeListEntry.getCodeListEntryData().getAdditionalValue().getFallback();
+        }
+        return super.createExtractor(fieldToExport);
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListExportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListExportJobFactory.java
@@ -18,7 +18,6 @@ import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.ProcessLink;
 import sirius.db.jdbc.SmartQuery;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 import sirius.web.security.Permission;
@@ -50,12 +49,17 @@ public class SQLCodeListExportJobFactory
     }
 
     @Override
+    protected String createProcessTitle(Map<String, String> context) {
+        return super.createProcessTitle(context) + codeListParameter.get(context)
+                                                                    .map(codeList -> " - " + codeList.getCodeListData()
+                                                                                                     .getName())
+                                                                    .orElse("");
+    }
+
+    @Override
     protected void executeTask(ProcessContext process) throws Exception {
         process.addLink(new ProcessLink().withLabel("$CodeList")
                                          .withUri("/code-list/" + process.require(codeListParameter).getIdAsString()));
-        process.updateTitle(Strings.apply("%s - %s",
-                                          process.getTitle(),
-                                          process.require(codeListParameter).getCodeListData().getName()));
         super.executeTask(process);
     }
 

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListExportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListExportJobFactory.java
@@ -16,7 +16,9 @@ import sirius.biz.jobs.batch.file.EntityExportJobFactory;
 import sirius.biz.jobs.params.CodeListParameter;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
+import sirius.biz.process.ProcessLink;
 import sirius.db.jdbc.SmartQuery;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 import sirius.web.security.Permission;
@@ -45,6 +47,16 @@ public class SQLCodeListExportJobFactory
     @Override
     protected Class<SQLCodeListEntry> getExportType() {
         return SQLCodeListEntry.class;
+    }
+
+    @Override
+    protected void executeTask(ProcessContext process) throws Exception {
+        process.addLink(new ProcessLink().withLabel("$CodeList")
+                                         .withUri("/code-list/" + process.require(codeListParameter).getIdAsString()));
+        process.updateTitle(Strings.apply("%s - %s",
+                                          process.getTitle(),
+                                          process.require(codeListParameter).getCodeListData().getName()));
+        super.executeTask(process);
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListImportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListImportJobFactory.java
@@ -18,7 +18,6 @@ import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.ProcessLink;
 import sirius.db.mixing.BaseEntity;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 import sirius.web.security.Permission;
@@ -49,12 +48,17 @@ public class SQLCodeListImportJobFactory extends EntityImportJobFactory {
     }
 
     @Override
+    protected String createProcessTitle(Map<String, String> context) {
+        return super.createProcessTitle(context) + codeListParameter.get(context)
+                                                                    .map(codeList -> " - " + codeList.getCodeListData()
+                                                                                                     .getName())
+                                                                    .orElse("");
+    }
+
+    @Override
     protected void executeTask(ProcessContext process) throws Exception {
         process.addLink(new ProcessLink().withLabel("$CodeList")
                                          .withUri("/code-list/" + process.require(codeListParameter).getIdAsString()));
-        process.updateTitle(Strings.apply("%s - %s",
-                                          process.getTitle(),
-                                          process.require(codeListParameter).getCodeListData().getName()));
         super.executeTask(process);
     }
 

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListImportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListImportJobFactory.java
@@ -16,7 +16,9 @@ import sirius.biz.jobs.batch.file.EntityImportJobFactory;
 import sirius.biz.jobs.params.CodeListParameter;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
+import sirius.biz.process.ProcessLink;
 import sirius.db.mixing.BaseEntity;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 import sirius.web.security.Permission;
@@ -44,6 +46,16 @@ public class SQLCodeListImportJobFactory extends EntityImportJobFactory {
     @Override
     protected Class<? extends BaseEntity<?>> getImportType() {
         return SQLCodeListEntry.class;
+    }
+
+    @Override
+    protected void executeTask(ProcessContext process) throws Exception {
+        process.addLink(new ProcessLink().withLabel("$CodeList")
+                                         .withUri("/code-list/" + process.require(codeListParameter).getIdAsString()));
+        process.updateTitle(Strings.apply("%s - %s",
+                                          process.getTitle(),
+                                          process.require(codeListParameter).getCodeListData().getName()));
+        super.executeTask(process);
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntryImportHandler.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntryImportHandler.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.codelists.mongo;
 
+import sirius.biz.codelists.CodeListEntry;
 import sirius.biz.codelists.CodeListEntryData;
 import sirius.biz.importer.ImportHandler;
 import sirius.biz.importer.ImportHandlerFactory;
@@ -20,6 +21,7 @@ import sirius.kernel.di.std.Register;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * Provides an import handler for {@link MongoCodeListEntry code list entries}.
@@ -51,6 +53,18 @@ public class MongoCodeListEntryImportHandler extends MongoEntityImportHandler<Mo
      */
     protected MongoCodeListEntryImportHandler(Class<?> clazz, ImporterContext context) {
         super(clazz, context);
+    }
+
+    @Override
+    public Function<? super MongoCodeListEntry, ?> createExtractor(String fieldToExport) {
+        if (fieldToExport.equals(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.VALUE).getName())) {
+            return codeListEntry -> codeListEntry.getCodeListEntryData().getValue().getFallback();
+        }
+        if (fieldToExport.equals(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.ADDITIONAL_VALUE)
+                                                                   .getName())) {
+            return codeListEntry -> codeListEntry.getCodeListEntryData().getAdditionalValue().getFallback();
+        }
+        return super.createExtractor(fieldToExport);
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListExportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListExportJobFactory.java
@@ -16,7 +16,9 @@ import sirius.biz.jobs.batch.file.EntityExportJobFactory;
 import sirius.biz.jobs.params.CodeListParameter;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
+import sirius.biz.process.ProcessLink;
 import sirius.db.mongo.MongoQuery;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 import sirius.web.security.Permission;
@@ -45,6 +47,16 @@ public class MongoCodeListExportJobFactory
     @Override
     protected Class<MongoCodeListEntry> getExportType() {
         return MongoCodeListEntry.class;
+    }
+
+    @Override
+    protected void executeTask(ProcessContext process) throws Exception {
+        process.addLink(new ProcessLink().withLabel("$CodeList")
+                                         .withUri("/code-list/" + process.require(codeListParameter).getIdAsString()));
+        process.updateTitle(Strings.apply("%s - %s",
+                                          process.getTitle(),
+                                          process.require(codeListParameter).getCodeListData().getName()));
+        super.executeTask(process);
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListExportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListExportJobFactory.java
@@ -18,7 +18,6 @@ import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.ProcessLink;
 import sirius.db.mongo.MongoQuery;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 import sirius.web.security.Permission;
@@ -50,12 +49,17 @@ public class MongoCodeListExportJobFactory
     }
 
     @Override
+    protected String createProcessTitle(Map<String, String> context) {
+        return super.createProcessTitle(context) + codeListParameter.get(context)
+                                                                    .map(codeList -> " - " + codeList.getCodeListData()
+                                                                                                     .getName())
+                                                                    .orElse("");
+    }
+
+    @Override
     protected void executeTask(ProcessContext process) throws Exception {
         process.addLink(new ProcessLink().withLabel("$CodeList")
                                          .withUri("/code-list/" + process.require(codeListParameter).getIdAsString()));
-        process.updateTitle(Strings.apply("%s - %s",
-                                          process.getTitle(),
-                                          process.require(codeListParameter).getCodeListData().getName()));
         super.executeTask(process);
     }
 

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListImportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListImportJobFactory.java
@@ -16,7 +16,9 @@ import sirius.biz.jobs.batch.file.EntityImportJobFactory;
 import sirius.biz.jobs.params.CodeListParameter;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
+import sirius.biz.process.ProcessLink;
 import sirius.db.mixing.BaseEntity;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 import sirius.web.security.Permission;
@@ -47,6 +49,16 @@ public class MongoCodeListImportJobFactory extends EntityImportJobFactory {
     @Override
     protected Class<? extends BaseEntity<?>> getImportType() {
         return MongoCodeListEntry.class;
+    }
+
+    @Override
+    protected void executeTask(ProcessContext process) throws Exception {
+        process.addLink(new ProcessLink().withLabel("$CodeList")
+                                         .withUri("/code-list/" + process.require(codeListParameter).getIdAsString()));
+        process.updateTitle(Strings.apply("%s - %s",
+                                          process.getTitle(),
+                                          process.require(codeListParameter).getCodeListData().getName()));
+        super.executeTask(process);
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListImportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListImportJobFactory.java
@@ -18,7 +18,6 @@ import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.ProcessLink;
 import sirius.db.mixing.BaseEntity;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 import sirius.web.security.Permission;
@@ -52,12 +51,17 @@ public class MongoCodeListImportJobFactory extends EntityImportJobFactory {
     }
 
     @Override
+    protected String createProcessTitle(Map<String, String> context) {
+        return super.createProcessTitle(context) + codeListParameter.get(context)
+                                                                    .map(codeList -> " - " + codeList.getCodeListData()
+                                                                                                     .getName())
+                                                                    .orElse("");
+    }
+
+    @Override
     protected void executeTask(ProcessContext process) throws Exception {
         process.addLink(new ProcessLink().withLabel("$CodeList")
                                          .withUri("/code-list/" + process.require(codeListParameter).getIdAsString()));
-        process.updateTitle(Strings.apply("%s - %s",
-                                          process.getTitle(),
-                                          process.require(codeListParameter).getCodeListData().getName()));
         super.executeTask(process);
     }
 

--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -324,7 +324,9 @@ public class MultiLanguageString extends SafeMap<String, String> {
     @Override
     public void setData(Map<String, String> newData) {
         // remove keys with null values first
-        super.setData(newData.entrySet()
+        super.setData(newData == null ?
+                      Collections.emptyMap() :
+                      newData.entrySet()
                              .stream()
                              .filter(entry -> entry.getValue() != null)
                              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));

--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -323,10 +323,13 @@ public class MultiLanguageString extends SafeMap<String, String> {
 
     @Override
     public void setData(Map<String, String> newData) {
+        if (newData == null) {
+            super.setData(Collections.emptyMap());
+            return;
+        }
+
         // remove keys with null values first
-        super.setData(newData == null ?
-                      Collections.emptyMap() :
-                      newData.entrySet()
+        super.setData(newData.entrySet()
                              .stream()
                              .filter(entry -> entry.getValue() != null)
                              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));

--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -324,7 +324,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     @Override
     public void setData(Map<String, String> newData) {
         if (newData == null) {
-            super.setData(Collections.emptyMap());
+            this.clear();
             return;
         }
 

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -40,6 +40,7 @@ import java.lang.reflect.Modifier;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -338,5 +339,13 @@ public class MultiLanguageStringProperty extends BaseMapProperty
     public void parseValues(Object entity, Values values) {
         MultiLanguageString multiLanguageString = getMultiLanguageString(entity);
         multiLanguageString.setFallback(values.at(0).getString());
+    }
+
+    @Override
+    protected void setValueToField(Object value, Object target) {
+        if (value instanceof String) {
+            value = Collections.singletonMap(MultiLanguageString.FALLBACK_KEY, value.toString());
+        }
+        super.setValueToField(value, target);
     }
 }


### PR DESCRIPTION
- Fixes some errors induced by existing MongoCodeLists
- Exports only the fallback of value and additionalValue instead of dumping the entire MultiLanguageString, so we output `value` in the export instead of `{"fallback" : "value"}`.
-> we should probably revisit supporting multiple languages soon (see #881)

Fixes: OX-6731