### PR TITLE
BREAKING: Changes the index settings for AuditLogEntries for deduplic…

### DIFF
--- a/src/main/java/sirius/biz/protocol/AuditLogEntry.java
+++ b/src/main/java/sirius/biz/protocol/AuditLogEntry.java
@@ -116,7 +116,6 @@ public class AuditLogEntry extends SearchableEntity {
     public static final Mapping MESSAGE = Mapping.named("message");
     @NullAllowed
     @SearchContent
-    @IndexMode(indexed = ESOption.FALSE, docValues = ESOption.FALSE)
     private String message;
 
     public LocalDateTime getTimestamp() {


### PR DESCRIPTION
…ation.

The "message" field actually contains just the NLS key used to
translate the message. Therefore we can safely index this field
(which is required to de-duplicate positive entries).

Note that due to an index settings change, one must use the
"Re-Index Elasticseach Entity " and " Move Elasticsearch Index Alias"
jobs to fix this.

The first job will output the index name:
![grafik](https://user-images.githubusercontent.com/875799/112357527-e8653d80-8ccf-11eb-843d-5f2b700ed060.png)

This has to be supplied to the second job (both need to run on AuditLogEntry) in order
to complete this task.