### PR TITLE
Logs empty conversion results as errors in a tenant specific standby process

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -178,55 +178,60 @@ public class ConversionEngine {
         Watch queueWatch = Watch.start();
         tasks.executor(EXECUTOR_STORAGE_CONVERSION)
              .dropOnOverload(() -> result.fail(new IllegalStateException("Conversion subsystem overloaded!")))
-             .fork(() -> {
-                 try {
-                     conversionProcess.recordQueueDuration(queueWatch.elapsedMillis());
-                     Converter converter = fetchConverter(conversionProcess.getVariantName());
-                     if (converter == null) {
-                         // We use a handled exception here as the error has already been reported and we do not want to jam
-                         // the logs with additional error reports for the same problem.
-                         throw Exceptions.createHandled()
-                                         .withSystemErrorMessage("A configuration problem is present for: %s",
-                                                                 conversionProcess.getVariantName())
-                                         .handle();
-                     }
-
-                     converter.performConversion(conversionProcess);
-                     FileHandle resultFileHandle = conversionProcess.getResultFileHandle();
-                     if (resultFileHandle == null
-                         || !resultFileHandle.exists()
-                         || resultFileHandle.getFile().length() == 0) {
-                         if (resultFileHandle != null) {
-                             resultFileHandle.close();
-                         }
-                         processes.executeInStandbyProcessForCurrentTenant("conversion",
-                                                                           () -> NLS.get("ConversionEngine.processTitle"),
-                                                                           processContext -> processContext.log(
-                                                                                   ProcessLog.error()
-                                                                                             .withNLSKey(
-                                                                                                     "ConversionEngine.emptyResult")
-                                                                                             .withContext("variantName",
-                                                                                                          conversionProcess
-                                                                                                                  .getVariantName())
-                                                                                             .withContext("filename",
-                                                                                                          conversionProcess
-                                                                                                                  .getBlobToConvert()
-                                                                                                                  .getFilename())));
-                         throw new IllegalArgumentException(Strings.apply(
-                                 "The conversion engine created an empty result for variant %s of %s (%s)",
-                                 conversionProcess.getVariantName(),
-                                 conversionProcess.getBlobToConvert().getFilename(),
-                                 conversionProcess.getBlobToConvert().getBlobKey()));
-                     }
-
-                     conversionDuration.addValue(conversionProcess.getConversionDuration());
-                     result.success();
-                 } catch (Exception e) {
-                     result.fail(e);
-                 }
-             });
+             .fork(() -> doConversion(conversionProcess, result, queueWatch));
 
         return result;
+    }
+
+    private void doConversion(ConversionProcess conversionProcess, Future result, Watch queueWatch) {
+        try {
+            conversionProcess.recordQueueDuration(queueWatch.elapsedMillis());
+            Converter converter = fetchConverter(conversionProcess.getVariantName());
+            if (converter == null) {
+                // We use a handled exception here as the error has already been reported and we do not want to jam
+                // the logs with additional error reports for the same problem.
+                throw Exceptions.createHandled()
+                                .withSystemErrorMessage("A configuration problem is present for: %s",
+                                                        conversionProcess.getVariantName())
+                                .handle();
+            }
+
+            converter.performConversion(conversionProcess);
+            FileHandle resultFileHandle = conversionProcess.getResultFileHandle();
+            if (resultFileHandle == null || !resultFileHandle.exists() || resultFileHandle.getFile().length() == 0) {
+                handleEmptyResult(conversionProcess, resultFileHandle);
+            }
+
+            conversionDuration.addValue(conversionProcess.getConversionDuration());
+            result.success();
+        } catch (Exception e) {
+            result.fail(e);
+        }
+    }
+
+    private void handleEmptyResult(ConversionProcess conversionProcess, FileHandle resultFileHandle) {
+        if (resultFileHandle != null) {
+            resultFileHandle.close();
+        }
+        processes.executeInStandbyProcessForCurrentTenant("conversion",
+                                                          () -> NLS.get("ConversionEngine.processTitle"),
+                                                          processContext -> processContext.log(ProcessLog.error()
+                                                                                                         .withNLSKey(
+                                                                                                                 "ConversionEngine.emptyResult")
+                                                                                                         .withContext(
+                                                                                                                 "variantName",
+                                                                                                                 conversionProcess
+                                                                                                                         .getVariantName())
+                                                                                                         .withContext(
+                                                                                                                 "filename",
+                                                                                                                 conversionProcess
+                                                                                                                         .getBlobToConvert()
+                                                                                                                         .getFilename())));
+        throw new IllegalArgumentException(Strings.apply(
+                "The conversion engine created an empty result for variant %s of %s (%s)",
+                conversionProcess.getVariantName(),
+                conversionProcess.getBlobToConvert().getFilename(),
+                conversionProcess.getBlobToConvert().getBlobKey()));
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -8,6 +8,8 @@
 
 package sirius.biz.storage.layer2.variants;
 
+import sirius.biz.process.Processes;
+import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.storage.layer1.FileHandle;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.kernel.Sirius;
@@ -20,6 +22,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Average;
 import sirius.kernel.health.Exceptions;
+import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
 
 import javax.annotation.Nullable;
@@ -58,6 +61,9 @@ public class ConversionEngine {
 
     @Part
     private GlobalContext globalContext;
+
+    @Part
+    private Processes processes;
 
     /**
      * When delivering files (e.g. preview images to be shown in the browser), we normally don't bother to lookup the
@@ -193,6 +199,20 @@ public class ConversionEngine {
                     if (resultFileHandle != null) {
                         resultFileHandle.close();
                     }
+                    processes.executeInStandbyProcessForCurrentTenant("conversion",
+                                                                      () -> NLS.get("ConversionEngine.processTitle"),
+                                                                      processContext -> processContext.log(ProcessLog.error()
+                                                                                                                     .withNLSKey(
+                                                                                                                             "ConversionEngine.emptyResult")
+                                                                                                                     .withContext(
+                                                                                                                             "variantName",
+                                                                                                                             conversionProcess
+                                                                                                                                     .getVariantName())
+                                                                                                                     .withContext(
+                                                                                                                             "filename",
+                                                                                                                             conversionProcess
+                                                                                                                                     .getBlobToConvert()
+                                                                                                                                     .getFilename())));
                     throw new IllegalArgumentException(Strings.apply(
                             "The conversion engine created an empty result for variant %s of %s (%s)",
                             conversionProcess.getVariantName(),

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -899,3 +899,5 @@ XMLImportJob.invalidXMLDetected = Der Import der Datei '${fileName}' wurde abgeb
 XMLImportJobFactory.xsdSchema = XML-Schema prüfen
 XMLImportJobFactory.xsdSchema.help = Bei Auswahl eines der vorgegebenen XML-Schemata erfolgt der Import nur, wenn die Datei der vorgegebenen Struktur entspricht.
 XMLValidatorErrorHandler.error = Während der Validierung ist ein Fehler aufgetreten in Zeile ${line}: ${message}
+ConversionEngine.processTitle = Bildkonvertierung
+ConversionEngine.emptyResult = Die Konvertierung der Datei ${filename} ist fehlgeschlagen, die Variante ${variantName} konnte nicht erstellt werden. Bitte überprüfen Sie die Ursprungsdatei.

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -899,5 +899,5 @@ XMLImportJob.invalidXMLDetected = Der Import der Datei '${fileName}' wurde abgeb
 XMLImportJobFactory.xsdSchema = XML-Schema prüfen
 XMLImportJobFactory.xsdSchema.help = Bei Auswahl eines der vorgegebenen XML-Schemata erfolgt der Import nur, wenn die Datei der vorgegebenen Struktur entspricht.
 XMLValidatorErrorHandler.error = Während der Validierung ist ein Fehler aufgetreten in Zeile ${line}: ${message}
-ConversionEngine.processTitle = Bildkonvertierung
+ConversionEngine.processTitle = Datei-Konvertierung
 ConversionEngine.emptyResult = Die Konvertierung der Datei ${filename} ist fehlgeschlagen, die Variante ${variantName} konnte nicht erstellt werden. Bitte überprüfen Sie die Ursprungsdatei.


### PR DESCRIPTION
only in case of an error we query the processes framework, as we want to be as quick as possible for successful conversions

Fixes: OX-6843