### PR TITLE
No longer always fills the total items with the current items

### DIFF
--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -408,8 +408,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
     }
 
     protected void enforcePaging(Page<E> result, List<E> items) {
-        int originalSize = items.size();
-        if (originalSize > pageSize) {
+        if (items.size() > pageSize) {
             result.withHasMore(true);
             items.remove(items.size() - 1);
             if (withTotalCount) {
@@ -417,7 +416,7 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
             }
         } else if (withTotalCount) {
             // we don't have any more items, so total items is end of the current page
-            result.withTotalItems(result.getEnd());
+            result.withTotalItems(result.getStart() - 1 + items.size());
         }
     }
 

--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -408,14 +408,19 @@ public abstract class BasePageHelper<E extends BaseEntity<?>, C extends Constrai
 
     protected void enforcePaging(Page<E> result, List<E> items) {
         int originalSize = items.size();
+        Integer totalItems = null;
         if (originalSize > pageSize) {
             result.withHasMore(true);
             items.remove(items.size() - 1);
+        } else if (result.getStart() == 0) {
+            // we do not have any items before and after this page, so the total count is the current items count
+            totalItems = items.size();
         }
-        if (fetchTotalCount && (originalSize > pageSize || result.getStart() > pageSize)) {
+        if (fetchTotalCount && totalItems == null) {
             result.withTotalItems((int) baseQuery.count());
-        } else {
-            result.withTotalItems(items.size());
+        }
+        if (totalItems != null) {
+            result.withTotalItems(totalItems);
         }
     }
 


### PR DESCRIPTION
If we don't know the total size, we don't want to supply a total item count to the page. This bug was introduced while trying to fix another bug, where fetchTotalItems wasn't applied for non-full pages that weren't at start=0.
This change keeps this fix so total items will only be filled when
 **withTotalCount is enforced**

**In all other cases the totalItems will not be supplied to the Page at all.**

This behavior/bug was introduced with https://github.com/scireum/sirius-biz/pull/923

This filled totalItems produces the following error in the UI:

![Screenshot 2021-08-24 at 18 24 51](https://user-images.githubusercontent.com/10437176/130653869-81ed57ab-f92e-4aea-b2cb-acc79c86226a.png)
