### PR TITLE
Fixes the alignment of process logs after the last fix

### DIFF
--- a/src/main/resources/default/templates/biz/process/process-logs.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-logs.html.pasta
@@ -56,7 +56,7 @@
                     <i:for type="sirius.biz.process.logs.ProcessLog" var="log" items="logs.getItems()">
                         <tr>
                             <td class="left-border border-sirius-@log.getRowColor()">
-                                <div class="whitespace-pre-wrap overflow-hidden text-monospace text-small text-break">
+                                <div class="overflow-hidden text-monospace text-small text-break">
                                     @log.getMessage()
                                 </div>
                                 <div class="text-small text-muted mt-2">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2427877/134466124-850312f1-e2e0-400a-8188-d37f2177794f.png)

After:
![image](https://user-images.githubusercontent.com/2427877/134466152-d6f29afb-500c-48ae-bf30-b6b9eea2f7b8.png)

Fixes: OX-7441