### PR TITLE
Allows to access the importer of an import job externally

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/ImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/ImportJob.java
@@ -88,4 +88,8 @@ public abstract class ImportJob extends BatchJob {
         }
         super.close();
     }
+
+    public Importer getImporter() {
+        return importer;
+    }
 }


### PR DESCRIPTION
This is useful for configuring helpers/handlers during the job creation in a job factory.

Fixes: OX-7263