### PR TITLE
Permit an empty search in IDBTables.

### DIFF
--- a/src/main/java/sirius/biz/jupiter/IDBTable.java
+++ b/src/main/java/sirius/biz/jupiter/IDBTable.java
@@ -179,16 +179,13 @@ public class IDBTable {
          */
         public Optional<Values> singleRow(String... pathsToQuery) {
             checkConstraints();
+
             if (exact && Strings.isFilled(searchValue)) {
                 if (Strings.isFilled(primaryLang)) {
                     return ilookup(primaryLang, fallbackLang, searchPaths, searchValue, pathsToQuery);
                 } else {
                     return lookup(searchPaths, searchValue, pathsToQuery);
                 }
-            }
-
-            if (Strings.isFilled(searchPaths)) {
-                return Optional.empty();
             }
 
             return execute(Limit.singleItem(), pathsToQuery).stream().findFirst();


### PR DESCRIPTION
If a searchPath is given, but the searchValue is empty, we now
automatically return an empty result. (Previously this failed with an
IllegalArgumentException.)

We still fail, if a searchValue is present but no searchPath is
specified.