### PR TITLE
Make BasicJobFactory#checkPermissions final

### DIFF
--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -262,8 +262,11 @@ public abstract class BasicJobFactory implements JobFactory {
 
     /**
      * Enforces the permissions sepcified by this job.
+     *
+     * You cannot override this method, because it should behave consistently with {@link #getRequiredPermissions()}.
+     * Please add all required permissions there.
      */
-    protected void checkPermissions() {
+    protected final void checkPermissions() {
         UserInfo currentUser = UserContext.getCurrentUser();
         getRequiredPermissions().forEach(currentUser::assertPermission);
     }

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountExportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountExportJobFactory.java
@@ -16,6 +16,7 @@ import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Provides an export for {@link SQLUserAccount user accounts}.
@@ -33,8 +34,10 @@ public class SQLUserAccountExportJobFactory extends EntityExportJobFactory<SQLUs
     }
 
     @Override
-    protected void checkPermissions() {
-        UserAccountController.assertProperUserManagementPermission();
+    public List<String> getRequiredPermissions() {
+        List<String> requiredPermissions = super.getRequiredPermissions();
+        requiredPermissions.add(UserAccountController.getUserManagementPermission());
+        return requiredPermissions;
     }
 
     @Override

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountImportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountImportJobFactory.java
@@ -16,6 +16,7 @@ import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Provides an import job for {@link SQLUserAccount user accounts} stored in a JDBC database.
@@ -33,8 +34,10 @@ public class SQLUserAccountImportJobFactory extends EntityImportJobFactory {
     }
 
     @Override
-    protected void checkPermissions() {
-        UserAccountController.assertProperUserManagementPermission();
+    public List<String> getRequiredPermissions() {
+        List<String> requiredPermissions = super.getRequiredPermissions();
+        requiredPermissions.add(UserAccountController.getUserManagementPermission());
+        return requiredPermissions;
     }
 
     @Override

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountExportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountExportJobFactory.java
@@ -16,6 +16,7 @@ import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Provides an export for {@link MongoUserAccount user accounts}.
@@ -34,8 +35,10 @@ public class MongoUserAccountExportJobFactory
     }
 
     @Override
-    protected void checkPermissions() {
-        UserAccountController.assertProperUserManagementPermission();
+    public List<String> getRequiredPermissions() {
+        List<String> requiredPermissions = super.getRequiredPermissions();
+        requiredPermissions.add(UserAccountController.getUserManagementPermission());
+        return requiredPermissions;
     }
 
     @Override

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountImportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountImportJobFactory.java
@@ -16,6 +16,7 @@ import sirius.kernel.di.std.Register;
 import sirius.web.http.QueryString;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Provides an import job for {@link MongoUserAccount user accounts} stored in MongoDB.
@@ -33,8 +34,10 @@ public class MongoUserAccountImportJobFactory extends EntityImportJobFactory {
     }
 
     @Override
-    protected void checkPermissions() {
-        UserAccountController.assertProperUserManagementPermission();
+    public List<String> getRequiredPermissions() {
+        List<String> requiredPermissions = super.getRequiredPermissions();
+        requiredPermissions.add(UserAccountController.getUserManagementPermission());
+        return requiredPermissions;
     }
 
     @Override


### PR DESCRIPTION
SIRI 364
This makes sure that `checkPermissions` always works consistently with `getRequiredPermissions`. Previously this was not always the case, which lead to bad user experience: The user account import did override the check, which prevented the user from executing it, but left it visible in the jobs overview.

Migration:
If you have existing overrides, refactor them to override `getRequiredPermissions` instead. You may return complex permission expressions, if required; see `Permissions#hasPermission`.