### PR TITLE
Tracks the login in the UserAccount when accessing FTP/SSH

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -175,18 +175,20 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
     private static final String REMOVE_BY_TENANT_UNIQUE_NAME = "tenant-unique-name";
 
     protected static Cache<String, Tuple<Set<String>, String>> rolesCache =
-            CacheManager.<Tuple<Set<String>, String>>createCoherentCache("tenants-roles").addRemover(
-                    REMOVE_BY_TENANT_UNIQUE_NAME,
-                    (uniqueTenantName, entry) -> Strings.areEqual(uniqueTenantName, entry.getValue().getSecond()));
+            CacheManager.<Tuple<Set<String>, String>>createCoherentCache("tenants-roles")
+                        .addRemover(REMOVE_BY_TENANT_UNIQUE_NAME,
+                                    (uniqueTenantName, entry) -> Strings.areEqual(uniqueTenantName,
+                                                                                  entry.getValue().getSecond()));
 
     protected static Cache<String, UserAccount<?, ?>> userAccountCache =
             CacheManager.createCoherentCache("tenants-users");
     protected static Cache<String, Tenant<?>> tenantsCache = CacheManager.createCoherentCache("tenants-tenants");
 
     protected static Cache<String, Tuple<UserSettings, String>> configCache =
-            CacheManager.<Tuple<UserSettings, String>>createCoherentCache("tenants-configs").addRemover(
-                    REMOVE_BY_TENANT_UNIQUE_NAME,
-                    (uniqueTenantName, entry) -> Strings.areEqual(uniqueTenantName, entry.getValue().getSecond()));
+            CacheManager.<Tuple<UserSettings, String>>createCoherentCache("tenants-configs")
+                        .addRemover(REMOVE_BY_TENANT_UNIQUE_NAME,
+                                    (uniqueTenantName, entry) -> Strings.areEqual(uniqueTenantName,
+                                                                                  entry.getValue().getSecond()));
 
     protected TenantUserManager(ScopeInfo scope, Extension config) {
         super(scope, config);
@@ -764,7 +766,13 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         recordLogin(user, true);
     }
 
-    protected abstract void recordLogin(UserInfo user, boolean external);
+    /**
+     * Actually tracks the login of the user in the account entity.
+     *
+     * @param user     the user which logged in
+     * @param external whether or not the login was from an external source (e.g. via SAML)
+     */
+    public abstract void recordLogin(UserInfo user, boolean external);
 
     @Override
     protected U getUserObject(UserInfo userInfo) {

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantUserManager.java
@@ -58,7 +58,7 @@ public class SQLTenantUserManager extends TenantUserManager<Long, SQLTenant, SQL
     }
 
     @Override
-    protected void recordLogin(UserInfo user, boolean external) {
+    public void recordLogin(UserInfo user, boolean external) {
         try {
             SQLUserAccount account = getUserObject(user);
 

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantUserManager.java
@@ -61,7 +61,7 @@ public class MongoTenantUserManager extends TenantUserManager<String, MongoTenan
     }
 
     @Override
-    protected void recordLogin(UserInfo user, boolean external) {
+    public void recordLogin(UserInfo user, boolean external) {
         try {
             MongoUserAccount account = getUserObject(user);
 


### PR DESCRIPTION
This updates the login information of the user account (last login date and number of logins counter) when a user logs in via FTP/SFTP/FTPS. This needs to be done as some user accounts can only access the system via those means and not via the web interface.

Fixes: SIRI-342