### PR TITLE
Fixes the SFTP server 'forgetting' the last byte

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeSeekableByteChannel.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeSeekableByteChannel.java
@@ -52,7 +52,10 @@ class BridgeSeekableByteChannel implements SeekableByteChannel {
             lastRead = in.read(destination.array(),
                                destination.arrayOffset() + destination.position() + read,
                                destination.remaining() - read);
-            read += lastRead;
+
+            if (lastRead > 0) {
+                read += lastRead;
+            }
         }
 
         if (read > 0) {


### PR DESCRIPTION
InputStream#read() will return -1 if the end of the stream is reached. This should not be included in the total size, because otherwise the SFTP server drops the last byte when serving files to clients.