### PR TITLE
Adds a way to retrieve all entries matching a lookup of idb tables

### DIFF
--- a/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
@@ -134,6 +134,8 @@ class CodeListLookupTable extends LookupTable {
 
     @Override
     protected Stream<LookupTableEntry> performQuery(String lang, String lookupPath, String lookupValue) {
+        // This would need a complex caching strategy as always fetching the DB would be too expensive.
+        // Could be implemented when needed.
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
@@ -133,7 +133,7 @@ class CodeListLookupTable extends LookupTable {
     }
 
     @Override
-    protected Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue) {
+    protected Stream<LookupTableEntry> performQuery(String lang, String lookupPath, String lookupValue) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
@@ -131,4 +131,9 @@ class CodeListLookupTable extends LookupTable {
     protected Stream<LookupTableEntry> performScan(String lang) {
         return codeLists.getEntries(codeList).stream().map(entry -> extractEntryData(entry, lang));
     }
+
+    @Override
+    protected Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/sirius/biz/codelists/CustomLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CustomLookupTable.java
@@ -101,8 +101,8 @@ class CustomLookupTable extends LookupTable {
     }
 
     @Override
-    protected Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue) {
-        return Stream.concat(customTable.performLookupScan(lang, lookupPath, lookupValue),
-                             baseTable.performLookupScan(lang, lookupPath, lookupValue));
+    protected Stream<LookupTableEntry> performQuery(String lang, String lookupPath, String lookupValue) {
+        return Stream.concat(customTable.performQuery(lang, lookupPath, lookupValue),
+                             baseTable.performQuery(lang, lookupPath, lookupValue));
     }
 }

--- a/src/main/java/sirius/biz/codelists/CustomLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CustomLookupTable.java
@@ -99,4 +99,10 @@ class CustomLookupTable extends LookupTable {
     protected Stream<LookupTableEntry> performScan(String lang) {
         return Stream.concat(customTable.performScan(lang), baseTable.performScan(lang));
     }
+
+    @Override
+    protected Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue) {
+        return Stream.concat(customTable.performLookupScan(lang, lookupPath, lookupValue),
+                             baseTable.performLookupScan(lang, lookupPath, lookupValue));
+    }
 }

--- a/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
@@ -114,7 +114,7 @@ class IDBFilteredLookupTable extends LookupTable {
     }
 
     @Override
-    protected Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue) {
-        return baseTable.lookupScan(lang, lookupPath, lookupValue).filter(pair -> contains(pair.getCode()));
+    protected Stream<LookupTableEntry> performQuery(String lang, String lookupPath, String lookupValue) {
+        return baseTable.query(lang, lookupPath, lookupValue).filter(pair -> contains(pair.getCode()));
     }
 }

--- a/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
@@ -112,4 +112,9 @@ class IDBFilteredLookupTable extends LookupTable {
     protected Stream<LookupTableEntry> performScan(String lang) {
         return baseTable.scan(lang).filter(pair -> contains(pair.getCode()));
     }
+
+    @Override
+    protected Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue) {
+        return baseTable.lookupScan(lang, lookupPath, lookupValue).filter(pair -> contains(pair.getCode()));
+    }
 }

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -323,7 +323,12 @@ class IDBLookupTable extends LookupTable {
             Exceptions.createHandled()
                       .to(Jupiter.LOG)
                       .error(e)
-                      .withSystemErrorMessage("Error scanning lang '%s' table '%s': %s (%s)", lang, table.getName())
+                      .withSystemErrorMessage(
+                              "Error on lookup scan lang '%s' lookupPath '%s' lookupValue '%s' table '%s': %s (%s)",
+                              lang,
+                              lookupPath,
+                              lookupValue,
+                              table.getName())
                       .handle();
             return Stream.empty();
         }

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -306,4 +306,26 @@ class IDBLookupTable extends LookupTable {
             return Stream.empty();
         }
     }
