### PR TITLE
Language configuration via Scopes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-23.3.0</sirius.kernel>
-        <sirius.web>dev-36.0.0</sirius.web>
-        <sirius.db>dev-27.4.0</sirius.db>
+        <sirius.kernel>dev-24.0.0</sirius.kernel>
+        <sirius.web>dev-37.0.0</sirius.web>
+        <sirius.db>dev-28.0.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/codelists/CodeListEntryData.java
+++ b/src/main/java/sirius/biz/codelists/CodeListEntryData.java
@@ -27,6 +27,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Priorized;
 import sirius.kernel.nls.NLS;
+import sirius.web.security.UserContext;
 
 import javax.annotation.Nullable;
 
@@ -73,7 +74,8 @@ public class CodeListEntryData extends Composite {
     @Autoloaded
     @PrefixSearchContent
     private final MultiLanguageString value = new MultiLanguageString().withFallback()
-                                                                       .withValidLanguages(NLS.getSupportedLanguages())
+                                                                       .withValidLanguages(UserContext.getCurrentScope()
+                                                                                                      .getAvailableLanguages())
                                                                        .withConditionName("code-lists");
 
     /**
@@ -85,7 +87,8 @@ public class CodeListEntryData extends Composite {
     @Autoloaded
     @PrefixSearchContent
     private final MultiLanguageString additionalValue = new MultiLanguageString().withFallback()
-                                                                                 .withValidLanguages(NLS.getSupportedLanguages())
+                                                                                 .withValidLanguages(UserContext.getCurrentScope()
+                                                                                                                .getAvailableLanguages())
                                                                                  .withConditionName("code-lists");
 
     /**

--- a/src/main/java/sirius/biz/codelists/CodeListEntryData.java
+++ b/src/main/java/sirius/biz/codelists/CodeListEntryData.java
@@ -27,7 +27,6 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Priorized;
 import sirius.kernel.nls.NLS;
-import sirius.web.security.UserContext;
 
 import javax.annotation.Nullable;
 
@@ -74,8 +73,6 @@ public class CodeListEntryData extends Composite {
     @Autoloaded
     @PrefixSearchContent
     private final MultiLanguageString value = new MultiLanguageString().withFallback()
-                                                                       .withValidLanguages(UserContext.getCurrentScope()
-                                                                                                      .getAvailableLanguages())
                                                                        .withConditionName("code-lists");
 
     /**
@@ -87,8 +84,6 @@ public class CodeListEntryData extends Composite {
     @Autoloaded
     @PrefixSearchContent
     private final MultiLanguageString additionalValue = new MultiLanguageString().withFallback()
-                                                                                 .withValidLanguages(UserContext.getCurrentScope()
-                                                                                                                .getAvailableLanguages())
                                                                                  .withConditionName("code-lists");
 
     /**

--- a/src/main/java/sirius/biz/importer/format/FieldDefinition.java
+++ b/src/main/java/sirius/biz/importer/format/FieldDefinition.java
@@ -325,8 +325,7 @@ public class FieldDefinition {
             return this;
         }
 
-        UserContext.getCurrentScope()
-                   .getAvailableLanguages()
+        UserContext.getCurrentScope().getDisplayLanguages()
                    .stream()
                    .map(lang -> NLS.smartGet(alias, lang))
                    .filter(text -> !text.equals(getLabel()))

--- a/src/main/java/sirius/biz/importer/format/FieldDefinition.java
+++ b/src/main/java/sirius/biz/importer/format/FieldDefinition.java
@@ -12,6 +12,7 @@ import sirius.kernel.commons.Lambdas;
 import sirius.kernel.commons.Value;
 import sirius.kernel.commons.Values;
 import sirius.kernel.nls.NLS;
+import sirius.web.security.UserContext;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -324,16 +325,17 @@ public class FieldDefinition {
             return this;
         }
 
-        NLS.getSupportedLanguages()
-           .stream()
-           .map(lang -> NLS.smartGet(alias, lang))
-           .filter(text -> !text.equals(getLabel()))
-           .filter(text -> !aliases.stream()
-                                   .map(String::toLowerCase)
-                                   .collect(Collectors.toSet())
-                                   .contains(text.toLowerCase()))
-           .distinct()
-           .forEach(aliases::add);
+        UserContext.getCurrentScope()
+                   .getAvailableLanguages()
+                   .stream()
+                   .map(lang -> NLS.smartGet(alias, lang))
+                   .filter(text -> !text.equals(getLabel()))
+                   .filter(text -> !aliases.stream()
+                                           .map(String::toLowerCase)
+                                           .collect(Collectors.toSet())
+                                           .contains(text.toLowerCase()))
+                   .distinct()
+                   .forEach(aliases::add);
 
         return this;
     }

--- a/src/main/java/sirius/biz/jupiter/IDBTable.java
+++ b/src/main/java/sirius/biz/jupiter/IDBTable.java
@@ -159,7 +159,7 @@ public class IDBTable {
         }
 
         /**
-         * Uses the currently active languages for transaltable fields.
+         * Uses the currently active languages for translatable fields.
          * <p>
          * This is boilerplate for {@code translate(NLS.getCurrentLang(), NLS.getFallbackLanguage())}.
          *

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -194,9 +194,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         super(scope, config);
         this.systemTenant = config.get("system-tenant").asString();
         this.acceptApiTokens = config.get("accept-api-tokens").asBoolean(true);
-        this.availableLanguages = config.getStringList("available-languages").isEmpty() ?
-                                  Collections.singletonList(NLS.getDefaultLanguage()) :
-                                  config.getStringList("available-languages");
+        this.availableLanguages = scope.getAvailableLanguages().stream().toList();
     }
 
     /**
@@ -211,7 +209,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
     }
 
     /**
-     * Flushes all cahes for the given tenant.
+     * Flushes all caches for the given tenant.
      *
      * @param tenant the tenant to flush
      */

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -194,7 +194,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         super(scope, config);
         this.systemTenant = config.get("system-tenant").asString();
         this.acceptApiTokens = config.get("accept-api-tokens").asBoolean(true);
-        this.availableLanguages = scope.getAvailableLanguages().stream().toList();
+        this.availableLanguages = scope.getDisplayLanguages().stream().toList();
     }
 
     /**

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -36,7 +36,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 import sirius.web.http.WebContext;
-import sirius.web.security.UserContext;
+import sirius.web.security.ScopeInfo;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -335,7 +335,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty
 
         if (i18nEnabled && multiLanguageString.isEnabledForCurrentUser()) {
             Collection<String> languagesToLoad = multiLanguageString.getValidLanguages().isEmpty() ?
-                                                 UserContext.getCurrentScope().getAvailableLanguages() :
+                                                 ScopeInfo.DEFAULT_SCOPE.getAvailableLanguages() :
                                                  multiLanguageString.getValidLanguages();
             languagesToLoad.forEach(code -> {
                 String parameterName = getPropertyName() + "-" + code;

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -335,7 +335,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty
 
         if (i18nEnabled && multiLanguageString.isEnabledForCurrentUser()) {
             Collection<String> languagesToLoad = multiLanguageString.getValidLanguages().isEmpty() ?
-                                                 ScopeInfo.DEFAULT_SCOPE.getAvailableLanguages() :
+                                                 ScopeInfo.DEFAULT_SCOPE.getKnownLanguages() :
                                                  multiLanguageString.getValidLanguages();
             languagesToLoad.forEach(code -> {
                 String parameterName = getPropertyName() + "-" + code;

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -35,8 +35,8 @@ import sirius.kernel.commons.Values;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
-import sirius.kernel.nls.NLS;
 import sirius.web.http.WebContext;
+import sirius.web.security.UserContext;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -335,7 +335,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty
 
         if (i18nEnabled && multiLanguageString.isEnabledForCurrentUser()) {
             Collection<String> languagesToLoad = multiLanguageString.getValidLanguages().isEmpty() ?
-                                                 NLS.getSupportedLanguages() :
+                                                 UserContext.getCurrentScope().getAvailableLanguages() :
                                                  multiLanguageString.getValidLanguages();
             languagesToLoad.forEach(code -> {
                 String parameterName = getPropertyName() + "-" + code;

--- a/src/main/java/sirius/biz/util/Languages.java
+++ b/src/main/java/sirius/biz/util/Languages.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 
 /**
- * Provides a helper class to query the <tt>countries</tt> {@link LookupTable}.
+ * Provides a helper class to query the <tt>languages</tt> {@link LookupTable}.
  * <p>
  * Note that the table can be backed by either a {@link sirius.biz.codelists.CodeLists code list} or a
  * {@link sirius.biz.jupiter.Jupiter IDB table}. For most of the additional fields to work properly,

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -593,6 +593,14 @@ code-lists {
         name = "Countries"
         description = "Contains all countries known to the system. A RegEx can be supplied as additional value which is used to verify ZIP codes"
     }
+
+    # Defines the list of languages.
+    languages {
+        autofill = false
+        global = true
+        name = "Languages"
+        description = "Contains all languages known to the system."
+    }
 }
 
 # Provides the settings which determine how LookupTables are fueled with data.

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1225,7 +1225,7 @@ security {
         default-language = "de"
         fallback-language = "en"
         known-languages = ["de", "en", "fr", "nl", "it", "es", "pl", "cs", "hu", "da", "sv", "ro", "ru", "sk", "bg"]
-        available-languages = ["de", "en", "fr", "nl", "it", "es", "pl", "cs", "hu", "da", "sv", "ro", "ru", "sk", "bg"]
+        display-languages = ["de", "en", "fr", "nl", "it", "es", "pl", "cs", "hu", "da", "sv", "ro", "ru", "sk", "bg"]
     }
 
     permissions {

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1214,7 +1214,9 @@ security {
         manager = "tenants"
         system-tenant = "1"
         loginCookieTTL = 90 days
-        available-languages = []
+        default-language = "de"
+        fallback-language = "en"
+        available-languages = ["de", "en", "fr", "nl", "it", "es", "pl", "cs", "hu", "da", "sv", "ro", "ru", "sk", "bg"]
     }
 
     permissions {
@@ -1250,7 +1252,7 @@ security {
     # Defines all sub scopes known by the system. This can be redefined by the application.
     subScopes = [ "ui", "api", "vfs", "empty" ]
 
-    # Defines all tenant permissions (aka features). This also can be redefinec by the application.
+    # Defines all tenant permissions (aka features). This also can be redefined by the application.
     tenantPermissions = [
     ]
 

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1224,6 +1224,7 @@ security {
         loginCookieTTL = 90 days
         default-language = "de"
         fallback-language = "en"
+        known-languages = ["de", "en", "fr", "nl", "it", "es", "pl", "cs", "hu", "da", "sv", "ro", "ru", "sk", "bg"]
         available-languages = ["de", "en", "fr", "nl", "it", "es", "pl", "cs", "hu", "da", "sv", "ro", "ru", "sk", "bg"]
     }
 


### PR DESCRIPTION
Based on https://github.com/scireum/sirius-web/pull/864:
- Defines the default, fallback, and available languages for the default scope. Note: this provides more selectable languages to the user by default, since the previous setting (`nls.languages`) only included `de` and `en`.
- Replaces usages of the now deprecated `NLS.getSupportedLanguages`.

Fixes: SIRI-368
