### PR TITLE
Makes the process counters more readable

### DIFF
--- a/src/main/java/sirius/biz/process/Process.java
+++ b/src/main/java/sirius/biz/process/Process.java
@@ -25,6 +25,8 @@ import sirius.db.mixing.types.NestedList;
 import sirius.db.mixing.types.StringIntMap;
 import sirius.db.mixing.types.StringList;
 import sirius.db.mixing.types.StringMap;
+import sirius.kernel.commons.Amount;
+import sirius.kernel.commons.NumberFormat;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Framework;
 import sirius.kernel.di.std.Part;
@@ -451,7 +453,8 @@ public class Process extends SearchableEntity {
      * @return the count value of the given counter
      */
     public String getCounterValue(String name) {
-        return String.valueOf(performanceCounters.get(name).orElse(adminPerformanceCounters.get(name).orElse(0)));
+        Integer value = performanceCounters.get(name).orElse(adminPerformanceCounters.get(name).orElse(0));
+        return Amount.of(value).toString(NumberFormat.NO_DECIMAL_PLACES).asString();
     }
 
     /**
@@ -487,8 +490,8 @@ public class Process extends SearchableEntity {
     /**
      * Adds or updates the timing with the given name.
      *
-     * @param name      the name of the timing
-     * @param average   contains the count and average time of the events
+     * @param name    the name of the timing
+     * @param average contains the count and average time of the events
      */
     public void addTiming(String name, Average average) {
         performanceCounters.put(name, (int) average.getCount());
@@ -498,8 +501,8 @@ public class Process extends SearchableEntity {
     /**
      * Adds or updates the timing with the given name which is only visible to administrators.
      *
-     * @param name      the name of the timing
-     * @param average   contains the count and average time of the events
+     * @param name    the name of the timing
+     * @param average contains the count and average time of the events
      */
     public void addAdminTiming(String name, Average average) {
         adminPerformanceCounters.put(name, (int) average.getCount());


### PR DESCRIPTION
... by formatting them with thousands grouping symbols.

Before:

![Bildschirmfoto 2021-05-21 um 15 58 51](https://user-images.githubusercontent.com/2427877/119151821-0a6d0900-ba50-11eb-90b2-97b98ccf744a.png)

After:

![image](https://user-images.githubusercontent.com/2427877/119151863-1062ea00-ba50-11eb-90d7-9a6cf5151677.png)

