### PR TITLE
Escapes the JSON in the multiLanguageStringField to allow " in the translations

### DIFF
--- a/src/main/resources/default/taglib/w/multiLanguageTextArea.html.pasta
+++ b/src/main/resources/default/taglib/w/multiLanguageTextArea.html.pasta
@@ -77,7 +77,7 @@
                 hasFallback: ___value.isWithFallback(),
                 fallbackLabel: '@i18n("Language.fallback")',
                 wrapperId: '___fieldId',
-                values: JSON.parse(<i:raw>'@escapeJS(value.getAsJSON())'</i:raw>),
+                values: <i:raw>@value.getAsJSON()</i:raw>,
                 defaultLanguage: '___defaultLanguage',
                 validLanguages: validLanguages,
                 languageManagementEnabled: ___languageManagementEnabled,

--- a/src/main/resources/default/taglib/w/multiLanguageTextField.html.pasta
+++ b/src/main/resources/default/taglib/w/multiLanguageTextField.html.pasta
@@ -88,7 +88,7 @@
                 fallbackLabel: '@i18n("Language.fallback")',
                 wrapperId: '___fieldId',
                 modalId: '___modalId',
-                values: JSON.parse(<i:raw>'@escapeJS(value.getAsJSON())'</i:raw>),
+                values: <i:raw>@value.getAsJSON()</i:raw>,
                 defaultLanguage: '___defaultLanguage',
                 validLanguages: validLanguages,
                 languageManagementEnabled: ___languageManagementEnabled,

--- a/src/main/resources/default/taglib/w/multiLanguageTextField.html.pasta
+++ b/src/main/resources/default/taglib/w/multiLanguageTextField.html.pasta
@@ -88,7 +88,7 @@
                 fallbackLabel: '@i18n("Language.fallback")',
                 wrapperId: '___fieldId',
                 modalId: '___modalId',
-                values: JSON.parse(<i:raw>'___value.getAsJSON()'</i:raw>),
+                values: JSON.parse(<i:raw>'@escapeJS(value.getAsJSON())'</i:raw>),
                 defaultLanguage: '___defaultLanguage',
                 validLanguages: validLanguages,
                 languageManagementEnabled: ___languageManagementEnabled,


### PR DESCRIPTION
If " is used inside one of the translations, it is correctly escaped using `\`. But JSON.parse expects `\` itself to be escaped (`\\"`).