### PR TITLE
Differentiation between deletion of files and whole directories

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/fs/LocalDirectoryUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/fs/LocalDirectoryUplink.java
@@ -171,7 +171,11 @@ public class LocalDirectoryUplink extends ConfigBasedUplink {
 
     private boolean deleteHandler(VirtualFile file) {
         try {
-            sirius.kernel.commons.Files.delete(file.as(File.class));
+            if (file.isDirectory()) {
+                sirius.kernel.commons.Files.delete(file.as(File.class).toPath());
+            } else {
+                sirius.kernel.commons.Files.delete(file.as(File.class));
+            }
             return true;
         } catch (Exception e) {
             throw Exceptions.handle()


### PR DESCRIPTION
Will fix java.nio.file.DirectoryNotEmptyException which was thrown by deletion of locally mounted directories.