### PR TITLE
Introduces the DelegateJournalData

### DIFF
--- a/src/main/java/sirius/biz/protocol/DelegateJournalData.java
+++ b/src/main/java/sirius/biz/protocol/DelegateJournalData.java
@@ -1,0 +1,148 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.protocol;
+
+import sirius.db.mixing.BaseEntity;
+import sirius.db.mixing.Composite;
+import sirius.db.mixing.EntityDescriptor;
+import sirius.db.mixing.Mixing;
+import sirius.db.mixing.annotations.AfterDelete;
+import sirius.db.mixing.annotations.AfterSave;
+import sirius.db.mixing.annotations.Transient;
+import sirius.db.mixing.types.BaseEntityRef;
+import sirius.kernel.Sirius;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.health.Exceptions;
+
+import javax.annotation.Nonnull;
+import java.util.function.Supplier;
+
+/**
+ * Provides a hook which records custom messages into the system journal which can be embedded into other entities
+ * or mixins.
+ * <p>
+ * To skip a record entirely, {@link #setSilent(boolean)} can be called before the update or delete.
+ */
+public class DelegateJournalData extends Composite {
+
+    @Transient
+    private volatile boolean silent;
+
+    @Transient
+    private final BaseEntity<?> owner;
+
+    @Transient
+    private final Supplier<String> targetId;
+
+    @Transient
+    private final Supplier<String> targetType;
+
+    @Transient
+    private Supplier<String> changeMessageSupplier;
+
+    @Transient
+    private Supplier<String> deleteMessageSupplier;
+
+    /**
+     * Creates a new instance for the given id and type suppliers.
+     *
+     * @param owner      the entity which triggered the change or delete event.
+     * @param targetId   the supplier which delivers the target id under which the journal message will be created
+     * @param targetType the supplier which delivers the target entity type under which the journal message will be created
+     */
+    public DelegateJournalData(BaseEntity<?> owner, Supplier<String> targetId, Supplier<String> targetType) {
+        this.owner = owner;
+        this.targetId = targetId;
+        this.targetType = targetType;
+    }
+
+    /**
+     * Creates a new instance for the given entity reference.
+     *
+     * @param owner     the entity which triggered the change or delete event.
+     * @param entityRef the entity reference under which the journal message will be created
+     */
+    public DelegateJournalData(BaseEntity<?> owner, @Nonnull BaseEntityRef<?, ?> entityRef) {
+        this(owner, entityRef::getIdAsString, () -> Mixing.getNameForType(entityRef.getType()));
+    }
+
+    /**
+     * Defines the supplier responsible to deliver the message to write in the protocol upon entity changes.
+     * <p>
+     * The supplier is called automatically as an {@link AfterSave} action. If the supplier is not set
+     * or delivers empty results, no protocol message is written.
+     * <p>
+     * The {@link EntityDescriptor#getLabel() label} of the entity will be automatically
+     * preppend to the generated message.
+     *
+     * @param changeMessageSupplier the supplier of the journal message
+     * @return the object itself for fluent calls.
+     */
+    public DelegateJournalData withChangeMessageSupplier(Supplier<String> changeMessageSupplier) {
+        this.changeMessageSupplier = changeMessageSupplier;
+        return this;
+    }
+
+    /**
+     * Defines the supplier responsible to deliver the message to write in the protocol upon entity deletes.
+     * <p>
+     * The supplier is called automatically as an {@link AfterDelete} action. If the supplier is not set
+     * or delivers empty results, no protocol message is written.
+     * <p>
+     * The {@link EntityDescriptor#getLabel() label} of the entity will be automatically
+     * preppend to the generated message.
+     *
+     * @param deleteMessageSupplier the supplier of the journal message
+     * @return the object itself for fluent calls.
+     */
+    public DelegateJournalData withDeleteMessageSupplier(Supplier<String> deleteMessageSupplier) {
+        this.deleteMessageSupplier = deleteMessageSupplier;
+        return this;
+    }
+
+    /**
+     * Sets the skip flag.
+     * <p>
+     * Calling this with <tt>true</tt>, will skip all changes performed on the referenced entity instance.
+     *
+     * @param silent <tt>true</tt> to skip the recording of all changes on the referenced entity instance,
+     *               <tt>false</tt> to re-enable.
+     */
+    public void setSilent(boolean silent) {
+        this.silent = silent;
+    }
+
+    @AfterSave
+    protected void onSave() {
+        createJournalEntry(changeMessageSupplier);
+    }
+
+    @AfterDelete
+    protected void onDelete() {
+        createJournalEntry(deleteMessageSupplier);
+    }
+
+    private void createJournalEntry(Supplier<String> messageSupplier) {
+        if (silent
+            || !Sirius.isFrameworkEnabled(Protocols.FRAMEWORK_JOURNAL)
+            || messageSupplier == null
+            || owner.isNew()) {
+            return;
+        }
+
+        try {
+            String message = messageSupplier.get();
+            if (Strings.isFilled(message)) {
+                JournalData.addJournalEntry(targetId.get(), targetType.get(), owner.toString(), message);
+            }
+        } catch (Exception e) {
+            Exceptions.handle(e);
+        }
+    }
+}

