### PR TITLE
Allows the browser to break long process log messages if necessary

### DIFF
--- a/src/main/resources/default/templates/biz/process/process-logs.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-logs.html.pasta
@@ -56,7 +56,9 @@
                     <i:for type="sirius.biz.process.logs.ProcessLog" var="log" items="logs.getItems()">
                         <tr>
                             <td class="left-border border-sirius-@log.getRowColor()">
-                                <div class="whitespace-pre-wrap overflow-hidden text-monospace text-small">@log.getMessage()</div>
+                                <div class="whitespace-pre-wrap overflow-hidden text-monospace text-small text-break">
+                                    @log.getMessage()
+                                </div>
                                 <div class="text-small text-muted mt-2">
                                     <i:for type="sirius.biz.process.logs.ProcessLogAction" var="action"
                                            items="log.getActions()">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2427877/134352158-cf5dac88-fe92-4820-ba75-dd267b487417.png)


After:
![image](https://user-images.githubusercontent.com/2427877/134352104-937e7b5c-db8a-4de9-b129-544fcc7d7d84.png)


Fixes: OX-7441