### PR TITLE
Defaults to the base table's code case for filtered lookup tables

### DIFF
--- a/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
@@ -36,6 +36,10 @@ class IDBFilteredLookupTable extends LookupTable {
         super(extension);
         this.baseTable = baseTable;
         this.filterSet = filterSet;
+        this.codeCase = extension.get(LookupTable.CONFIG_KEY_CODE_CASE_MODE)
+                                 .upperCase()
+                                 .getEnum(CodeCase.class)
+                                 .orElse(baseTable.codeCase);
     }
 
     protected boolean contains(String code) {

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -54,11 +54,11 @@ public abstract class LookupTable {
 
     private static final int MAX_SUGGESTIONS = 25;
     private static final String CONFIG_KEY_SUPPORTS_SCAN = "supportsScan";
-    private static final String CONFIG_KEY_CODE_CASE_MODE = "codeCase";
+    protected static final String CONFIG_KEY_CODE_CASE_MODE = "codeCase";
     public static final String CONFIG_KEY_MAPPING_FIELD = "mappingsField";
     private final boolean supportsScan;
-    private final CodeCase codeCase;
     private final String mappingsField;
+    protected CodeCase codeCase;
 
     enum CodeCase {
         LOWER, UPPER, VERBATIM
@@ -88,14 +88,11 @@ public abstract class LookupTable {
             return null;
         }
 
-        switch (codeCase) {
-            case LOWER:
-                return code.toLowerCase();
-            case UPPER:
-                return code.toUpperCase();
-            default:
-                return code;
-        }
+        return switch (codeCase) {
+            case LOWER -> code.toLowerCase();
+            case UPPER -> code.toUpperCase();
+            default -> code;
+        };
     }
 
     /**


### PR DESCRIPTION
This way, we don't need to repeat the code case in the config for each filtered table, where the base table's code case differs from the default setting.

Fixes: SIRI-385