### PR TITLE
Permits to enable the system maintenance mode by default.

### DIFF
--- a/src/main/java/sirius/biz/web/DisasterModeInfo.java
+++ b/src/main/java/sirius/biz/web/DisasterModeInfo.java
@@ -64,7 +64,7 @@ public class DisasterModeInfo implements MaintenanceInfo {
     /**
      * Contains the timestamp when to start showing the maintenance message.
      * <p>
-     * If left empty, this will be shown immediatelly.
+     * If left empty, this will be shown immediately.
      */
     private LocalDateTime displayMessageStartTime;
 
@@ -81,7 +81,7 @@ public class DisasterModeInfo implements MaintenanceInfo {
     /**
      * Contains the timestamp when to enable the lock.
      * <p>
-     * If left empty, this will be immediatelly.
+     * If left empty, this will be immediately.
      */
     private LocalDateTime lockStartTime;
 
@@ -99,7 +99,7 @@ public class DisasterModeInfo implements MaintenanceInfo {
             CacheManager.createInlineCache(Duration.ofSeconds(10), this::determineIfLocked);
 
     /**
-     * Caches the effective message for ten seconds to avoid frequent recomputations.
+     * Caches the effective message for ten seconds to avoid frequent re-computations.
      */
     private final InlineCache<String> disasterMessage =
             CacheManager.createInlineCache(Duration.ofSeconds(10), this::fetchDisasterMessage);
@@ -131,7 +131,7 @@ public class DisasterModeInfo implements MaintenanceInfo {
                 Exceptions.handle()
                           .to(Log.SYSTEM)
                           .error(e)
-                          .withSystemErrorMessage("Failed to parse diaster mode settings from redis: %s (%s)")
+                          .withSystemErrorMessage("Failed to parse disaster mode settings from redis: %s (%s)")
                           .handle();
             }
         });
@@ -190,16 +190,18 @@ public class DisasterModeInfo implements MaintenanceInfo {
      * administrator can log-in and disable locking.
      *
      * @param uri the currently requested URI
-     * @return <tt>true</tt> if the uri can be accessed despite of an active lock, <tt>false</tt> otherwise
+     * @return <tt>true</tt> if the uri can be accessed in spite of an active lock, <tt>false</tt> otherwise
      */
     private boolean isWhitelistedURI(String uri) {
-        return DisasterController.URI_DISASTER.equals(uri) || DisasterController.URI_SYSTEM_DISASTER.equals(uri) || uri.startsWith(SAMLController.SAML_URI_PREFIX);
+        return DisasterController.URI_DISASTER.equals(uri)
+               || DisasterController.URI_SYSTEM_DISASTER.equals(uri)
+               || uri.startsWith(SAMLController.SAML_URI_PREFIX);
     }
 
     /**
      * Determines if the current user is an administrator.
      * <p>
-     * An administrator can always login (espectially in order to disable the locking).
+     * An administrator can always perform a login (especially in order to disable the locking).
      *
      * @return <tt>true</tt> if the current user is a system administrator (even if disguised as normal user).
      */
@@ -226,7 +228,7 @@ public class DisasterModeInfo implements MaintenanceInfo {
      * @param lock                    determines if the scope should be locked
      * @param lockStartTime           determines the beginning of the lock
      * @param displayMessageStartTime determine when to start displaying the maintenance message
-     * @param previewMessage          constains the maintenance message
+     * @param previewMessage          contains the maintenance message
      * @param lockMessage             contains the message to show as the system is locked
      */
     public void updateMode(boolean lock,

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -7,6 +7,19 @@ product {
             vcs = "${build.vcs.number}"
         }
     }
+
+    # Can be used to lock the system (enable the maintenance mode) right from the start of the system.
+    #
+    # Note that this is more of an exotic setting as it should only be used for cold- or hot-standby systems,
+    # which might be brought up during a disaster scenario. The system can be used as a backup system, while the primary
+    # instance recovers. The backup system should mutate as little data as possible. This is because it possibly runs on
+    # (slightly) outdated data, and merging any modification back into the recovered primary system is a nightmare.
+    # Therefore this setting is used to lock the system by default (which can still be disabled via the
+    # admin UI /system/disaster).
+    #
+    # Note that once a message is specified here, the system is locked automatically on startup. If the value if left
+    # empty, nothing will happen.
+    defaultMaintenanceMessage = ""
 }
 
 # sirius-biz provides a multitude of frameworks for different use-cases


### PR DESCRIPTION
See the description in component-biz.conf of
'product.defaultMaintenanceMessage' for an in-depth explanation of
what is achieved with this change.

Fixes: SIRI-413