### PR TITLE
Fixes url after following wrongly encoded redirect headers

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -1433,8 +1433,11 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
 
             if (Strings.isEmpty(path) && !url.getPath().equals(lastConnectedURL.getPath())) {
                 // We don't have a path yet but we followed redirects so we check the new URL
-                if (headRequest.getResponseCode() == 404 && lastConnectedURL.toString().contains("Ã")) {
-                    // the redirect header contained UTF-8 das was interpreted as ISO-8859-1, try to fix this
+                if (headRequest.getResponseCode() == HttpResponseStatus.NOT_FOUND.code() && lastConnectedURL.toString()
+                                                                                                            .contains(
+                                                                                                                    "Ã")) {
+                    // We followed a redirect header in UTF-8 that was interpreted as ISO-8859-1, indicated by 'Ã' in the url
+                    // as the starting byte of two byte characters in UTF-8 will always be interpreted as 'Ã' in ISO-8859-1
                     lastConnectedURL =
                             new URL(new String(lastConnectedURL.toString().getBytes(StandardCharsets.ISO_8859_1),
                                                StandardCharsets.UTF_8));

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -1433,6 +1433,12 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
 
             if (Strings.isEmpty(path) && !url.getPath().equals(lastConnectedURL.getPath())) {
                 // We don't have a path yet but we followed redirects so we check the new URL
+                if (headRequest.getResponseCode() == 404 && lastConnectedURL.toString().contains("Ã")) {
+                    // the redirect header contained UTF-8 das was interpreted as ISO-8859-1, try to fix this
+                    lastConnectedURL =
+                            new URL(new String(lastConnectedURL.toString().getBytes(StandardCharsets.ISO_8859_1),
+                                               StandardCharsets.UTF_8));
+                }
                 path = parsePathFromUrl(lastConnectedURL, fileExtensionVerifier);
             }
 


### PR DESCRIPTION
By standard, the redirect header should contain the url in ISO-8859-1;
But most browsers and a lot of other clients also support UTF-8 so some servers will use UTF-8. When UTF-8 is used, the wrongly interpreted symbols will always start with the character 'Ã'. As the chance for this symbol in uppercase to be used in a correct url is pretty low, and at this point of the code we are at our last resort anyway, we will re interpret the String as UTF-8 if we come across this character.