### PR TITLE
Simplify the parsing of complex properties inside Import Handlers

### DIFF
--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -170,6 +170,14 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
      * @param data     the full context which is being imported
      */
     protected void parseProperty(E entity, Property property, Value value, Context data) {
+        if (property instanceof BaseEntityRefProperty) {
+            Class<?> referencedType = ((BaseEntityRefProperty<?, ?, ?>) property).getReferencedType();
+            if (value.is(referencedType)) {
+                property.parseValueFromImport(entity, value);
+                return;
+            }
+        }
+
         if (parseComplexProperty(entity, property, value, data)) {
             return;
         }


### PR DESCRIPTION
If the value already contains the target type, there is no need to use complex parsing.

This also fixes a bug where the `parseComplexProperty` of `SQLUserAccount` would throw an exception when the tenant is supplied as tenant-object and not as account-number-string