### PR TITLE
Uses IDB.LOOKUP in favor of IDB.SEARCH.

### DIFF
--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -204,7 +204,7 @@ class IDBLookupTable extends LookupTable {
         try {
             return jupiter.fetchFromSmallCache(CACHE_PREFIX_REVERSE_LOOKUP + table.getName() + "-" + name,
                                                () -> table.query()
-                                                          .searchPaths(nameField)
+                                                          .lookupPaths(nameField)
                                                           .searchValue(name.toLowerCase())
                                                           .singleRow(codeField)
                                                           .map(row -> row.at(0).asString())


### PR DESCRIPTION
When performing a reverse-lookup we don't want any prefix matches but
only full field matched. Note that as "name" has a fulltext index, we
can lowercase the search value and make the whole operation
case-insensitive.