--- a/src/main/java/sirius/biz/protocol/DelegateJournalData.java
+++ b/src/main/java/sirius/biz/protocol/DelegateJournalData.java
@@ -129,10 +129,11 @@ public class DelegateJournalData extends Composite {
     }
 
     private void createJournalEntry(Supplier<String> messageSupplier) {
-        if (silent
-            || !Sirius.isFrameworkEnabled(Protocols.FRAMEWORK_JOURNAL)
-            || messageSupplier == null
-            || owner.isNew()) {
+        if (silent || !Sirius.isFrameworkEnabled(Protocols.FRAMEWORK_JOURNAL) || messageSupplier == null) {
+            return;
+        }
+
+        if (owner.isNew() || owner.wasCreated()) {
             return;
         }
 

--- a/src/main/java/sirius/biz/protocol/DelegateJournalData.java
+++ b/src/main/java/sirius/biz/protocol/DelegateJournalData.java
@@ -53,13 +53,13 @@ public class DelegateJournalData extends Composite {
      * Creates a new instance for the given id and type suppliers.
      *
      * @param owner      the entity which triggered the change or delete event.
-     * @param targetId   the supplier which delivers the target id under which the journal message will be created
      * @param targetType the supplier which delivers the target entity type under which the journal message will be created
+     * @param targetId   the supplier which delivers the target id under which the journal message will be created
      */
-    public DelegateJournalData(BaseEntity<?> owner, Supplier<String> targetId, Supplier<String> targetType) {
+    public DelegateJournalData(BaseEntity<?> owner, Supplier<String> targetType, Supplier<String> targetId) {
         this.owner = owner;
-        this.targetId = targetId;
         this.targetType = targetType;
+        this.targetId = targetId;
     }
 
     /**
@@ -139,7 +139,7 @@ public class DelegateJournalData extends Composite {
         try {
             String message = messageSupplier.get();
             if (Strings.isFilled(message)) {
-                JournalData.addJournalEntry(targetId.get(), targetType.get(), owner.toString(), message);
+                JournalData.addJournalEntry(targetType.get(), targetId.get(), owner.toString(), message);
             }
         } catch (Exception e) {
             Exceptions.handle(e);

--- a/src/main/java/sirius/biz/protocol/DelegateJournalData.java
+++ b/src/main/java/sirius/biz/protocol/DelegateJournalData.java
@@ -139,7 +139,12 @@ public class DelegateJournalData extends Composite {
         try {
             String message = messageSupplier.get();
             if (Strings.isFilled(message)) {
-                JournalData.addJournalEntry(targetType.get(), targetId.get(), owner.toString(), message);
+                JournalData.addJournalEntry(targetType.get(),
+                                            targetId.get(),
+                                            Strings.apply("%s-%s",
+                                                          Mixing.getNameForType(owner.getClass()),
+                                                          String.valueOf(owner.getId())),
+                                            Strings.apply("%s - %s", owner.getDescriptor().getLabel(), message));
             }
         } catch (Exception e) {
             Exceptions.handle(e);

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -133,12 +133,12 @@ public class JournalData extends Composite {
     /**
      * Adds an entry to the journal of the given entity.
      *
-     * @param targetId   the id of the entity under which the entity will be written
      * @param targetType the type of the entity under which the entity will be written
+     * @param targetId   the id of the entity under which the entity will be written
      * @param targetName the name identifying the entity, which can differ from the owner entity
      * @param changes    the entry to add to the journal
      */
-    public static void addJournalEntry(String targetId, String targetType, String targetName, String changes) {
+    public static void addJournalEntry(String targetType, String targetId, String targetName, String changes) {
         addJournalEntry(targetId, targetName, targetType, changes, false);
     }
 

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -143,7 +143,7 @@ public class JournalData extends Composite {
     }
 
     private static void addJournalEntry(@Nonnull BaseEntity<?> entity, String changes, boolean batchLog) {
-        if (entity.isNew()) {
+        if (entity.isNew() || entity.wasCreated()) {
             return;
         }
         addJournalEntry(String.valueOf(entity.getId()),

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -186,7 +186,7 @@ public class JournalData extends Composite {
     protected void onDelete() {
         if (!silent) {
             try {
-                addJournalEntry(owner, "Entity has been deleted.", batchLog);
+                addJournalEntry(owner, Strings.apply("Entity '%s' has been deleted.", owner.toString()), batchLog);
             } catch (Exception e) {
                 Exceptions.handle(e);
             }

--- a/src/main/java/sirius/biz/protocol/JournalEntry.java
+++ b/src/main/java/sirius/biz/protocol/JournalEntry.java
@@ -12,6 +12,8 @@ import sirius.biz.elastic.SearchContent;
 import sirius.biz.elastic.SearchableEntity;
 import sirius.db.es.annotations.ESOption;
 import sirius.db.es.annotations.IndexMode;
+import sirius.db.mixing.BaseEntity;
+import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mapping;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.di.std.Framework;
@@ -67,11 +69,16 @@ public class JournalEntry extends SearchableEntity {
     private String targetId;
 
     /**
-     * Contains the {@code toString()} of the entity which was changed.
+     * Contains the identifier of the changed entity.
+     * <p>
+     * The identifier is composed of {@link EntityDescriptor#getType()}-{@link BaseEntity#getIdAsString()}
+     * For entities using {@link JournalData}, it is equal to the {@link #TARGET_TYPE}-{@link #TARGET_ID}
+     * For entities using {@link DelegateJournalData}, it will contain the type and if of the entity which
+     * caused the journal entry, since the target fields contains the parent entity owning this record.
      */
-    public static final Mapping TARGET_NAME = Mapping.named("targetName");
+    public static final Mapping CONTENT_IDENTIFIER = Mapping.named("contentIdentifier");
     @SearchContent
-    private String targetName;
+    private String contentIdentifier;
 
     /**
      * Contains all changed fields as <tt>name: value</tt>.
@@ -131,12 +138,12 @@ public class JournalEntry extends SearchableEntity {
         this.targetId = targetId;
     }
 
-    public String getTargetName() {
-        return targetName;
+    public String getContentIdentifier() {
+        return contentIdentifier;
     }
 
-    public void setTargetName(String targetName) {
-        this.targetName = targetName;
+    public void setContentIdentifier(String contentIdentifier) {
+        this.contentIdentifier = contentIdentifier;
     }
 
     public String getChanges() {

--- a/src/main/java/sirius/biz/protocol/JournalEntry.java
+++ b/src/main/java/sirius/biz/protocol/JournalEntry.java
@@ -53,14 +53,14 @@ public class JournalEntry extends SearchableEntity {
     private String subsystem;
 
     /**
-     * Contains the type name of the entity which was changed.
+     * Contains the type name of the entity which owns this change record.
      */
     public static final Mapping TARGET_TYPE = Mapping.named("targetType");
     @SearchContent
     private String targetType;
 
     /**
-     * Contains the ID of entity which was changed.
+     * Contains the ID of entity which owns this change record.
      */
     public static final Mapping TARGET_ID = Mapping.named("targetId");
     @SearchContent

--- a/src/main/resources/default/templates/biz/protocol/protocol.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/protocol.html.pasta
@@ -47,7 +47,7 @@
                                 </div>
                                 <div class="col-md-4">
                                     <small>
-                                        @msg.getTargetName() (@msg.getTargetId())
+                                        @msg.getContentIdentifier() (@msg.getTargetId())
                                         <br>@msg.getTargetType()
                                     </small>
                                 </div>


### PR DESCRIPTION
This class should be used instead of JournalData when there is a need to record changes under another entity (usually the parent entity), like recording changes to product's features under the product itself instead of logging such changes directly at the child entity.

It can be constructed using an entity ref (of the entity which shall own the record) or using the id + type.

Fixes: SIRI-298