### PR TITLE
Resolve handlers without ConcurrentModificationException

### DIFF
--- a/src/main/java/sirius/biz/importer/ImporterContext.java
+++ b/src/main/java/sirius/biz/importer/ImporterContext.java
@@ -79,7 +79,7 @@ public class ImporterContext {
         ImportHandler<E> result = (ImportHandler<E>) handlers.get(type);
         if (result == null) {
             // Note: computeIfAbsent cannot be used as a handler might reference other handlers. Those handler's
-            // resolution would result in a ConcurrentModificationException in the #helpers Map.
+            // resolution would result in a ConcurrentModificationException in the #handlers Map.
             // This leads to cyclic handler dependencies not being resolvable here.
             result = (ImportHandler<E>) lookupHandler(type, type);
             handlers.put(type, result);

--- a/src/main/java/sirius/biz/importer/ImporterContext.java
+++ b/src/main/java/sirius/biz/importer/ImporterContext.java
@@ -30,23 +30,24 @@ import java.util.Map;
  */
 public class ImporterContext {
 
-    private final Importer importer;
-    private BatchContext batchContext;
-
-    @PriorityParts(ImportHandlerFactory.class)
-    private static List<ImportHandlerFactory> factories;
-
-    private final Map<Class<?>, ImportHandler<?>> handlers = new HashMap<>();
-    private final Map<Class<?>, ImportHelper> helpers = new HashMap<>();
-
-    private final Cache<Tuple<Class<?>, String>, Object> localCache = CacheBuilder.newBuilder().maximumSize(256).build();
-
-    private final List<Runnable> postCommitCallbacks = new ArrayList<>();
-
     /**
      * Specifies the maximum number of post commit callbacks to keep around before a {@link #commit()} is forced.
      */
     private static final int MAX_POST_COMMIT_CALLBACKS = 256;
+
+    @PriorityParts(ImportHandlerFactory.class)
+    private static List<ImportHandlerFactory> factories;
+
+    private final Importer importer;
+    private BatchContext batchContext;
+
+    private final Map<Class<?>, ImportHandler<?>> handlers = new HashMap<>();
+    private final Map<Class<?>, ImportHelper> helpers = new HashMap<>();
+
+    private final Cache<Tuple<Class<?>, String>, Object> localCache =
+            CacheBuilder.newBuilder().maximumSize(256).build();
+
+    private final List<Runnable> postCommitCallbacks = new ArrayList<>();
 
     /**
      * Creates a new context for the given importer.

--- a/src/main/java/sirius/biz/importer/ImporterContext.java
+++ b/src/main/java/sirius/biz/importer/ImporterContext.java
@@ -30,18 +30,18 @@ import java.util.Map;
  */
 public class ImporterContext {
 
-    private Importer importer;
+    private final Importer importer;
     private BatchContext batchContext;
 
     @PriorityParts(ImportHandlerFactory.class)
     private static List<ImportHandlerFactory> factories;
 
-    private Map<Class<?>, ImportHandler<?>> handlers = new HashMap<>();
-    private Map<Class<?>, ImportHelper> helpers = new HashMap<>();
+    private final Map<Class<?>, ImportHandler<?>> handlers = new HashMap<>();
+    private final Map<Class<?>, ImportHelper> helpers = new HashMap<>();
 
-    private Cache<Tuple<Class<?>, String>, Object> localCache = CacheBuilder.newBuilder().maximumSize(256).build();
+    private final Cache<Tuple<Class<?>, String>, Object> localCache = CacheBuilder.newBuilder().maximumSize(256).build();
 
-    private List<Runnable> postCommitCallbacks = new ArrayList<>();
+    private final List<Runnable> postCommitCallbacks = new ArrayList<>();
 
     /**
      * Specifies the maximum number of post commit callbacks to keep around before a {@link #commit()} is forced.


### PR DESCRIPTION
ConcurrentModificationException might occur since Java 16
update from computeIfAbsent in case the mappingFunction modifies
the map which happens when ImportHandler get resolved by lookupHandler
in other ImportHandler constructors