### PR TITLE
Permit to specify a custom name for the "Row" timing/counter.

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -93,7 +93,7 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
         /**
          * Specifies a custom counter name to be used for each processed row.
          *
-         * @param rowCounterName the name of the coutner which will be smart translated using
+         * @param rowCounterName the name of the counter which will be smart translated using
          *                       {@link sirius.kernel.nls.NLS#smartGet(String)}.
          * @return the file itself for fluent method calls
          */

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImport.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImport.java
@@ -25,6 +25,8 @@ import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
 
+import javax.annotation.Nullable;
+
 /**
  * Provides a helper to process line based values using a {@link ImportDictionary}.
  * <p>
@@ -45,10 +47,12 @@ public class DictionaryBasedImport {
     private static final String MESSAGE_PARAM_FILE = "file";
 
     protected final ProcessContext process;
-    protected final boolean ignoreEmptyValues;
     protected final ImportDictionary dictionary;
     protected final String filename;
     protected Callback<Tuple<Integer, Context>> rowHandler;
+
+    protected boolean ignoreEmptyValues;
+    protected String rowCounterName = "$LineBasedJob.row";
 
     /**
      * Creates a new job for the given factory, name and process.
@@ -59,13 +63,23 @@ public class DictionaryBasedImport {
     protected DictionaryBasedImport(String filename,
                                     ImportDictionary dictionary,
                                     ProcessContext process,
-                                    boolean ignoreEmptyValues,
                                     Callback<Tuple<Integer, Context>> rowHandler) {
         this.filename = filename;
         this.dictionary = dictionary;
         this.process = process;
-        this.ignoreEmptyValues = ignoreEmptyValues;
         this.rowHandler = rowHandler;
+    }
+
+    protected DictionaryBasedImport withRowCounterName(@Nullable String rowCounterName) {
+        if (Strings.isFilled(rowCounterName)) {
+            this.rowCounterName = rowCounterName;
+        }
+        return this;
+    }
+
+    protected DictionaryBasedImport withIgnoreEmptyValues(boolean ignoreEmptyValues) {
+        this.ignoreEmptyValues = ignoreEmptyValues;
+        return this;
     }
 
     /**
@@ -150,7 +164,7 @@ public class DictionaryBasedImport {
                                      .set(MESSAGE_PARAM_MESSAGE, e.getMessage())
                                      .handle());
         } finally {
-            process.addTiming(NLS.get("LineBasedJob.row"), watch.elapsedMillis());
+            process.addTiming(NLS.smartGet(rowCounterName), watch.elapsedMillis());
         }
     }
 

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJob.java
@@ -44,10 +44,9 @@ public abstract class DictionaryBasedImportJob extends LineBasedImportJob {
         this.dictionaryBasedImport = new DictionaryBasedImport(file.name(),
                                                                dictionary,
                                                                process,
-                                                               process.getParameter(DictionaryBasedImport.IGNORE_EMPTY_PARAMETER)
-                                                                      .orElse(false),
                                                                indexAndRow -> handleRow(indexAndRow.getFirst(),
-                                                                                        indexAndRow.getSecond()));
+                                                                                        indexAndRow.getSecond())).withIgnoreEmptyValues(
+                process.getParameter(DictionaryBasedImport.IGNORE_EMPTY_PARAMETER).orElse(false));
         super.execute();
     }
 

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -187,6 +187,7 @@ DeleteTenantJobFactory.title.simulate = Lösche Mandanten "${name}" (SIMULIERT)
 DeleteTenantTask.beforeExecution.many = Lösche ${count} ${name}.
 DeleteTenantTask.beforeExecution.no = Keine ${name} zu löschen.
 DeleteTenantTask.beforeExecution.one = Lösche 1 ${name}.
+DictionaryBasedArchiveImportJob.msgImportFile = Importiere ${file}...
 DictionaryBasedImportJobFactory.ignoreEmpty = Leere Werte ignorieren
 DictionaryBasedImportJobFactory.ignoreEmpty.help = Gibt an, dass fehlende Werte übersprungen werden statt das entsprechende Ziel-Feld zu leeren.
 DirectoryParameter.invalidPath = Das Verzeichnis '${path}' wurde nicht gefunden.


### PR DESCRIPTION
This is beneficial when importing data from many files as then one row doesn't equal another.

Therefore we also log the name of each file being imported.