### PR TITLE
Renames method to better reflect what it does

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -86,7 +86,7 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
         }
     }
 
-    protected void invokeChangedOrDeletedHandlers(Blob blob) {
+    protected void invokeCreatedOrRenamedHandlers(Blob blob) {
         createdOrRenamedHandlers.forEach(handler -> {
             try {
                 handler.execute(blob);

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -54,7 +54,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
     @Override
     protected void processCreatedOrRenamedBlobs(Runnable counter) {
         oma.select(SQLBlob.class).eq(SQLBlob.CREATED_OR_RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeChangedOrDeletedHandlers(blob);
+            invokeCreatedOrRenamedHandlers(blob);
             try {
                 oma.updateStatement(SQLBlob.class)
                    .set(SQLBlob.CREATED_OR_RENAMED, false)

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
@@ -60,7 +60,7 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
     @Override
     protected void processCreatedOrRenamedBlobs(Runnable counter) {
         mango.select(MongoBlob.class).eq(MongoBlob.CREATED_OR_RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeChangedOrDeletedHandlers(blob);
+            invokeCreatedOrRenamedHandlers(blob);
             mongo.update()
                  .set(MongoBlob.CREATED_OR_RENAMED, false)
                  .where(MongoBlob.ID, blob.getId())


### PR DESCRIPTION
As we renamed a protected method, this is technically a breaking change, but most probably without any action required.