### PR TITLE
Fix whitespace wrapping for job logs in chrome

### DIFF
--- a/src/main/resources/default/templates/biz/process/process-details.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-details.html.pasta
@@ -77,7 +77,7 @@
                     <td/>
                     <td>
                         <div>
-                            <pre class="plain" style="white-space: pre-wrap">@log.getMessage()</pre>
+                            <pre class="plain" style="white-space: break-spaces">@log.getMessage()</pre>
                         </div>
                         <div>
                             <i:for type="sirius.biz.process.logs.ProcessLogAction" var="action"

--- a/src/main/resources/default/templates/biz/process/process-logs.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-logs.html.pasta
@@ -55,7 +55,7 @@
                 <td/>
                 <td>
                     <div>
-                        <pre class="plain" style="white-space: pre-wrap">@log.getMessage()</pre>
+                        <pre class="plain" style="white-space: break-spaces">@log.getMessage()</pre>
                     </div>
                     <div>
                         <i:for type="sirius.biz.process.logs.ProcessLogAction" var="action" items="log.getActions()">

--- a/src/main/resources/default/templates/biz/process/process-output-logs.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-output-logs.html.pasta
@@ -41,7 +41,7 @@
             <tr class="@log.getRowClass()">
                 <td/>
                 <td>
-                    <pre class="plain" style="white-space: pre-wrap">@log.getMessage()</pre>
+                    <pre class="plain" style="white-space: break-spaces">@log.getMessage()</pre>
                 </td>
                 <td class="align-right">
                     @log.getTimestampAsString()<br>

--- a/src/main/resources/default/templates/biz/protocol/audit_logs.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/audit_logs.html.pasta
@@ -51,7 +51,7 @@
                                     @msg.getIp()
                                 </div>
                             </div>
-                            <pre class="plain" style="white-space: pre-wrap">@i18n(msg.getMessage())</pre>
+                            <pre class="plain" style="white-space: break-spaces">@i18n(msg.getMessage())</pre>
                         </td>
                     </tr>
                 </i:for>

--- a/src/main/resources/default/templates/biz/protocol/entity_protocol.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/entity_protocol.html.pasta
@@ -51,7 +51,7 @@
                             <div class="row">
                                 <div class="col-md-12">
                                     <p/>
-                                    <pre class="plain" style="white-space: pre-wrap">@msg.getChanges()</pre>
+                                    <pre class="plain" style="white-space: break-spaces">@msg.getChanges()</pre>
                                 </div>
                             </div>
                         </td>

--- a/src/main/resources/default/templates/biz/protocol/errors.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/errors.html.pasta
@@ -56,7 +56,7 @@
                             </div>
                             <div class="row">
                                 <div class="col-md-12 error-code">
-                                    <pre class="plain" style="white-space: pre-wrap; padding-top: 8px">@i.getMessage()</pre>
+                                    <pre class="plain" style="white-space: break-spaces; padding-top: 8px">@i.getMessage()</pre>
                                 </div>
                             </div>
                         </td>

--- a/src/main/resources/default/templates/biz/protocol/logs.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/logs.html.pasta
@@ -48,7 +48,7 @@
                             </div>
                             <div class="row">
                                 <div class="col-md-12">
-                                    <pre class="plain" style="white-space: pre-wrap; padding-top: 8px">@msg.getMessage()</pre>
+                                    <pre class="plain" style="white-space: break-spaces; padding-top: 8px">@msg.getMessage()</pre>
                                 </div>
                             </div>
                         </td>

--- a/src/main/resources/default/templates/biz/protocol/protocol.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/protocol.html.pasta
@@ -55,7 +55,7 @@
                             </div>
                             <div class="row">
                                 <div class="col-md-12">
-                                    <pre class="plain" style="white-space: pre-wrap; padding-top: 8px">@msg.getChanges()</pre>
+                                    <pre class="plain" style="white-space: break-spaces; padding-top: 8px">@msg.getChanges()</pre>
                                 </div>
                             </div>
                         </td>


### PR DESCRIPTION
| Before | After |
|:----:|:------|
| <img width="1222" alt="grafik" src="https://user-images.githubusercontent.com/3729858/124439554-d9376680-dd79-11eb-8f98-a19bcf6c5ac6.png"> | <img width="1222" alt="grafik" src="https://user-images.githubusercontent.com/3729858/124439464-bd33c500-dd79-11eb-902b-7a0e90af9ae6.png"> |
| <img width="1222" alt="grafik" src="https://user-images.githubusercontent.com/3729858/124439620-ea807300-dd79-11eb-9e97-20ba44b1b96a.png"> | <img width="1222" alt="grafik" src="https://user-images.githubusercontent.com/3729858/124439664-f9672580-dd79-11eb-916f-aa2d485f1ada.png"> |

Links to the examples:
https://webshop-test.unielektro.de/ps/Q3VG09KL8LBBU9HHPBAI908BBO/logs?type=WARNING&query=%21price+group+%21ELEKTRO+intern+data+sued-ost
https://webshop-test.unielektro.de/system/errors?query=getNetPrice