### PR TITLE
Ensures the login is recorded everytime findUserByCredentials is called

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -639,6 +639,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         LoginData loginData = account.getUserAccountData().getLogin();
         if (acceptApiTokens && checkApiToken(loginData, password)) {
             completeAuditLogForUser(auditLog.neutral("AuditLog.apiTokenLogin"), account);
+            recordLogin(result, false);
             return result;
         }
 
@@ -653,6 +654,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
                 return rehashingResult.get();
             }
 
+            recordLogin(result, false);
             return result;
         }
 
@@ -750,7 +752,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
 
     @Override
     protected void recordUserLogin(WebContext ctx, UserInfo user) {
-        recordLogin(user, false);
+        // Ignored, as findUserByCredentials already records all logins.
     }
 
     /**


### PR DESCRIPTION
This method is sometimes used in other authenticating places (e.g. the FTP or SSH bridge) where previously a authentication would create an audit log entry but would not count towards the last login / number of logins of the account. This is now coupled more directly by moving the recordLogin call within the findUserByCredentials function where also the audit logs are written.

Fixes: SIRI-342