### PR TITLE
Logs and skips 0-byte file when extracting archives

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -156,6 +156,11 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
                                   .format());
 
         Watch watch = Watch.start();
+
+        if (checkEmptyFile(extractedFile, process, watch)) {
+            return;
+        }
+
         String targetPath = getTargetPath(extractedFile, flattenDirectory);
         VirtualFile targetFile = targetDirectory.resolve(targetPath);
         ArchiveExtractor.UpdateResult result = extractor.updateFile(extractedFile, targetFile, overrideMode);
@@ -174,6 +179,17 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
         }
 
         log(process, extractedFile, targetFile, result.name());
+    }
+
+    private boolean checkEmptyFile(ExtractedFile extractedFile, ProcessContext process, Watch watch) {
+        if (extractedFile.size() > 0) {
+            return false;
+        }
+        process.log(ProcessLog.warn()
+                              .withNLSKey("ExtractArchiveJob.emptyFile")
+                              .withContext("filename", extractedFile.getFilePath()));
+        process.addTiming(NLS.get("ExtractArchiveJob.fileSkipped"), watch.elapsedMillis());
+        return true;
     }
 
     private String getTargetPath(ExtractedFile extractedFile, boolean flattenDirectory) {

--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -157,7 +157,11 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
 
         Watch watch = Watch.start();
 
-        if (checkEmptyFile(extractedFile, process, watch)) {
+        if (extractedFile.size() == 0) {
+            process.log(ProcessLog.warn()
+                                  .withNLSKey("ExtractArchiveJob.emptyFile")
+                                  .withContext("filename", extractedFile.getFilePath()));
+            process.addTiming(NLS.get("ExtractArchiveJob.fileSkipped"), watch.elapsedMillis());
             return;
         }
 
@@ -179,17 +183,6 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
         }
 
         log(process, extractedFile, targetFile, result.name());
-    }
-
-    private boolean checkEmptyFile(ExtractedFile extractedFile, ProcessContext process, Watch watch) {
-        if (extractedFile.size() > 0) {
-            return false;
-        }
-        process.log(ProcessLog.warn()
-                              .withNLSKey("ExtractArchiveJob.emptyFile")
-                              .withContext("filename", extractedFile.getFilePath()));
-        process.addTiming(NLS.get("ExtractArchiveJob.fileSkipped"), watch.elapsedMillis());
-        return true;
     }
 
     private String getTargetPath(ExtractedFile extractedFile, boolean flattenDirectory) {

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -229,6 +229,7 @@ ExtractArchiveJob.deletingArchive = Lösche entpacktes Archiv...
 ExtractArchiveJob.description = Entpackt eine Archivdatei aus der Dateiablage in das angegebene Zielverzeichnis.
 ExtractArchiveJob.destinationParameter = Zielverzeichnis
 ExtractArchiveJob.destinationParameter.help = Verzeichnis, in welches die Datei entpackt werden soll. Leer lassen, damit die Datei ins aktuelle Verzeichnis entpackt wird.
+ExtractArchiveJob.emptyFile = Datei '${filename}' ist leer und wurde übersprungen.
 ExtractArchiveJob.fileCreated = Datei erstellt
 ExtractArchiveJob.fileOverwritten = Datei überschrieben
 ExtractArchiveJob.fileSkipped = Datei ignoriert

--- a/src/main/resources/biz_en.properties
+++ b/src/main/resources/biz_en.properties
@@ -227,6 +227,7 @@ ExtractArchiveJob.deletingArchive = Delete unpacked archive ...
 ExtractArchiveJob.description = Extracts an archive file from the file storage into the specified target directory.
 ExtractArchiveJob.destinationParameter = Target directory
 ExtractArchiveJob.destinationParameter.help = Directory in which the file is to be extracted. Leave blank so that the file is extracted into the current directory.
+ExtractArchiveJob.emptyFile = File '${filename}' is empty and was skipped.
 ExtractArchiveJob.fileCreated = File created
 ExtractArchiveJob.fileOverwritten = File overwritten
 ExtractArchiveJob.fileSkipped = File ignored


### PR DESCRIPTION
```
unzip -v archive.zip
Archive:  archive.zip
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
   21599  Defl:N     8665  60% 06-29-2021 08:47 8ba3606f  12130.1k4.jpg
   28037  Defl:N    18916  33% 06-29-2021 08:47 70129347  99770ak3.jpg
 7760705  Defl:N   509247  93% 06-29-2021 08:47 a7173782  haproxy.log.3
       0  Stored        0   0% 06-29-2021 11:48 00000000  dummy.txt
--------          -------  ---                            -------
 7810341           536828  93%                            4 files
```

![image](https://user-images.githubusercontent.com/54799255/123777844-e0212d80-d8d0-11eb-8cbc-786d6746460d.png)

Fixes: SIRI-373