### PR TITLE
Marks the txnId with AutoImport

### DIFF
--- a/src/main/java/sirius/biz/importer/txn/ImportTransactionData.java
+++ b/src/main/java/sirius/biz/importer/txn/ImportTransactionData.java
@@ -17,7 +17,7 @@ import sirius.db.mixing.Mapping;
  * Contains an import transaction id.
  * <p>
  * This is used by the {@link ImportTransactionHelper} to identify and delete all unchanged
- * entities after an update transaction has beend completed.
+ * entities after an update transaction has been completed.
  * <p>
  * Note that appropriate index should be added to the embedding entity.
  */
@@ -28,6 +28,7 @@ public class ImportTransactionData extends Composite {
      */
     public static final Mapping TXN_ID = Mapping.named("txnId");
     @NoJournal
+    @AutoImport
     private long txnId = 0;
 
     public long getTxnId() {

--- a/src/main/java/sirius/biz/importer/txn/ImportTransactionData.java
+++ b/src/main/java/sirius/biz/importer/txn/ImportTransactionData.java
@@ -28,7 +28,7 @@ public class ImportTransactionData extends Composite {
      */
     public static final Mapping TXN_ID = Mapping.named("txnId");
     @NoJournal
-    @AutoImport
+    @AutoImport(hidden = true)
     private long txnId = 0;
 
     public long getTxnId() {


### PR DESCRIPTION
Otherwise this field wouldn't be considered as changed and will not be updated upon processing an already existing record. This will have a nasty side effect as calling ImportTransactionHelper.deleteUnmarked will unwillingly remove existing records.
We mark it as hidden, as we don't want it to appear in job documentation as a field which can be set by end users.

Fixes: OX-6996