### PR TITLE
Improves the footer of Tycho templates.

### DIFF
--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -273,6 +273,7 @@ FileImportJobFactory.auxFileMode = Zusätzliche Dateien
 FileImportJobFactory.file = Datei
 FileOrDirectoryParameter.invalidPath = '${path}' ist weder eine Datei noch ein existierendes Ziel-Verzeichnis.
 FileParameter.invalidPath = Die Datei '${path}' wurde nicht gefunden.
+footer.html.supportLinkCopiedSuccessfully = Support-Link in Zwischenablage kopiert
 ForceReplicationJob.description = Erzwingt die vollständige Replikation eines Storage-Spaces. Dies ist vor allem sinnvoll, wenn ein neues Replikations-Ziel definiert wurde und Bestandsdaten repliziert werden sollen.
 ForceReplicationJob.jobTitle = Erzwinge vollständige Replikation von '${space}'
 ForceReplicationJob.label = Vollständige Storage-Space Replikation erzwingen

--- a/src/main/resources/default/extensions/tycho-page-menu/footer.html.pasta
+++ b/src/main/resources/default/extensions/tycho-page-menu/footer.html.pasta
@@ -21,7 +21,7 @@
                         copyToClipboard(window.location.protocol + window.location.host + '/tenants/select/@user().getTenantId()?goto=' + encodeURI(window.location.href));
 
                         clearMessages();
-                        addSuccessMessage('Support-Link in Zwischenablage kopiert');
+                        addSuccessMessage('@i18n("footer.html.supportLinkCopiedSuccessfully")');
                     }
                 </script>
             </i:if>

--- a/src/main/resources/default/extensions/tycho-page-menu/footer.html.pasta
+++ b/src/main/resources/default/extensions/tycho-page-menu/footer.html.pasta
@@ -14,15 +14,17 @@
         <t:permission permission="flag-logged-in">
             <i:if test="user().is(sirius.biz.tenants.Tenant.class)">
                 <span class="d-none d-md-inline-block text-muted small ml-2 pl-4 pr-0 bl-gray">
-                    <a id="supportLink" href="javascript:copySupportLink()" class="text-sirius-gray-dark"><i class="fa fa-link"></i></a>
+                    <a id="supportLink" class="text-sirius-gray-dark cursor-pointer"><i class="fa fa-link"></i></a>
                 </span>
                 <script type="text/javascript">
-                    function copySupportLink() {
-                        copyToClipboard(window.location.protocol + window.location.host + '/tenants/select/@user().getTenantId()?goto=' + encodeURI(window.location.href));
+                    sirius.ready(function() {
+                        document.querySelector('#supportLink').addEventListener('click', function() {
+                            copyToClipboard(window.location.protocol + window.location.host + '/tenants/select/@user().getTenantId()?goto=' + encodeURI(window.location.href));
 
-                        clearMessages();
-                        addSuccessMessage('@i18n("footer.html.supportLinkCopiedSuccessfully")');
-                    }
+                            clearMessages();
+                            addSuccessMessage('@i18n("footer.html.supportLinkCopiedSuccessfully")');
+                        });
+                    });
                 </script>
             </i:if>
         </t:permission>

--- a/src/main/resources/default/extensions/tycho-page-menu/footer.html.pasta
+++ b/src/main/resources/default/extensions/tycho-page-menu/footer.html.pasta
@@ -1,0 +1,30 @@
+<i:arg type="String" name="point"/>
+<i:pragma name="priority" value="1000"/>
+
+<i:switch test="@point">
+    <i:block name="footer-right-start">
+        <t:permission permission="flag-logged-in">
+            <span class="d-none d-xl-inline-block text-muted small mr-2 pr-2 br-gray">
+               <b>@user().getUserName()</b>
+               <i:if test="isFilled(user().getTenantName())">(@user().getTenantName())</i:if>
+            </span>
+        </t:permission>
+    </i:block>
+    <i:block name="footer-right-end">
+        <t:permission permission="flag-logged-in">
+            <i:if test="user().is(sirius.biz.tenants.Tenant.class)">
+                <span class="d-none d-md-inline-block text-muted small ml-2 pl-4 pr-0 bl-gray">
+                    <a id="supportLink" href="javascript:copySupportLink()" class="text-sirius-gray-dark"><i class="fa fa-link"></i></a>
+                </span>
+                <script type="text/javascript">
+                    function copySupportLink() {
+                        copyToClipboard(window.location.protocol + window.location.host + '/tenants/select/@user().getTenantId()?goto=' + encodeURI(window.location.href));
+
+                        clearMessages();
+                        addSuccessMessage('Support-Link in Zwischenablage kopiert');
+                    }
+                </script>
+            </i:if>
+        </t:permission>
+    </i:block>
+</i:switch>

--- a/src/main/resources/default/extensions/tycho-script/tycho-script.html.pasta
+++ b/src/main/resources/default/extensions/tycho-script/tycho-script.html.pasta
@@ -1,0 +1,1 @@
+<i:invoke template="/assets/scripts/tycho-biz.js.pasta" />


### PR DESCRIPTION
<img width="459" alt="grafik" src="https://user-images.githubusercontent.com/875799/123816853-f42c5580-d8f7-11eb-8c9a-f5d18f846b1f.png">

We now include the user/tenant name and a deep-link to be sent to support agents. This will perform the proper tenant selection and then redirect to the page the user is currently visiting.
