### PR TITLE
ProcessLog and ImportHandler improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>dev-23.12.0</sirius.kernel>
         <sirius.web>dev-41.0.0</sirius.web>
-        <sirius.db>dev-29.3.0</sirius.db>
+        <sirius.db>dev-29.3.1</sirius.db>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-23.10.0</sirius.kernel>
+        <sirius.kernel>dev-23.12.0</sirius.kernel>
         <sirius.web>dev-41.0.0</sirius.web>
-        <sirius.db>dev-29.0.0</sirius.db>
+        <sirius.db>dev-29.3.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -11,6 +11,8 @@ package sirius.biz.importer;
 import sirius.biz.importer.format.FieldDefinition;
 import sirius.biz.importer.format.FieldDefinitionSupplier;
 import sirius.biz.importer.format.ImportDictionary;
+import sirius.biz.importer.txn.ImportTransactionHelper;
+import sirius.biz.importer.txn.ImportTransactionalEntity;
 import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.protocol.Journaled;
 import sirius.biz.web.TenantAware;
@@ -213,6 +215,25 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
 
         if (entity instanceof Journaled) {
             ((Journaled) entity).getJournal().enableBatchLog();
+        }
+
+        if (entity instanceof ImportTransactionalEntity transactionalEntity) {
+            markTransaction(transactionalEntity);
+        }
+    }
+
+    /**
+     * Marks the given entity with the current opened transaction id.
+     *
+     * @param transactionalEntity the entity to mark
+     * @see ImportTransactionHelper
+     */
+    protected void markTransaction(ImportTransactionalEntity transactionalEntity) {
+        ImportTransactionHelper importTransactionHelper =
+                context.getImporter().findHelper(ImportTransactionHelper.class);
+
+        if (importTransactionHelper.isActive()) {
+            importTransactionHelper.mark(transactionalEntity);
         }
     }
 

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -41,6 +41,7 @@ import sirius.kernel.settings.Extension;
 import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -419,6 +420,16 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
     }
 
     /**
+     * Returns the entity label key used to categorize messages for errors.
+     *
+     * @param entity the entity to retrieve the label
+     * @return the key
+     */
+    protected String obtainMessageTypeKey(@Nonnull E entity) {
+        return entity.getDescriptor().getLabelKey();
+    }
+
+    /**
      * Includes process hints to the {@link HandledException} thrown when saving an entity.
      * <p>
      * This permits processes to categorize these errors under the entity's label.
@@ -431,7 +442,7 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
      */
     protected HandledException enhanceExceptionWithHints(HandledException exception, E entity) {
         if (exception.getHint(ProcessLog.HINT_MESSAGE_KEY).isEmptyString()) {
-            exception.withHint(ProcessLog.HINT_MESSAGE_KEY, entity.getDescriptor().getLabelKey());
+            exception.withHint(ProcessLog.HINT_MESSAGE_KEY, obtainMessageTypeKey(entity));
         }
         if (obtainMessageTypeLimit() > 0) {
             exception.withHint(ProcessLog.HINT_MESSAGE_COUNT, obtainMessageTypeLimit());

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -75,8 +75,6 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
     @Parts(EntityImportHandlerExtender.class)
     protected static PartCollection<EntityImportHandlerExtender> extenders;
 
-    private static final int DEFAULT_MESSAGE_TYPE_COUNT = 250;
-
     protected EntityDescriptor descriptor;
     protected ImporterContext context;
     protected Mapping exportRepresentationMapping;
@@ -417,7 +415,7 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
      * @return the amount of messages to limit
      */
     protected int obtainMessageTypeLimit() {
-        return DEFAULT_MESSAGE_TYPE_COUNT;
+        return ProcessLog.MESSAGE_TYPE_COUNT_MEDIUM;
     }
 
     /**

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -216,17 +216,17 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
     }
 
     /**
-     * Enforces some consistency checks before a delete is performed.
+     * Enforces some consistency checks before a deletion is performed.
      * <p>
      * This method should only rarely be overwritten as most checks should be either be performed during a load
      * or within the <tt>beforeDelete</tt> checks of the entity. The main point of this method is enforcing the
-     * correct tenant before deleteing, as some import handlers might yield (readonly) entities from parent
+     * correct tenant before deleting, as some import handlers might yield (readonly) entities from parent
      * tenants.
      *
      * @param entity the entity to check
      */
     protected void enforcePreDeleteConstraints(E entity) {
-        // By default the constraints are the same as when the entity is saved...
+        // By default, the constraints are the same as when the entity is saved...
         enforcePreSaveConstraints(entity);
     }
 
@@ -627,7 +627,7 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
      * By default the column wearing an {@link Exportable} with {@link Exportable#defaultRepresentation()} set to <tt>true</tt>
      * and the lowest {@link Exportable#priority()} is used.
      *
-     * @return the column / mapping to use when representing a entity of this type in an export
+     * @return the column / mapping to use when representing an entity of this type in an export
      */
     protected Mapping determineExportRepresentationMapping() {
         return descriptor.getProperties()

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -28,6 +28,7 @@ import sirius.kernel.Sirius;
 import sirius.kernel.commons.ComparableTuple;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Explain;
+import sirius.kernel.commons.Producer;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
@@ -54,6 +55,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -661,8 +663,9 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
      *
      * @param entity the entity to extract its label
      * @return the formatted message
+     * @see sirius.biz.process.ErrorContext#performInContextAndGet(String, Object, UnaryOperator, Producer)
      */
-    public String getCannotSaveMessage(E entity) {
+    public String createCannotSaveMessage(@Nonnull E entity) {
         return NLS.fmtr("BaseImportHandler.cannotSaveEntity").set("entity", entity.getDescriptor().getLabel()).format();
     }
 

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -134,8 +134,8 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
      * @param entity the entity to check
      */
     protected void enforcePostLoadConstraints(E entity) {
-        if (entity instanceof TenantAware) {
-            ((TenantAware) entity).setOrVerifyCurrentTenant();
+        if (entity instanceof TenantAware tenantAwareEntity) {
+            tenantAwareEntity.setOrVerifyCurrentTenant();
         }
     }
 
@@ -209,12 +209,12 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
 
     @Override
     public void enforcePreSaveConstraints(E entity) {
-        if (entity instanceof TenantAware) {
-            ((TenantAware) entity).setOrVerifyCurrentTenant();
+        if (entity instanceof TenantAware tenantAwareEntity) {
+            tenantAwareEntity.setOrVerifyCurrentTenant();
         }
 
-        if (entity instanceof Journaled) {
-            ((Journaled) entity).getJournal().enableBatchLog();
+        if (entity instanceof Journaled journaledEntity) {
+            journaledEntity.getJournal().enableBatchLog();
         }
 
         if (entity instanceof ImportTransactionalEntity transactionalEntity) {

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -34,6 +34,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
+import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
 import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
@@ -617,6 +618,22 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
         return fieldLookupCache.lookup((Class<? extends BaseEntity<?>>) descriptor.getType(),
                                        entityId,
                                        exportRepresentationMapping);
+    }
+
+    /**
+     * Builds a standard message that the given entity cannot be saved.
+     * <p>
+     * This message is mostly used with {@link sirius.biz.process.ErrorContext} methods which accept an extra failure description.
+     * For instance, when an entities required field is not populated, a standard message like this will be logged:
+     * {@code Field 'MyField' is required.}
+     * As to would be rather nice to tell the end user that an entity couldn't be saved due to the error.
+     * {@code MyEntity cannot be saved. Field 'MyField' is required.}
+     *
+     * @param entity the entity to extract its label
+     * @return the formatted message
+     */
+    public String getCannotSaveMessage(E entity) {
+        return NLS.fmtr("BaseImportHandler.cannotSaveEntity").set("entity", entity.getDescriptor().getLabel()).format();
     }
 
     /**

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -20,6 +20,7 @@ import sirius.db.mixing.Property;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.ValueHolder;
+import sirius.kernel.health.HandledException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -227,16 +228,20 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
      * @return the updated or created entity or, if batch updates are active, the given entity
      */
     protected E createOrUpdate(E entity, boolean batch) {
-        enforcePreSaveConstraints(entity);
+        try {
+            enforcePreSaveConstraints(entity);
 
-        // Invoke the beforeSave checks so that the change-detection below works for
-        // computed properties...
-        descriptor.beforeSave(entity);
+            // Invoke the beforeSave checks so that the change-detection below works for
+            // computed properties...
+            descriptor.beforeSave(entity);
 
-        if (entity.isNew()) {
-            return createIfChanged(entity, batch);
-        } else {
-            return updateIfChanged(entity, batch);
+            if (entity.isNew()) {
+                return createIfChanged(entity, batch);
+            } else {
+                return updateIfChanged(entity, batch);
+            }
+        } catch (HandledException exception) {
+            throw enhanceExceptionWithHints(exception, entity);
         }
     }
 

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -107,7 +107,7 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
      * Using this approach, several find queries based on different field combinations can be used to execute
      * find.
      * <p>
-     * Additional queries can also added by providing an {@link SQLEntityImportHandlerExtender} if extending
+     * Additional queries can also be added by providing an {@link SQLEntityImportHandlerExtender} if extending
      * the importer class itself isn't a viable option.
      *
      * @param queryConsumer the consumer to be supplied with queries
@@ -159,7 +159,7 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
     }
 
     /**
-     * Loads all {@link #mappingsToLoadForFind} and may perform some cleanups if necessarry.
+     * Loads all {@link #mappingsToLoadForFind} and may perform some cleanups if necessary.
      * <p>
      * Some fields are normalized within {@link sirius.db.mixing.annotations.BeforeSave} handlers. This method
      * can be overwritten to perform the same operations so that the values properly match within the
@@ -332,7 +332,7 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
     /**
      * Creates the prepared statement as {@link DeleteQuery} used to delete entities.
      *
-     * @return the delete query to use
+     * @return the deletion query to use
      */
     @SuppressWarnings("unchecked")
     protected DeleteQuery<E> getDeleteQuery() {

--- a/src/main/java/sirius/biz/jobs/batch/file/XMLValidator.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/XMLValidator.java
@@ -115,7 +115,8 @@ public class XMLValidator {
             process.log(processLog.withNLSKey("XMLValidatorErrorHandler.error")
                                   .withContext("line", exception.getLineNumber())
                                   .withContext("message", exception.getMessage())
-                                  .withLimitedMessageType("$XMLValidatorErrorHandler.error.messageType", 250));
+                                  .withLimitedMessageType("$XMLValidatorErrorHandler.error.messageType",
+                                                          ProcessLog.MESSAGE_TYPE_COUNT_MEDIUM));
         }
 
         /**

--- a/src/main/java/sirius/biz/process/ProcessContext.java
+++ b/src/main/java/sirius/biz/process/ProcessContext.java
@@ -47,18 +47,6 @@ import java.util.function.Supplier;
 public interface ProcessContext extends TaskContextAdapter {
 
     /**
-     * Hints the {@link ProcessLog#withMessageType(String)} to be used when handling an exception via
-     * {@link ProcessContext#handle(Exception)}.
-     */
-    ExceptionHint HINT_MESSAGE_TYPE = new ExceptionHint("messageType");
-
-    /**
-     * Hints the limit to be used for {@link ProcessLog#withLimitedMessageType(String, int)} to be used when handling
-     * an exception via {@link ProcessContext#handle(Exception)}.
-     */
-    ExceptionHint HINT_MESSAGE_COUNT = new ExceptionHint("messageCount");
-
-    /**
      * Returns the id of the process context.
      *
      * @return the id of the process

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -52,6 +52,12 @@ import java.util.Optional;
 @Framework(Processes.FRAMEWORK_PROCESSES)
 public class ProcessLog extends SearchableEntity {
 
+    public static final int MESSAGE_TYPE_COUNT_ONE = 1;
+    public static final int MESSAGE_TYPE_COUNT_VERY_LOW = 10;
+    public static final int MESSAGE_TYPE_COUNT_LOW = 100;
+    public static final int MESSAGE_TYPE_COUNT_MEDIUM = 250;
+    public static final int MESSAGE_TYPE_COUNT_HIGH = 1000;
+
     /**
      * Hints the {@link ProcessLog#withMessageType(String)} to be used when handling an exception via
      * {@link #withHandledException(HandledException)}.

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -53,10 +53,29 @@ import java.util.Optional;
 @Framework(Processes.FRAMEWORK_PROCESSES)
 public class ProcessLog extends SearchableEntity {
 
+    /**
+     * Defines a limit to log messages for a {@link #messageType} to one.
+     */
     public static final int MESSAGE_TYPE_COUNT_ONE = 1;
+
+    /**
+     * Defines a limit to log messages for a {@link #messageType} to 10.
+     */
     public static final int MESSAGE_TYPE_COUNT_VERY_LOW = 10;
+
+    /**
+     * Defines a limit to log messages for a {@link #messageType} to 100.
+     */
     public static final int MESSAGE_TYPE_COUNT_LOW = 100;
+
+    /**
+     * Defines a limit to log messages for a {@link #messageType} to 250.
+     */
     public static final int MESSAGE_TYPE_COUNT_MEDIUM = 250;
+
+    /**
+     * Defines a limit to log messages for a {@link #messageType} to 1000.
+     */
     public static final int MESSAGE_TYPE_COUNT_HIGH = 1000;
 
     /**

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -56,7 +56,7 @@ public class ProcessLog extends SearchableEntity {
      * Hints the {@link ProcessLog#withMessageType(String)} to be used when handling an exception via
      * {@link #withHandledException(HandledException)}.
      * <p>
-     * A message key is suppose d to be {@link NLS#smartGet(String) smart translated}.
+     * A message key is supposed to be {@link NLS#smartGet(String) smart translated}.
      */
     public static final ExceptionHint HINT_MESSAGE_KEY = new ExceptionHint("messageKey");
 

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -1285,7 +1285,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                             .withNLSKey("VirtualFile.downloadFailed")
                             .set("url", url)
                             .hint(ProcessLog.HINT_MESSAGE_KEY, "$VirtualFile.loadFromUrlFailed")
-                            .hint(ProcessLog.HINT_MESSAGE_COUNT, 250)
+                            .hint(ProcessLog.HINT_MESSAGE_COUNT, ProcessLog.MESSAGE_TYPE_COUNT_MEDIUM)
                             .handle();
         }
     }
@@ -1386,7 +1386,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                             .withNLSKey("VirtualFile.downloadFailed")
                             .set("url", url)
                             .hint(ProcessLog.HINT_MESSAGE_KEY, "$VirtualFile.loadFromUrlFailed")
-                            .hint(ProcessLog.HINT_MESSAGE_COUNT, 250)
+                            .hint(ProcessLog.HINT_MESSAGE_COUNT, ProcessLog.MESSAGE_TYPE_COUNT_MEDIUM)
                             .handle();
         }
     }
@@ -1465,7 +1465,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
         return Exceptions.createHandled()
                          .withNLSKey("VirtualFile.loadFromUrl.noValidPath")
                          .hint(ProcessLog.HINT_MESSAGE_KEY, "$VirtualFile.loadFromUrlFailed")
-                         .hint(ProcessLog.HINT_MESSAGE_COUNT, 250)
+                         .hint(ProcessLog.HINT_MESSAGE_COUNT, ProcessLog.MESSAGE_TYPE_COUNT_MEDIUM)
                          .set("url", url)
                          .handle();
     }

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -12,7 +12,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.QueryStringDecoder;
-import sirius.biz.process.ProcessContext;
+import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.storage.layer1.FileHandle;
 import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.util.Attempt;
@@ -1284,8 +1284,8 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                             .error(e)
                             .withNLSKey("VirtualFile.downloadFailed")
                             .set("url", url)
-                            .hint(ProcessContext.HINT_MESSAGE_TYPE, "$VirtualFile.loadFromUrlFailed")
-                            .hint(ProcessContext.HINT_MESSAGE_COUNT, 250)
+                            .hint(ProcessLog.HINT_MESSAGE_KEY, "$VirtualFile.loadFromUrlFailed")
+                            .hint(ProcessLog.HINT_MESSAGE_COUNT, 250)
                             .handle();
         }
     }
@@ -1385,8 +1385,8 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                             .error(e)
                             .withNLSKey("VirtualFile.downloadFailed")
                             .set("url", url)
-                            .hint(ProcessContext.HINT_MESSAGE_TYPE, "$VirtualFile.loadFromUrlFailed")
-                            .hint(ProcessContext.HINT_MESSAGE_COUNT, 250)
+                            .hint(ProcessLog.HINT_MESSAGE_KEY, "$VirtualFile.loadFromUrlFailed")
+                            .hint(ProcessLog.HINT_MESSAGE_COUNT, 250)
                             .handle();
         }
     }
@@ -1453,8 +1453,8 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     private HandledException createInvalidPathError(URL url) {
         return Exceptions.createHandled()
                          .withNLSKey("VirtualFile.loadFromUrl.noValidPath")
-                         .hint(ProcessContext.HINT_MESSAGE_TYPE, "$VirtualFile.loadFromUrlFailed")
-                         .hint(ProcessContext.HINT_MESSAGE_COUNT, 250)
+                         .hint(ProcessLog.HINT_MESSAGE_KEY, "$VirtualFile.loadFromUrlFailed")
+                         .hint(ProcessLog.HINT_MESSAGE_COUNT, 250)
                          .set("url", url)
                          .handle();
     }

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -39,6 +39,7 @@ AuxiliaryFileMode.ALWAYS_UPDATE = Immer abspeichern (überschreiben)
 AuxiliaryFileMode.IGNORE = Nie abspeichern
 AuxiliaryFileMode.NEVER_UPDATE = Neue Dateien abspeichern
 AuxiliaryFileMode.UPDATE_ON_CHANGE = Neue Dateien speichern und bei Änderungen überschreiben
+BaseImportHandler.cannotSaveEntity = ${entity} wurde nicht gespeichert.
 BaseFileParameter.invalidFileExtension = Die Datei '${name}' enthält keine der gültigen Datei-Endungen: ${extensions}
 BasePageHelper.sort = Sortierung
 BasicBlobStorageSpace.cannotMoveAcrossSpaces = Ein Verschieben über Dateisystem-Grenzen hinweg ist nicht möglich. Bitte verwenden Sie den 'Verschieben' Job.

--- a/src/main/resources/biz_en.properties
+++ b/src/main/resources/biz_en.properties
@@ -43,6 +43,7 @@ AuxiliaryFileMode.NEVER_UPDATE = Save new files
 AuxiliaryFileMode.UPDATE_ON_CHANGE = Save new files and overwrite them when changes are made
 BaseFileParameter.invalidFileExtension = The file '${name}' contains none of the valid file extensions: ${extensions}
 BasePageHelper.sort = Sort
+BaseImportHandler.cannotSaveEntity = ${entity} cannot be saved.
 BasicBlobStorageSpace.cannotMoveAcrossSpaces = Moving across file system boundaries is not possible. Please use the 'Move' job.
 BasicBlobStorageSpace.cannotMoveDuplicateName = Moving is not possible because a directory or file with that name already exists.
 BasicBlobStorageSpace.cannotMoveIntoLoop = It is not possible to move them, as this would create a cyclic dependency.


### PR DESCRIPTION
- Differentiate when providing keys or messages as hints to categorize process log entries
- On errors, categorizes entities under their labels in process logs
- Marks transactional entities automatically if a transaction is open

Fixes: OX-7331
Fixes: OX-7244