### PR TITLE
Add new permissions to wondergem templates

### DIFF
--- a/src/main/resources/default/extensions/biz-menu/menu-jobs.html.pasta
+++ b/src/main/resources/default/extensions/biz-menu/menu-jobs.html.pasta
@@ -7,7 +7,7 @@
             <w:menuItem titleKey="JobsController.jobs" url="/jobs"
                         permission="permission-execute-jobs"
                         framework="biz.jobs"/>
-            <w:menuItem titleKey="Process.plural" url="/ps"
+            <w:menuItem titleKey="Process.plural" url="/ps" permission="permission-view-processes"
                         framework="biz.processes"/>
         </w:menuSection>
     </i:block>

--- a/src/main/resources/default/extensions/biz-menu/menu-protcols.html.pasta
+++ b/src/main/resources/default/extensions/biz-menu/menu-protcols.html.pasta
@@ -4,7 +4,7 @@
 <i:switch test="@point">
     <i:block name="user">
         <w:menuSection>
-            <w:menuItem titleKey="AuditLogEntry.plural" url="/audit-log" framework="biz.protocols"/>
+            <w:menuItem titleKey="AuditLogEntry.plural" url="/audit-log" permission="permission-view-audit-log" framework="biz.protocols"/>
         </w:menuSection>
     </i:block>
     <i:block name="system">

--- a/src/main/resources/default/extensions/biz-menu/menu-vfs.html.pasta
+++ b/src/main/resources/default/extensions/biz-menu/menu-vfs.html.pasta
@@ -4,7 +4,7 @@
 <i:switch test="@point">
     <i:block name="settings">
         <w:menuSection>
-            <w:menuItem titleKey="VFSController.root" url="/fs"/>
+            <w:menuItem titleKey="VFSController.root" url="/fs" permission="permission-view-files"/>
         </w:menuSection>
     </i:block>
 </i:switch>

--- a/src/main/resources/default/extensions/wondergem-page-menu/menu.html.pasta
+++ b/src/main/resources/default/extensions/wondergem-page-menu/menu.html.pasta
@@ -25,7 +25,8 @@
                              icon="/images/icons/ps.png"
                              activeIcon="/images/icons/ps-notif.png"
                              active="part(sirius.biz.process.Processes.class).hasActiveProcesses()"
-                             link="/ps"/>
+                             link="/ps"
+                             permission="permission-view-processes"/>
 
             <w:menuImageDropdownItem
                     icon="@user().tryAs(sirius.biz.web.UserIconProvider.class).flatMap(|provider| provider.getUserIcon()).orElse('/images/icons/user_avatar_d.png')"


### PR DESCRIPTION
Adds the newly introduced permissions `permission-view-processes`, `permission-view-audit-log` and `permission-view-files` to wondergem templates, so that they don't only work for tycho.