### PR TITLE
Resolve helpers without ConcurrentModificationException

### DIFF
--- a/src/main/java/sirius/biz/importer/ImportHelper.java
+++ b/src/main/java/sirius/biz/importer/ImportHelper.java
@@ -12,7 +12,7 @@ package sirius.biz.importer;
  * Subclasses can be created and instantiated via {@link ImporterContext#findHelper(Class)}.
  * <p>
  * As these helpers are instantiated per {@link Importer} / {@link ImporterContext} they can carry around state
- * and supply helper methods.
+ * and supply helper methods. Note that cyclic dependencies between helper will not get resolved.
  */
 public abstract class ImportHelper {
 


### PR DESCRIPTION
- ConcurrentModificationException might occur since Java 16
update from computeIfAbsent in case the mappingFunction modifies
the map which happens when ImportHelper get resolved by findHelper
in other ImportHelper constructors