### PR TITLE
Resolves cast error parsing 7-zip entries

### DIFF
--- a/src/main/java/sirius/biz/util/SevenZipAdapter.java
+++ b/src/main/java/sirius/biz/util/SevenZipAdapter.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Date;
 import java.util.function.Predicate;
 
 /**
@@ -82,12 +83,15 @@ class SevenZipAdapter implements IArchiveExtractCallback {
         }
 
         currentFilePath = fetchFilePath(index);
-        currentLastModified = Instant.ofEpochSecond((Long) inArchive.getProperty(index, PropID.LAST_MODIFICATION_TIME));
 
         // Enforce the filename filter...
         if (!filter.test(currentFilePath)) {
             return null;
         }
+
+        Date lastModificationTime = (Date) inArchive.getProperty(index, PropID.LAST_MODIFICATION_TIME);
+        currentLastModified =
+                lastModificationTime == null ? Instant.now() : Instant.ofEpochSecond(lastModificationTime.getTime());
 
         // We actually want to extract this file - setup the shared buffer properly.
         // Note that this might (sooner or later) create a temporary file. Therefore it is essential that this stream

--- a/src/main/java/sirius/biz/util/SevenZipAdapter.java
+++ b/src/main/java/sirius/biz/util/SevenZipAdapter.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -89,9 +90,9 @@ class SevenZipAdapter implements IArchiveExtractCallback {
             return null;
         }
 
-        Date lastModificationTime = (Date) inArchive.getProperty(index, PropID.LAST_MODIFICATION_TIME);
-        currentLastModified =
-                lastModificationTime == null ? Instant.now() : Instant.ofEpochSecond(lastModificationTime.getTime());
+        currentLastModified = Optional.ofNullable((Date) inArchive.getProperty(index, PropID.LAST_MODIFICATION_TIME))
+                                      .map(lastModificationTime -> Instant.ofEpochSecond(lastModificationTime.getTime()))
+                                      .orElse(Instant.now());
 
         // We actually want to extract this file - setup the shared buffer properly.
         // Note that this might (sooner or later) create a temporary file. Therefore it is essential that this stream

--- a/src/main/java/sirius/biz/util/SevenZipAdapter.java
+++ b/src/main/java/sirius/biz/util/SevenZipAdapter.java
@@ -91,7 +91,8 @@ class SevenZipAdapter implements IArchiveExtractCallback {
         }
 
         currentLastModified = Optional.ofNullable((Date) inArchive.getProperty(index, PropID.LAST_MODIFICATION_TIME))
-                                      .map(lastModificationTime -> Instant.ofEpochMilli(lastModificationTime.getTime()))
+                                      .map(Date::getTime)
+                                      .map(Instant::ofEpochMilli)
                                       .orElse(Instant.now());
 
         // We actually want to extract this file - setup the shared buffer properly.

--- a/src/main/java/sirius/biz/util/SevenZipAdapter.java
+++ b/src/main/java/sirius/biz/util/SevenZipAdapter.java
@@ -91,7 +91,7 @@ class SevenZipAdapter implements IArchiveExtractCallback {
         }
 
         currentLastModified = Optional.ofNullable((Date) inArchive.getProperty(index, PropID.LAST_MODIFICATION_TIME))
-                                      .map(lastModificationTime -> Instant.ofEpochSecond(lastModificationTime.getTime()))
+                                      .map(lastModificationTime -> Instant.ofEpochMilli(lastModificationTime.getTime()))
                                       .orElse(Instant.now());
 
         // We actually want to extract this file - setup the shared buffer properly.


### PR DESCRIPTION
PropID.LAST_MODIFICATION_TIME returns a Date (or null) which can't be parsed as Long.

Therefore we use getTime or assume the Instant.now in the unlikely event where the modification date isn't present in the archive

Fixes: SIRI-373