### PR TITLE
No longer removes hidden AutoImport fields from the import.

### DIFF
--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -336,7 +335,6 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
         return descriptor.getProperties()
                          .stream()
                          .filter(property -> property.getAnnotation(AutoImport.class)
-                                                     .filter(Predicate.not(AutoImport::hidden))
                                                      .map(AutoImport::permissions)
                                                      .map(currentUser::hasPermissions)
                                                      .orElse(false))


### PR DESCRIPTION
This was already fixed in https://github.com/scireum/sirius-biz/pull/1171, but reoccurred after merging master into develop

Fixes: OX-7173