### PR TITLE
Enhances the ErrorContext

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -32,6 +32,9 @@ import java.util.function.Consumer;
  */
 public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
 
+    private static final String ERROR_CONTEXT_FILE_PATH = "$DictionaryBasedArchiveImportJob.file";
+    private static final String ERROR_CONTEXT_ROW = "$LineBasedJob.row";
+
     /**
      * Describes a file to be imported from an archive.
      */
@@ -162,13 +165,18 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
                                                                                 importFile.rowHandler).withIgnoreEmptyValues(
                 importFile.ignoreEmptyFields).withRowCounterName(importFile.rowCounterName);
 
+        errorContext.withContext(ERROR_CONTEXT_FILE_PATH, extractedFile.getFilePath());
         try (InputStream stream = extractedFile.openInputStream()) {
-            LineBasedProcessor.create(importFile.filename, stream, false)
-                              .run(dictionaryBasedImport::handleRow, error -> {
-                                  process.handle(error);
-                                  return true;
-                              });
+            LineBasedProcessor.create(importFile.filename, stream, false).run((lineNumber, row) -> {
+                errorContext.withContext(ERROR_CONTEXT_ROW, lineNumber);
+                dictionaryBasedImport.handleRow(lineNumber, row);
+                errorContext.removeContext(ERROR_CONTEXT_ROW);
+            }, error -> {
+                process.handle(error);
+                return true;
+            });
         }
+        errorContext.removeContext(ERROR_CONTEXT_FILE_PATH);
 
         if (importFile.completionHandler != null) {
             importFile.completionHandler.execute();

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -173,10 +173,12 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
                 errorContext.removeContext(ERROR_CONTEXT_ROW);
             }, error -> {
                 process.handle(error);
+                errorContext.removeContext(ERROR_CONTEXT_ROW);
                 return true;
             });
+        } finally {
+            errorContext.removeContext(ERROR_CONTEXT_FILE_PATH);
         }
