### PR TITLE
Improves messages thrown by import handlers

### DIFF
--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -14,6 +14,7 @@ import sirius.db.mongo.Mango;
 import sirius.db.mongo.MongoEntity;
 import sirius.kernel.commons.Context;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 
 import java.util.Optional;
@@ -127,7 +128,11 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
 
             return entity;
         } catch (HandledException exception) {
-            throw enhanceExceptionWithHints(exception, entity);
+            HandledException handledException = Exceptions.createHandled()
+                                                          .withDirectMessage(entity.getDescriptor()
+                                                                                   .createCannotSaveMessage(exception.getMessage()))
+                                                          .handle();
+            throw enhanceExceptionWithHints(handledException, entity);
         }
     }
 

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -20,6 +20,7 @@ import sirius.db.mixing.Property;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.ValueHolder;
+import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 
 import java.util.ArrayList;
@@ -241,7 +242,11 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
                 return updateIfChanged(entity, batch);
             }
         } catch (HandledException exception) {
-            throw enhanceExceptionWithHints(exception, entity);
+            HandledException handledException = Exceptions.createHandled()
+                                                          .withDirectMessage(entity.getDescriptor()
+                                                                                   .createCannotSaveMessage(exception.getMessage()))
+                                                          .handle();
+            throw enhanceExceptionWithHints(handledException, entity);
         }
     }
 


### PR DESCRIPTION
when saving entities, which now always build the "cannot create entity" message. This way job using import handlers won't need to enhance messages

Needs: https://github.com/scireum/sirius-db/pull/450

Fixes: OX-7244