### PR TITLE
Improves optional file logging in archive imports

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -119,10 +119,10 @@ public abstract class ArchiveImportJob extends FileImportJob {
                             .set("fileName", fileName)
                             .handle();
         } else {
-            process.log(ProcessLog.warn()
+            process.log(ProcessLog.info()
                                   .withNLSKey("ArchiveImportJob.errorMsg.optionalFileMissing")
                                   .withContext("fileName", fileName)
-                                  .withMessageType(fileName));
+                                  .withMessageType("$ArchiveImportJob.errorMsg.optionalFileMissing.messageType"));
         }
     }
 

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -13,6 +13,7 @@ AmountScaleCheck.errorMsg.precisionExceeded = Der Wert (${value}) ist ungültig 
 AmountScaleCheck.errorMsg.scaleExceeded = Der Wert (${value}) ist ungültig da er aus mehr als ${scale} Nachkommastellen besteht.
 AmountScaleCheck.remark = Der Wert darf nicht mehr als ${precision} Ziffern und ${scale} Nachkommastellen umfassen.
 ArchiveImportJob.errorMsg.optionalFileMissing = Die optionale Datei '${fileName}' ist nicht im angegebenen Archiv vorhanden.
+ArchiveImportJob.errorMsg.optionalFileMissing.messageType = Optionale Dateien
 ArchiveImportJob.errorMsg.requiredFileMissing = Die Datei '${fileName}' ist nicht im angegebenen Archiv vorhanden.
 AuditLog.apiTokenLogin = Anmeldung des Benutzers via API-Token.
 AuditLog.externalLoginRequired = Der Anmeldeversuch des Benutzers wurde abgebrochen, da eine externe Anmeldung benötigt wird.

--- a/src/main/resources/biz_en.properties
+++ b/src/main/resources/biz_en.properties
@@ -15,6 +15,7 @@ AmountScaleCheck.remark = The value must not exceed ${precision} digits and ${sc
 ArchiveFileImportJob.error.optionalFileMissing = The optional file '${filename}' does not exist inside the provided archive.
 ArchiveFileImportJob.error.requiredFileMissing = The file '${filename}' was not found inside the provided archive.
 ArchiveImportJob.errorMsg.optionalFileMissing = The optional file '${fileName}' does not exist in the specified archive.
+ArchiveImportJob.errorMsg.optionalFileMissing.messageType = Optional Files
 ArchiveImportJob.errorMsg.requiredFileMissing = The file '${fileName}' does not exist in the specified archive.
 AuditLog.apiTokenLogin = Login via API token.
 AuditLog.externalLoginRequired = The login was aborted as an external login is required.


### PR DESCRIPTION
Optional files are logged as INFO and the messages are grouped under a single key
![image](https://user-images.githubusercontent.com/54799255/133424907-9022c50d-3f79-4810-ad1c-bc958e0bf788.png)

Fixes: OX-7404