### PR TITLE
ImporterContext cache enhancement

### DIFF
--- a/src/main/java/sirius/biz/importer/ImporterContext.java
+++ b/src/main/java/sirius/biz/importer/ImporterContext.java
@@ -156,6 +156,21 @@ public class ImporterContext {
     }
 
     /**
+     * Purges the given entity from the local cache.
+     * <p>
+     * This is useful if the entity is updated, forcing the cache to load a fresh instance in the next call
+     *
+     * @param entity the entity to purge
+     */
+    public <E extends BaseEntity<?>> void purgeFromLocalCache(E entity) {
+        localCache.asMap().forEach((key, entry) -> {
+            if (entry instanceof BaseEntity && ((BaseEntity<?>) entry).getIdAsString().equals(entity.getIdAsString())) {
+                localCache.invalidate(key);
+            }
+        });
+    }
+
+    /**
      * Closes this context and completes all running batches.
      *
      * @throws IOException in case of an io error. Most probably this won't happen, as we only use

--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -121,6 +121,7 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
 
         if (isChanged(entity)) {
             mango.update(entity);
+            context.purgeFromLocalCache(entity);
         }
 
         return entity;

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -278,6 +278,7 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
     protected E updateIfChanged(E entity, boolean batch) {
         if (isChanged(entity)) {
             getUpdateQuery().update(entity, true, batch);
+            context.purgeFromLocalCache(entity);
         }
 
         return entity;


### PR DESCRIPTION
- Allows the user to drop an entity from the local cache
- Updates done by the ImportHandlers also drop the entity from the local cache