### PR TITLE
Provides a toString and forceName for LookupValue.

### DIFF
--- a/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
@@ -50,8 +50,8 @@ class CodeListLookupTable extends LookupTable {
     }
 
     @Override
-    protected Optional<String> performFetchField(String code, String targetField) {
-        return Optional.ofNullable(codeLists.getValues(codeList, code).getSecond());
+    protected Value performFetchField(String code, String targetField) {
+        return Value.of(codeLists.getValues(codeList, code).getSecond());
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/CustomLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CustomLookupTable.java
@@ -9,6 +9,7 @@
 package sirius.biz.codelists;
 
 import sirius.kernel.commons.Limit;
+import sirius.kernel.commons.Value;
 import sirius.kernel.settings.Extension;
 
 import javax.annotation.Nonnull;
@@ -47,13 +48,17 @@ class CustomLookupTable extends LookupTable {
 
     @Override
     protected Optional<String> performResolveDescription(@Nonnull String code, String lang) {
-        return or(customTable.performResolveDescription(code, lang), () -> baseTable.performResolveDescription(code, lang));
+        return or(customTable.performResolveDescription(code, lang),
+                  () -> baseTable.performResolveDescription(code, lang));
     }
 
     @Override
-    protected Optional<String> performFetchField(String code, String targetField) {
-        return or(customTable.performFetchField(code, targetField),
-                  () -> baseTable.performFetchField(code, targetField));
+    protected Value performFetchField(String code, String targetField) {
+        Value result = customTable.performFetchField(code, targetField);
+        if (result.isFilled()) {
+            return result;
+        }
+        return baseTable.performFetchField(code, targetField);
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
@@ -11,6 +11,7 @@ package sirius.biz.codelists;
 import sirius.biz.jupiter.IDBSet;
 import sirius.biz.jupiter.Jupiter;
 import sirius.kernel.commons.Limit;
+import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.settings.Extension;
 
@@ -61,11 +62,11 @@ class IDBFilteredLookupTable extends LookupTable {
     }
 
     @Override
-    protected Optional<String> performFetchField(String code, String targetField) {
+    protected Value performFetchField(String code, String targetField) {
         if (contains(code)) {
             return baseTable.performFetchField(code, targetField);
         } else {
-            return Optional.empty();
+            return Value.EMPTY;
         }
     }
 

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -14,6 +14,7 @@ import sirius.biz.jupiter.IDBTable;
 import sirius.biz.jupiter.Jupiter;
 import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.settings.Extension;
 
@@ -41,6 +42,7 @@ class IDBLookupTable extends LookupTable {
     private static final String COL_DEPRECATED = "deprecated";
 
     private static final String CACHE_PREFIX_FETCH_FIELD = "fetch-field-";
+    private static final String CACHE_PREFIX_FETCH_TRANSLATED_FIELD = "fetch-field-";
     private static final String CACHE_PREFIX_NORMALIZE = "normalize-";
     private static final String CACHE_PREFIX_NORMALIZE_WITH_MAPPING = "normalize-with-mapping";
     private static final String CACHE_PREFIX_REVERSE_LOOKUP = "reverse-lookup-";
@@ -87,19 +89,20 @@ class IDBLookupTable extends LookupTable {
     }
 
     @Override
-    protected Optional<String> performFetchField(String code, String targetField) {
+    protected Value performFetchField(String code, String targetField) {
         return jupiter.fetchFromSmallCache(CACHE_PREFIX_FETCH_FIELD + table.getName() + "-" + code + "-" + targetField,
                                            () -> table.query()
                                                       .lookupPaths(codeField)
                                                       .searchValue(code)
                                                       .singleRow(targetField)
-                                                      .map(row -> row.at(0).asString())
-                                                      .filter(Strings::isFilled));
+                                                      .map(row -> row.at(0))
+                                                      .filter(Value::isFilled)
+                                                      .orElse(Value.EMPTY));
     }
 
     @Override
     protected Optional<String> performFetchTranslatedField(String code, String targetField, String lang) {
-        return jupiter.fetchFromSmallCache(CACHE_PREFIX_FETCH_FIELD
+        return jupiter.fetchFromSmallCache(CACHE_PREFIX_FETCH_TRANSLATED_FIELD
                                            + table.getName()
                                            + "-"
                                            + code

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -177,6 +177,22 @@ public abstract class LookupTable {
             return Optional.empty();
         }
 
+        return performFetchField(normalizeCodeValue(code), targetField).asOptionalString();
+    }
+
+    /**
+     * Fetches the requested field for the given code.
+     *
+     * @param code        the code to fetch the field for
+     * @param targetField the field to fetch
+     * @return the value of the field or an empty value if the code is unknown. Note that this will only resolve the
+     * main code. When in doubt, the code must be normalized via {@link #normalize(String)} before invoking this method.
+     */
+    public Value fetchFieldValue(String code, String targetField) {
+        if (Strings.isEmpty(code)) {
+            return Value.EMPTY;
+        }
+
         return performFetchField(normalizeCodeValue(code), targetField);
     }
 
@@ -196,7 +212,7 @@ public abstract class LookupTable {
             return Optional.empty();
         }
 
-        return performFetchField(normalizeCodeValue(code), mappingsField + "." + mapping);
+        return performFetchField(normalizeCodeValue(code), mappingsField + "." + mapping).asOptionalString();
     }
 
     /**
@@ -233,12 +249,13 @@ public abstract class LookupTable {
             return Optional.empty();
         }
 
-        Optional<String> result = performFetchField(normalizeCodeValue(code), mappingsField + "." + primaryMapping);
+        Optional<String> result =
+                performFetchField(normalizeCodeValue(code), mappingsField + "." + primaryMapping).asOptionalString();
         if (result.isPresent()) {
             return result;
         }
 
-        return performFetchField(normalizeCodeValue(code), mappingsField + "." + secondaryMapping);
+        return performFetchField(normalizeCodeValue(code), mappingsField + "." + secondaryMapping).asOptionalString();
     }
 
     /**
@@ -259,7 +276,7 @@ public abstract class LookupTable {
         return fetchMappings(code, primaryMapping, secondaryMapping).orElseGet(() -> normalizeCodeValue(code));
     }
 
-    protected abstract Optional<String> performFetchField(@Nonnull String code, String targetField);
+    protected abstract Value performFetchField(@Nonnull String code, String targetField);
 
     /**
      * Fetches the translated value of the requested field for the given code.

--- a/src/main/java/sirius/biz/codelists/LookupValue.java
+++ b/src/main/java/sirius/biz/codelists/LookupValue.java
@@ -122,6 +122,20 @@ public class LookupValue {
     }
 
     /**
+     * Resolves the name for the current value or returns the code itself if the name is unknown.
+     *
+     * @return the name of the current value or the code, if the name cannot be resolved. Note that this will return
+     * an empty string if no value is presnet
+     */
+    public String forceFetchName() {
+        if (Strings.isEmpty(value)) {
+            return "";
+        } else {
+            return fetchName().orElse(value);
+        }
+    }
+
+    /**
      * Fetches the description for the current value.
      *
      * @return the description for the current value in the current language, or an empty optional if no value is
@@ -149,5 +163,14 @@ public class LookupValue {
 
     public CustomValues getCustomValues() {
         return customValues;
+    }
+
+    @Override
+    public String toString() {
+        if (Strings.isEmpty(value)) {
+            return lookupTableName + ": empty";
+        } else {
+            return Strings.apply("%s: %s (%s)", lookupTableName, value, fetchName().orElse("unknown"));
+        }
     }
 }

--- a/src/main/java/sirius/biz/codelists/LookupValue.java
+++ b/src/main/java/sirius/biz/codelists/LookupValue.java
@@ -145,6 +145,23 @@ public class LookupValue {
         return getTable().resolveDescription(value);
     }
 
+    /**
+     * Determines if a value is present.
+     *
+     * @return <tt>true</tt> if a non-null and non-empty value is present, <tt>false</tt> otherwise
+     */
+    public boolean isFilled() {
+        return Strings.isFilled(value);
+    }
+
+    /**
+     * Determines if no value is present.
+     * @return <tt>true</tt> if the value is null or empty, <tt>false otherwise</tt>
+     */
+    public boolean isEmpty() {
+        return !isFilled();
+    }
+
     public String getValue() {
         return value;
     }


### PR DESCRIPTION
These are common methods and thus factored out here as otherwise
one had to repeat "value.fetchName(value.getValue)" all the time.