### PR TITLE
Prohibit a queue for process side tasks.

### DIFF
--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -315,10 +315,11 @@ async {
         }
 
         # Provides a smaller "work stealing" pool which is used by Processes (ProcessContext) to execute
-        # small side tasks in parallel.
+        # small side tasks in parallel. Note that we explicitly do not want to have a queue here as
+        # we'd rather block the "main thread" than queue up tasks.
         process-sidetask {
             poolSize = 16
-            queueLength = 0
+            queueLength = -1
         }
 
         # This executor collects all requests which are served via the storage framework. These requests might


### PR DESCRIPTION
The API kind of relies on the fact that the
"main" thread of the process is blocked if no
workers are available for work stealing.

With the previous config, we had and UNBOUNDED queue
which grew pretty quick and violently consumed
all heap.