+
+    @Override
+    protected Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue) {
+        try {
+            return table.query()
+                        .translate(lang)
+                        .lookupPaths(lookupPath)
+                        .searchValue(lookupValue)
+                        .allRows(codeField, nameField, descriptionField, COL_DEPRECATED)
+                        .filter(row -> !row.at(3).asBoolean())
+                        .map(row -> new LookupTableEntry(row.at(0).asString(),
+                                                         row.at(1).asString(),
+                                                         row.at(2).getString()));
+        } catch (Exception e) {
+            Exceptions.createHandled()
+                      .to(Jupiter.LOG)
+                      .error(e)
+                      .withSystemErrorMessage("Error scanning lang '%s' table '%s': %s (%s)", lang, table.getName())
+                      .handle();
+            return Stream.empty();
+        }
+    }
 }

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -48,6 +48,7 @@ class IDBLookupTable extends LookupTable {
     private static final String CACHE_PREFIX_NORMALIZE_WITH_MAPPING = "normalize-with-mapping";
     private static final String CACHE_PREFIX_REVERSE_LOOKUP = "reverse-lookup-";
     private static final String CACHE_PREFIX_FETCH_OBJECT = "fetch-object-";
+    private static final String CACHE_PREFIX_LOOKUP_SCAN = "lookup-scan-";
 
     private static final String CONFIG_CODE_FIELD = "codeField";
     private static final String CONFIG_NAME_FIELD = "nameField";
@@ -308,7 +309,7 @@ class IDBLookupTable extends LookupTable {
     }
 
     @Override
-    protected Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue) {
+    protected Stream<LookupTableEntry> performQuery(String lang, String lookupPath, String lookupValue) {
         try {
             return table.query()
                         .translate(lang)

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -48,7 +48,6 @@ class IDBLookupTable extends LookupTable {
     private static final String CACHE_PREFIX_NORMALIZE_WITH_MAPPING = "normalize-with-mapping";
     private static final String CACHE_PREFIX_REVERSE_LOOKUP = "reverse-lookup-";
     private static final String CACHE_PREFIX_FETCH_OBJECT = "fetch-object-";
-    private static final String CACHE_PREFIX_LOOKUP_SCAN = "lookup-scan-";
 
     private static final String CONFIG_CODE_FIELD = "codeField";
     private static final String CONFIG_NAME_FIELD = "nameField";

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -740,10 +740,6 @@ public abstract class LookupTable {
      * @return a stream of all entries matching the lookup or an empty stream if scanning isn't supported
      */
     public Stream<LookupTableEntry> lookupScan(String lang, String lookupPath, String lookupValue) {
-        if (!canScan()) {
-            return Stream.empty();
-        }
-
         return performLookupScan(lang, lookupPath, lookupValue);
     }
 

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -739,9 +739,9 @@ public abstract class LookupTable {
      * @param lookupValue the value to search for
      * @return a stream of all entries matching the lookup or an empty stream if scanning isn't supported
      */
-    public Stream<LookupTableEntry> lookupScan(String lang, String lookupPath, String lookupValue) {
-        return performLookupScan(lang, lookupPath, lookupValue);
+    public Stream<LookupTableEntry> query(String lang, String lookupPath, String lookupValue) {
+        return performQuery(lang, lookupPath, lookupValue);
     }
 
-    protected abstract Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue);
+    protected abstract Stream<LookupTableEntry> performQuery(String lang, String lookupPath, String lookupValue);
 }

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -636,8 +636,7 @@ public abstract class LookupTable {
                                              .stream()
                                              .filter(entry -> entry.getValue() instanceof JSONArray)
                                              .collect(Collectors.toMap(Map.Entry::getKey,
-                                                                       entry -> transformArrayToStringList((JSONArray) entry
-                                                                               .getValue())));
+                                                                       entry -> transformArrayToStringList((JSONArray) entry.getValue())));
         } else {
             return Collections.emptyMap();
         }
@@ -720,7 +719,7 @@ public abstract class LookupTable {
      * Enumerates all entries in the table using the given language.
      *
      * @param lang the language to translate the name and description to
-     * @return a stream of all entries in this table or an empty stream is scanning isn't supported
+     * @return a stream of all entries in this table or an empty stream if scanning isn't supported
      */
     public Stream<LookupTableEntry> scan(String lang) {
         if (!canScan()) {
@@ -731,4 +730,22 @@ public abstract class LookupTable {
     }
 
     protected abstract Stream<LookupTableEntry> performScan(String lang);
+
+    /**
+     * Enumerates all entries matching the given lookup in the table using the given language.
+     *
+     * @param lang        the language to translate the name and description to
+     * @param lookupPath  the field to search in
+     * @param lookupValue the value to search for
+     * @return a stream of all entries matching the lookup or an empty stream if scanning isn't supported
+     */
+    public Stream<LookupTableEntry> lookupScan(String lang, String lookupPath, String lookupValue) {
+        if (!canScan()) {
+            return Stream.empty();
+        }
+
+        return performLookupScan(lang, lookupPath, lookupValue);
+    }
+
+    protected abstract Stream<LookupTableEntry> performLookupScan(String lang, String lookupPath, String lookupValue);
 }


### PR DESCRIPTION
Previously there were only ways to easily either get all entries of a table or lookup a single entry.

Fixes: OX-6913