### PR TITLE
Ensures that language keys in MultiLanguageStrings cannot be empty

### DIFF
--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -304,6 +304,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
      *
      * @param language the language code
      * @return the text found under <tt>language</tt>, if none found the one from {@link #FALLBACK_KEY} is returned
+     * @throws IllegalStateException if this field does not support fallbacks.
      */
     @Nullable
     public String fetchTextOrFallback(String language) {
@@ -382,7 +383,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
      *     <li>{@link MultiLanguageString#clear()}
      * </ul>
      *
-     * @return throws an {@link UnsupportedOperationException}
+     * @throws UnsupportedOperationException direct modifications of the underlying map are not allowed.
      */
     @Override
     public Map<String, String> modify() {

--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -196,7 +196,7 @@ public class MultiLanguageString extends SafeMap<String, String> {
     public MultiLanguageString setFallback(String text) {
         if (!withFallback && Strings.isFilled(text)) {
             throw new IllegalStateException(
-                    "Can not call addFallback on a MultiLanguageString without fallback enabled.");
+                    "Can not call setFallback on a MultiLanguageString without fallback enabled.");
         }
         return addText(FALLBACK_KEY, text);
     }

--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -330,9 +330,13 @@ public class MultiLanguageString extends SafeMap<String, String> {
      * @param key   the key used to store the value
      * @param value the value to store
      * @return the map itself for fluent method calls
+     * @throws IllegalArgumentException if the given key is empty. Missing translations should be handled via {@link MultiLanguageString#setFallback(String)}.
      */
     @Override
     public MultiLanguageString put(@Nonnull String key, String value) {
+        if (Strings.isEmpty(key)) {
+            throw new IllegalArgumentException("Can not add a value for an empty language to a MultiLanguageString.");
+        }
         if (Strings.isFilled(value)) {
             super.modify().put(key, value);
         } else {
@@ -341,11 +345,21 @@ public class MultiLanguageString extends SafeMap<String, String> {
         return this;
     }
 
+    /**
+     * Replaces the current data of this MultiLanguageString with the given {@link Map}.
+     *
+     * @param newData the map holding the new key-value pairs
+     * @throws IllegalArgumentException if the map contains an empty key. Missing translations should be handled via {@link MultiLanguageString#setFallback(String)}.
+     */
     @Override
     public void setData(Map<String, String> newData) {
         if (newData == null) {
             this.clear();
             return;
+        }
+
+        if (newData.keySet().stream().anyMatch(Strings::isEmpty)) {
+            throw new IllegalArgumentException("Can not add a value for an empty language to a MultiLanguageString.");
         }
 
         // remove keys with null values first

--- a/src/test/java/sirius/biz/translations/MultiLanguageStringSpec.groovy
+++ b/src/test/java/sirius/biz/translations/MultiLanguageStringSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.translations
+
+import sirius.kernel.BaseSpecification
+
+class MultiLanguageStringSpec extends BaseSpecification {
+
+    def "adding a text with null as language key throws IllegalArgumentException"() {
+        given:
+        MultiLanguageString mls = new MultiLanguageString()
+        when:
+        mls.addText(null, "null key")
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "adding a text with an empty String as language key throws IllegalArgumentException"() {
+        given:
+        MultiLanguageString mls = new MultiLanguageString()
+        when:
+        mls.addText("", "empty key")
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "adding a value set with null as language key throws IllegalArgumentException"() {
+        given:
+        MultiLanguageString mls = new MultiLanguageString()
+        when:
+        mls.addText("en", "some text")
+        mls.addText("de", "irgendein text")
+        Map<String, String> map = new HashMap<>()
+        map.put("en", "some text")
+        map.put(null, "null key")
+        mls.setData(map)
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "adding a value set with an empty String as language key throws IllegalArgumentException"() {
+        given:
+        MultiLanguageString mls = new MultiLanguageString()
+        when:
+        mls.addText("en", "some text")
+        mls.addText("de", "irgendein text")
+        Map<String, String> map = new HashMap<>()
+        map.put("en", "some text")
+        map.put("", "empty key")
+        mls.setData(map)
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+}

--- a/src/test/java/sirius/biz/translations/MultiLanguageStringSpec.groovy
+++ b/src/test/java/sirius/biz/translations/MultiLanguageStringSpec.groovy
@@ -12,6 +12,16 @@ import sirius.kernel.BaseSpecification
 
 class MultiLanguageStringSpec extends BaseSpecification {
 
+    def "adding a text works"() {
+        given:
+        MultiLanguageString mls = new MultiLanguageString()
+        when:
+        mls.addText("en", "adding text works")
+        then:
+        noExceptionThrown()
+        mls.fetchText("en") == "adding text works"
+    }
+
     def "adding a text with null as language key throws IllegalArgumentException"() {
         given:
         MultiLanguageString mls = new MultiLanguageString()
@@ -30,7 +40,23 @@ class MultiLanguageStringSpec extends BaseSpecification {
         thrown(IllegalArgumentException)
     }
 
-    def "adding a value set with null as language key throws IllegalArgumentException"() {
+    def "adding a map of values with valid language keys works"() {
+        given:
+        MultiLanguageString mls = new MultiLanguageString()
+        when:
+        mls.addText("en", "some text")
+        mls.addText("de", "irgendein text")
+        Map<String, String> map = new HashMap<>()
+        map.put("fr", "en français")
+        map.put("sv", "på svensk")
+        mls.setData(map)
+        then:
+        noExceptionThrown()
+        mls.data.keySet().size() == 2
+        mls.data().keySet().containsAll(Arrays.asList("fr", "sv"))
+    }
+
+    def "adding a map of values with null as language key throws IllegalArgumentException"() {
         given:
         MultiLanguageString mls = new MultiLanguageString()
         when:
@@ -44,7 +70,7 @@ class MultiLanguageStringSpec extends BaseSpecification {
         thrown(IllegalArgumentException)
     }
 
-    def "adding a value set with an empty String as language key throws IllegalArgumentException"() {
+    def "adding a map of values with an empty String as language key throws IllegalArgumentException"() {
         given:
         MultiLanguageString mls = new MultiLanguageString()
         when:


### PR DESCRIPTION
Keys were already expected to be Nonnull, but empty keys could still be added forcefully. This produced fatal errors like persisted MultiLanguageStrings throwing NPEs when being loaded back from the database. Empty keys will now trigger an IllegalArgumentException and thus no longer be accepted! Missing translations should instead be handled via MultiLanguageStrings with fallback enabled.

Fixes: SIRI-375