### PR TITLE
Fixes context and language initialization

### DIFF
--- a/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
@@ -103,24 +103,24 @@ public class DistributedTasks implements MetricProvider {
     /**
      * Contains the concurrency tokens which limit the parallelism of one or more queues.
      */
-    private Map<String, Semaphore> concurrencyTokens = new ConcurrentHashMap<>();
+    private final Map<String, Semaphore> concurrencyTokens = new ConcurrentHashMap<>();
 
     /**
      * Contains the index of the queue in {@link #sortedTaskQueues} to pull work from.
      * <p>
      * Work is pulled in a round-robin fasion and this index contains the next queue to try to poll.
      */
-    private AtomicInteger nextQueueToFetchWorkFrom = new AtomicInteger(0);
+    private final AtomicInteger nextQueueToFetchWorkFrom = new AtomicInteger(0);
 
     /**
      * Contains all FIFO queues by their name.
      */
-    private Map<String, FifoQueue> fifos = new ConcurrentHashMap<>();
+    private final Map<String, FifoQueue> fifos = new ConcurrentHashMap<>();
 
     /**
      * Contains all prioritized queues by their name.
      */
-    private Map<String, PrioritizedQueue> prioritizedQueues = new ConcurrentHashMap<>();
+    private final Map<String, PrioritizedQueue> prioritizedQueues = new ConcurrentHashMap<>();
 
     /**
      * Contains the counters for each penalty token used by prioritized queues.

--- a/src/main/java/sirius/biz/cluster/work/WorkLoaderLoop.java
+++ b/src/main/java/sirius/biz/cluster/work/WorkLoaderLoop.java
@@ -44,7 +44,7 @@ public class WorkLoaderLoop extends BackgroundLoop {
     @Part
     private DistributedTasks distributedTasks;
 
-    private Lock schedulerLock = new ReentrantLock();
+    private final Lock schedulerLock = new ReentrantLock();
 
     @Nonnull
     @Override

--- a/src/main/java/sirius/biz/cluster/work/WorkLoaderLoop.java
+++ b/src/main/java/sirius/biz/cluster/work/WorkLoaderLoop.java
@@ -11,6 +11,7 @@ package sirius.biz.cluster.work;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.AsyncExecutor;
 import sirius.kernel.async.BackgroundLoop;
+import sirius.kernel.async.CallContext;
 import sirius.kernel.async.Tasks;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
@@ -69,6 +70,7 @@ public class WorkLoaderLoop extends BackgroundLoop {
         while (executor.getQueue().isEmpty() && executor.getActiveCount() < executor.getMaximumPoolSize()) {
             Optional<DistributedTasks.DistributedTask> work = distributedTasks.fetchWork();
             if (work.isPresent()) {
+                CallContext.initialize();
                 executor.submit(() -> executeWork(work.get()));
                 tasksScheduled++;
             } else {
@@ -94,6 +96,7 @@ public class WorkLoaderLoop extends BackgroundLoop {
     }
 
     private void executeWork(DistributedTasks.DistributedTask work) {
+        CallContext.initialize();
         work.execute();
         scheduleNextWork();
     }

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -721,12 +721,14 @@ public class Processes {
         taskContext.setAdapter(env);
         try {
             if (env.isActive()) {
+                CallContext.getCurrent().resetLang();
                 installUserOfProcess(userContext, env);
                 task.accept(env);
             }
         } catch (Exception e) {
             throw env.handle(e);
         } finally {
+            CallContext.getCurrent().resetLang();
             taskContext.setAdapter(taskContextAdapterBackup);
             userContext.setCurrentUser(userInfoBackup);
             if (complete) {

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -269,40 +269,64 @@ health.limits {
 
 }
 
+# Specifies thread pools used by the biz platform
 async {
+    executor {
     # Defines the maximal number of concurrent tasks executed for the
     # Distributed Tasks framework.
-    executor.distributed-tasks {
-        poolSize = 8
+        distributed-tasks {
+            poolSize = 8
 
-        # Having a queue would be pointless, as the WorkLoaderLoop only
-        # tries to keep the available executors running but will not
-        # schedule additional work.
-        queueLength = 0
-    }
+            # Having a queue would be pointless, as the WorkLoaderLoop only
+            # tries to keep the available executors running but will not
+            # schedule additional work.
+            queueLength = 0
+        }
 
-    # Interctive jobs should actually execute quite instantly. Therefore
-    # we only permit a low parallelism but a certain queue length for peak loads.
-    executor.interactive-jobs {
-        poolSize = 2
-        queueLength = 100
-    }
+        # Interctive jobs should actually execute quite instantly. Therefore
+        # we only permit a low parallelism but a certain queue length for peak loads.
+        interactive-jobs {
+            poolSize = 2
+            queueLength = 100
+        }
 
-    # Used to handle all OpenSearch requests in Tycho. As this is quite a database intense
-    # task, we pick quite a small number here but provide a queue to provide some backlog.
-    # When worse comes to worst, we handle a failure gracefully and show the user an overload
-    # hint.
-    executor.tycho-open-search {
-        poolSize = 2
-        queueLength = 32
-    }
+        # Used to handle all OpenSearch requests in Tycho. As this is quite a database intense
+        # task, we pick quite a small number here but provide a queue to provide some backlog.
+        # When worse comes to worst, we handle a failure gracefully and show the user an overload
+        # hint.
+        tycho-open-search {
+            poolSize = 2
+            queueLength = 32
+        }
 
-    # Executes the search tasks per provider. As some providers are faster than others, we provide a
-    # bit more parallelism here. If this thread pool is exhausted, the tasks will be handled in the
-    # tycho-open-search pool directly so that a proper back pressure is applied.
-    executor.tycho-open-search-task {
-        poolSize = 4
-        queueLength = 32
+        # Executes the search tasks per provider. As some providers are faster than others, we provide a
+        # bit more parallelism here. If this thread pool is exhausted, the tasks will be handled in the
+        # tycho-open-search pool directly so that a proper back pressure is applied.
+        tycho-open-search-task {
+            poolSize = 4
+            queueLength = 32
+        }
+
+        # This work queue is shared by all transfer managers across all object stores and
+        # used for multipart up- and downloads.
+        s3 {
+            poolSize = 10
+            queueLength = 0
+        }
+
+        # This executor collects all requests which are served via the storage framework. These requests might
+        # be blocked as we might need to wait for a conversion to finish.
+        storage-conversion-delivery {
+            poolSize = 16
+            queueLength = 128
+        }
+
+        # This executor is used by the storage framework (layer 2) to actually perform the conversion / generation of
+        # a variant of a blob.
+        storage-conversion {
+            poolSize = 8
+            queueLength = 1024
+        }
     }
 
     distributed {
@@ -1313,30 +1337,6 @@ cache {
     jupiter-local-large {
         maxSize = 512
         ttl = 1 hour
-    }
-}
-
-# Specifies thread pools used by the biz platform
-async.executor {
-    # This work queue is shared by all transfer managers across all object stores and
-    # used for multipart up- and downloads.
-    s3 {
-        poolSize = 10
-        queueLength = 0
-    }
-
-    # This executor collects all requests which are served via the storage framework. These requests might
-    # be blocked as we might need to wait for a conversion to finish.
-    storage-conversion-delivery {
-        poolSize = 16
-        queueLength = 128
-    }
-
-    # This executor is used by the storage framework (layer 2) to actually perform the conversion / generation of
-    # a variant of a blob.
-    storage-conversion {
-        poolSize = 8
-        queueLength = 1024
     }
 }
 


### PR DESCRIPTION
The language was being initialized once inside a thread of the thread-pool's context and further used by future tasks running on it.

Fixes: OX-6752