-        errorContext.removeContext(ERROR_CONTEXT_FILE_PATH);
 
         if (importFile.completionHandler != null) {
             importFile.completionHandler.execute();

--- a/src/main/java/sirius/biz/jobs/batch/file/FileImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/FileImportJob.java
@@ -42,6 +42,8 @@ import java.util.function.Consumer;
  */
 public abstract class FileImportJob extends ImportJob {
 
+    public static final String FILE_LABEL = "$FileImportJobFactory.file";
+
     /**
      * Contains the parameter which selects the file to import.
      * <p>
@@ -79,6 +81,7 @@ public abstract class FileImportJob extends ImportJob {
     protected ValueHolder<VirtualFile> auxFilesDestination;
     protected AuxiliaryFileMode auxiliaryFileMode;
     protected boolean flattenAuxiliaryFileDirs;
+    protected boolean suppressFileNameInContext;
 
     /**
      * Defines the modes in which an auxiliary file in an archive can be handled.
@@ -142,7 +145,7 @@ public abstract class FileImportJob extends ImportJob {
      * @return the parameter used to select the import file
      */
     public static Parameter<VirtualFile> createFileParameter(@Nullable List<String> acceptedFileExtensions) {
-        FileParameter result = new FileParameter("file", "$FileImportJobFactory.file").withBasePath("/work");
+        FileParameter result = new FileParameter("file", FILE_LABEL).withBasePath("/work");
         if (acceptedFileExtensions != null && !acceptedFileExtensions.isEmpty()) {
             result.withAcceptedExtensionsList(acceptedFileExtensions);
         }
@@ -163,7 +166,7 @@ public abstract class FileImportJob extends ImportJob {
 
             try (FileHandle fileHandle = file.download()) {
                 backupInputFile(file.name(), fileHandle);
-                errorContext.inContext("$FileImportJobFactory.file",
+                errorContext.inContext(suppressFileNameInContext ? "" : FILE_LABEL,
                                        file.name(),
                                        () -> executeForStream(file.name(), fileHandle::getInputStream));
             }
@@ -229,7 +232,7 @@ public abstract class FileImportJob extends ImportJob {
             process.log(ProcessLog.info()
                                   .withNLSKey("FileImportJob.importingZippedFile")
                                   .withContext("filename", extractedFile.getFilePath()));
-            errorContext.inContext("$FileImportJobFactory.file",
+            errorContext.inContext(suppressFileNameInContext ? "" : FILE_LABEL,
                                    extractedFile.getFilePath(),
                                    () -> executeForStream(extractedFile.getFilePath(), extractedFile::openInputStream));
             return true;
@@ -244,7 +247,7 @@ public abstract class FileImportJob extends ImportJob {
      * Gets invoked for every entry in a given ZIP archive which cannot be processed by this job itself.
      * <p>
      * This might be used e.g. if an XML file is being processed which is accompanied with some media files to
-     * move them into the proper direcotry in the {@link sirius.biz.storage.layer3.VirtualFileSystem}.
+     * move them into the proper directory in the {@link sirius.biz.storage.layer3.VirtualFileSystem}.
      * <p>
      * By default this is attempted if the {@link #determineAuxiliaryFilesDirectory()} returns a non-null result.
      * Otherwise these files are simply ignored.
@@ -336,4 +339,13 @@ public abstract class FileImportJob extends ImportJob {
      * @return <tt>true</tt> if it can be handled, <tt>false</tt> otherwise
      */
     protected abstract boolean canHandleFileExtension(@Nullable String fileExtension);
+
+    /**
+     * Permits to suppress the file name to be added in the {@link sirius.biz.process.ErrorContext}.
+     * <p>
+     * This is useful in jobs processing a single file, where the file name would be printed in every single error message
+     */
+    protected void suppressFileNameInContext() {
+        this.suppressFileNameInContext = true;
+    }
 }

--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -63,6 +63,9 @@ public class ErrorContext implements SubContext {
      * @return the extended context for fluent method calls
      */
     public ErrorContext withContext(String label, Object value) {
+        if (Strings.isEmpty(label)) {
+            return this;
+        }
         if (Strings.isEmpty(value)) {
             this.context.remove(label);
         } else {

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -188,6 +188,7 @@ DeleteTenantJobFactory.title.simulate = Lösche Mandanten "${name}" (SIMULIERT)
 DeleteTenantTask.beforeExecution.many = Lösche ${count} ${name}.
 DeleteTenantTask.beforeExecution.no = Keine ${name} zu löschen.
 DeleteTenantTask.beforeExecution.one = Lösche 1 ${name}.
+DictionaryBasedArchiveImportJob.file = Datei
 DictionaryBasedArchiveImportJob.msgImportFile = Importiere ${file}...
 DictionaryBasedImportJobFactory.ignoreEmpty = Leere Werte ignorieren
 DictionaryBasedImportJobFactory.ignoreEmpty.help = Gibt an, dass fehlende Werte übersprungen werden statt das entsprechende Ziel-Feld zu leeren.

--- a/src/main/resources/biz_en.properties
+++ b/src/main/resources/biz_en.properties
@@ -185,6 +185,7 @@ DeleteTenantJobFactory.title.simulate = Delete client "${name}" (SIMULATED)
 DeleteTenantTask.beforeExecution.many = Deleting ${count} ${name}.
 DeleteTenantTask.beforeExecution.no = No ${name} to delete.
 DeleteTenantTask.beforeExecution.one = Deleting 1 ${name}.
+DictionaryBasedArchiveImportJob.file = File
 DictionaryBasedImportJobFactory.ignoreEmpty = Ignore empty values
 DictionaryBasedImportJobFactory.ignoreEmpty.help = Specifies that missing values are skipped instead of emptying the corresponding target field.
 DirectoryParameter.invalidPath = The directory '${path}' was not found.


### PR DESCRIPTION
The DictionaryBasedArchiveImportJob parses multiple files (eg. CSV) from an archive, so we identify the current file and row being processed.

Logs errors messages (also in ProcessContext) instead of throwing them and avoiding abrupt stop (eg. when looping XML nodes)

Permits to suppress the file name when printing error messages, useful in single file operations.

Fixes: OX-7060