### PR TITLE
Fixes calls to Blob.getFilename / Blob.getPath after updating the blob contents without providing a file name

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -27,6 +27,7 @@ import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.annotations.Unique;
 import sirius.db.mixing.types.BaseEntityRef;
+import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Framework;
 import sirius.kernel.di.std.Part;
@@ -240,7 +241,7 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
             this.filename = filename.trim();
             if (Strings.isFilled(filename)) {
                 this.normalizedFilename = filename.toLowerCase();
-                this.fileExtension = Strings.splitAtLast(normalizedFilename, ".").getSecond();
+                this.fileExtension = Files.getFileExtension(normalizedFilename);
             } else {
                 this.filename = null;
                 this.normalizedFilename = null;

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -480,7 +480,9 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                 // Also update in-memory to avoid an additional database fetch...
                 String previousPhysicalObjectKey = blob.getPhysicalObjectKey();
                 blob.setPhysicalObjectKey(nextPhysicalId);
-                blob.setFilename(filename);
+                if (Strings.isFilled(filename)) {
+                    blob.setFilename(filename);
+                }
                 blob.updateFilenameFields();
                 blob.setSize(size);
                 blob.setLastModified(LocalDateTime.now());

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -27,6 +27,7 @@ import sirius.db.mixing.types.BaseEntityRef;
 import sirius.db.mongo.Mango;
 import sirius.db.mongo.MongoEntity;
 import sirius.db.mongo.types.MongoRef;
+import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Framework;
 import sirius.kernel.di.std.Part;
@@ -245,7 +246,7 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
             this.filename = filename.trim();
             if (Strings.isFilled(filename)) {
                 this.normalizedFilename = filename.toLowerCase();
-                this.fileExtension = Strings.splitAtLast(normalizedFilename, ".").getSecond();
+                this.fileExtension = Files.getFileExtension(normalizedFilename);
             } else {
                 this.filename = null;
                 this.normalizedFilename = null;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -409,7 +409,9 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                 // Also update in-memory to avoid an additional database fetch...
                 String previousPhysicalObjectKey = blob.getPhysicalObjectKey();
                 blob.setPhysicalObjectKey(nextPhysicalId);
-                blob.setFilename(filename);
+                if (Strings.isFilled(filename)) {
+                    blob.setFilename(filename);
+                }
                 blob.updateFilenameFields();
                 blob.setSize(size);
                 blob.setLastModified(LocalDateTime.now());


### PR DESCRIPTION
Example:
```
Blob blob = blobStorage.getSpace("attachments").findOrCreateByPath("file.ext");
   blob.getPath() -> "/attachments/file.ext"

blob.updateContent(null, file);
   ERROR: blob.getPath() -> "/attachments/null"
   EXPECTED: blob.getPath() -> "/attachments/file.ext"
```

Fixes: OX-7005