### PR TITLE
Stops processing entries if a vital error was found

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -12,6 +12,7 @@ import sirius.biz.importer.format.ImportDictionary;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.util.ExtractedFile;
+import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Callback;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Tuple;
@@ -138,6 +139,9 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
         handledFiles.clear();
 
         for (ImportFile importFile : importFiles) {
+            if (!TaskContext.get().isActive()) {
+                return;
+            }
             Optional<ExtractedFile> extractedFile = fetchEntry(importFile.filename);
             if (extractedFile.isPresent()) {
                 handleFile(importFile, extractedFile.get());


### PR DESCRIPTION
When a vital error is detected (eg. csv mismatch against the provided dictionary), we still tried to further process the files defined for processing. Such vital errors cancel the job execution.

Fixes: OX-7286