### PR TITLE
Improves creating ProcessLog entries out of Exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-23.7.0</sirius.kernel>
+        <sirius.kernel>dev-23.10.0</sirius.kernel>
         <sirius.web>dev-40.3.0</sirius.web>
         <sirius.db>dev-29.0.0</sirius.db>
     </properties>

--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -145,13 +145,13 @@ public class ErrorContext implements SubContext {
     }
 
     private void logException(UnaryOperator<String> failureDescription, HandledException exception) {
-        if (TaskContext.get().getAdapter() instanceof ProcessContext) {
-            ((ProcessContext) TaskContext.get().getAdapter()).log(ProcessLog.error()
-                                                                            .withException(exception)
-                                                                            .withMessage(enhanceMessage(
-                                                                                    failureDescription.apply(exception.getMessage()))));
+        TaskContext taskContext = TaskContext.get();
+        if (taskContext.getAdapter() instanceof ProcessContext processContext) {
+            processContext.log(ProcessLog.error()
+                                         .withException(exception)
+                                         .withMessage(enhanceMessage(failureDescription.apply(exception.getMessage()))));
         } else {
-            TaskContext.get().log(enhanceMessage(failureDescription.apply(exception.getMessage())));
+            taskContext.log(enhanceMessage(failureDescription.apply(exception.getMessage())));
         }
     }
 

--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -147,6 +147,7 @@ public class ErrorContext implements SubContext {
     private void logException(UnaryOperator<String> failureDescription, HandledException exception) {
         if (TaskContext.get().getAdapter() instanceof ProcessContext) {
             ((ProcessContext) TaskContext.get().getAdapter()).log(ProcessLog.error()
+                                                                            .withException(exception)
                                                                             .withMessage(enhanceMessage(
                                                                                     failureDescription.apply(exception.getMessage()))));
         } else {

--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -148,7 +148,7 @@ public class ErrorContext implements SubContext {
         TaskContext taskContext = TaskContext.get();
         if (taskContext.getAdapter() instanceof ProcessContext processContext) {
             processContext.log(ProcessLog.error()
-                                         .withException(exception)
+                                         .withHandledException(exception)
                                          .withMessage(enhanceMessage(failureDescription.apply(exception.getMessage()))));
         } else {
             taskContext.log(enhanceMessage(failureDescription.apply(exception.getMessage())));

--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -225,7 +225,7 @@ class ProcessEnvironment implements ProcessContext {
     @Override
     public HandledException handle(Exception e) {
         HandledException handledException = Exceptions.handle(Log.BACKGROUND, e);
-        log(ProcessLog.error().withException(handledException));
+        log(ProcessLog.error().withHandledException(handledException));
         return handledException;
     }
 

--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -225,20 +225,7 @@ class ProcessEnvironment implements ProcessContext {
     @Override
     public HandledException handle(Exception e) {
         HandledException handledException = Exceptions.handle(Log.BACKGROUND, e);
-        ProcessLog logEntry = ProcessLog.error().withMessage(handledException.getMessage());
-
-        String messageType = handledException.getHint(ProcessContext.HINT_MESSAGE_TYPE).getString();
-        if (Strings.isFilled(messageType)) {
-            int messageCount = handledException.getHint(ProcessContext.HINT_MESSAGE_COUNT).asInt(0);
-            if (messageCount > 0) {
-                logEntry.withLimitedMessageType(messageType, messageCount);
-            } else {
-                logEntry.withMessageType(messageType);
-            }
-        }
-
-        log(logEntry);
-
+        log(ProcessLog.error().withException(handledException));
         return handledException;
     }
 

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -396,27 +396,24 @@ public class ProcessLog extends SearchableEntity {
     }
 
     /**
-     * Specifies an exception from where to inherit the message.
+     * Specifies a handled handledException from where to inherit the message.
      * <p>
-     * If the provided exception is a {@link HandledException}, also considers the filled
-     * {@link ProcessContext#HINT_MESSAGE_TYPE} to categorize the log in message types and
-     * {@link ProcessContext#HINT_MESSAGE_COUNT} to limit the amount of allowed messages per type.
+     * If set, the {@link ProcessContext#HINT_MESSAGE_TYPE} hint is used to categorize the log in message types
+     * and {@link ProcessContext#HINT_MESSAGE_COUNT} to limit the amount of allowed messages per type.
      *
-     * @param exception the {@link Exception} to retrieve the message and eventually hints from
+     * @param handledException the {@link HandledException} to retrieve the message and eventually hints from
      * @return the log entry itself for fluent method calls
      */
-    public ProcessLog withException(Exception exception) {
-        this.withMessage(exception.getMessage());
-        if (exception instanceof HandledException handledException) {
-            handledException.getHint(ProcessContext.HINT_MESSAGE_TYPE).ifFilled(hint -> {
-                int messageCount = handledException.getHint(ProcessContext.HINT_MESSAGE_COUNT).asInt(0);
-                if (messageCount > 0) {
-                    this.withLimitedMessageType(hint.getString(), messageCount);
-                } else {
-                    this.withMessageType(hint.getString());
-                }
-            });
-        }
+    public ProcessLog withHandledException(HandledException handledException) {
+        this.withMessage(handledException.getMessage());
+        handledException.getHint(ProcessContext.HINT_MESSAGE_TYPE).ifFilled(hint -> {
+            int messageCount = handledException.getHint(ProcessContext.HINT_MESSAGE_COUNT).asInt(0);
+            if (messageCount > 0) {
+                this.withLimitedMessageType(hint.getString(), messageCount);
+            } else {
+                this.withMessageType(hint.getString());
+            }
+        });
         return this;
     }
 

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -10,6 +10,7 @@ package sirius.biz.process.logs;
 
 import sirius.biz.elastic.SearchableEntity;
 import sirius.biz.process.Process;
+import sirius.biz.process.ProcessContext;
 import sirius.biz.process.Processes;
 import sirius.db.es.annotations.ESOption;
 import sirius.db.es.annotations.IndexMode;
@@ -24,6 +25,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Framework;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.health.HandledException;
 import sirius.kernel.nls.NLS;
 
 import java.time.LocalDateTime;
@@ -391,6 +393,31 @@ public class ProcessLog extends SearchableEntity {
      */
     public ProcessLog withFormattedMessage(String message, Object... parameters) {
         return withMessage(Strings.apply(message, parameters));
+    }
+
+    /**
+     * Specifies an exception from where to inherit the message.
+     * <p>
+     * If the provided exception is a {@link HandledException}, also considers the filled
+     * {@link ProcessContext#HINT_MESSAGE_TYPE} to categorize the log in message types and
+     * {@link ProcessContext#HINT_MESSAGE_COUNT} to limit the amount of allowed messages per type.
+     *
+     * @param exception the {@link Exception} to retrieve the message and eventually hints from
+     * @return the log entry itself for fluent method calls
+     */
+    public ProcessLog withException(Exception exception) {
+        this.withMessage(exception.getMessage());
+        if (exception instanceof HandledException) {
+            ((HandledException) exception).getHint(ProcessContext.HINT_MESSAGE_TYPE).ifFilled(hint -> {
+                int messageCount = ((HandledException) exception).getHint(ProcessContext.HINT_MESSAGE_COUNT).asInt(0);
+                if (messageCount > 0) {
+                    this.withLimitedMessageType(hint.getString(), messageCount);
+                } else {
+                    this.withMessageType(hint.getString());
+                }
+            });
+        }
+        return this;
     }
 
     /**

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -407,9 +407,9 @@ public class ProcessLog extends SearchableEntity {
      */
     public ProcessLog withException(Exception exception) {
         this.withMessage(exception.getMessage());
-        if (exception instanceof HandledException) {
-            ((HandledException) exception).getHint(ProcessContext.HINT_MESSAGE_TYPE).ifFilled(hint -> {
-                int messageCount = ((HandledException) exception).getHint(ProcessContext.HINT_MESSAGE_COUNT).asInt(0);
+        if (exception instanceof HandledException handledException) {
+            handledException.getHint(ProcessContext.HINT_MESSAGE_TYPE).ifFilled(hint -> {
+                int messageCount = handledException.getHint(ProcessContext.HINT_MESSAGE_COUNT).asInt(0);
                 if (messageCount > 0) {
                     this.withLimitedMessageType(hint.getString(), messageCount);
                 } else {


### PR DESCRIPTION
Permits to "build" ProcessLog entries out of an existing Exception.
If the Exception is a HandledException, automatically parses the `messageType` and `messageCount` hints if set.

Fixes: OX-7331