### PR TITLE
Bugfix: Avoid false-positive SQL warning on a clickhouse evaluation

### DIFF
--- a/src/main/java/sirius/biz/analytics/events/ClickhouseSizeChartJobFactory.java
+++ b/src/main/java/sirius/biz/analytics/events/ClickhouseSizeChartJobFactory.java
@@ -94,9 +94,7 @@ public class ClickhouseSizeChartJobFactory extends LinearChartJobFactory {
                                               + " GROUP BY toYear(max_date), toMonth(max_date)"
                                               + " ORDER BY toYear(max_date), toMonth(max_date)");
 
-        entityDescriptorParameter.get(context).ifPresent(descriptor -> {
-            query.set("table", descriptor.getRelationName());
-        });
+        query.set("table", entityDescriptorParameter.get(context).map(EntityDescriptor::getRelationName).orElse(null));
 
         List<String> labels = new ArrayList<>();
         Dataset rows = new Dataset("Rows");


### PR DESCRIPTION
Previously, the sql engine issued an error about a "forgotten" parameter, which - in this case - is left out on purpose.