### PR TITLE
Provides a clickable administrator link to the query tool in journal entries.

### DIFF
--- a/src/main/java/sirius/biz/protocol/JournalEntry.java
+++ b/src/main/java/sirius/biz/protocol/JournalEntry.java
@@ -16,6 +16,8 @@ import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.EntityDescriptor;
 import sirius.db.mixing.Mapping;
 import sirius.kernel.async.TaskContext;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Tuple;
 import sirius.kernel.di.std.Framework;
 
 import java.time.LocalDateTime;
@@ -89,6 +91,19 @@ public class JournalEntry extends SearchableEntity {
     @SearchContent
     @IndexMode(indexed = ESOption.FALSE, docValues = ESOption.FALSE)
     private String changes;
+
+    /**
+     * Splits the {@link #CONTENT_IDENTIFIER} into its two original parts.
+     * <p>
+     * This can be used for entities {@link DelegateJournalData} as the {@link #TARGET_TYPE} and {@link #TARGET_ID} contain
+     * the type and ID of the parent entity in those cases. So this method returns the actual type and ID of the entity
+     * using {@link DelegateJournalData} instead, the same as for entities using {@link JournalData}.
+     *
+     * @return a <tt>Tuple</tt> containing the type and ID of the changed entity
+     */
+    public Tuple<String, String> splitContentIdentifierParts() {
+        return Strings.split(contentIdentifier, "-");
+    }
 
     public LocalDateTime getTod() {
         return tod;

--- a/src/main/resources/default/templates/biz/protocol/protocol.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/protocol.html.pasta
@@ -47,7 +47,16 @@
                                 </div>
                                 <div class="col-md-4">
                                     <small>
-                                        @msg.getContentIdentifier() (@msg.getTargetId())
+                                        <i:if test="user().hasPermission('flag-system-administrator')">
+                                            <i:local name="identifierParts" value="@msg.splitContentIdentifierParts()"/>
+                                            <a href="/system/query?class=@identifierParts.getFirst()&query=id:@identifierParts.getSecond()"
+                                               target="_blank">
+                                                <b>@msg.getContentIdentifier() (@msg.getTargetId())</b>
+                                            </a>
+                                            <i:else>
+                                                @msg.getContentIdentifier() (@msg.getTargetId())
+                                            </i:else>
+                                        </i:if>
                                         <br>@msg.getTargetType()
                                     </small>
                                 </div>


### PR DESCRIPTION
This change links the journal entry target identifier to the matching result page in the db query tool for system administrators.
All other users without the permission see the old plain text as before.

![image](https://user-images.githubusercontent.com/2427877/127637181-8bb578eb-ed82-4331-812c-524a7a0d8076.png)

![image](https://user-images.githubusercontent.com/2427877/127637225-41a84842-4212-448a-b374-72dfc9f0390e.png)
