### PR TITLE
Automatically drops the dollar sign for timings

### DIFF
--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -95,6 +95,11 @@ class ProcessEnvironment implements ProcessContext {
 
     @Override
     public void addTiming(String counter, long millis, boolean adminOnly) {
+        // Drops the dollar sign used in NLS.smartGet, because the counters are always translated.
+        if (counter.startsWith("$")) {
+            counter = counter.substring(1);
+        }
+
         if (adminOnly) {
             getAdminTimings().computeIfAbsent(counter, ignored -> new Average()).addValue(millis);
         } else {


### PR DESCRIPTION
When adding timings /counters, the stored keys are translated by default. Therefore we store them without the dollar sign. Sometimes a key is already at hand with the sign, so we still can use it for timings, without having to define a new key.