### PR TITLE
Keeps intentional line breaks in log messages intact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>ga-3.2.0</sirius.kernel>
-        <sirius.web>ga-4.0.0</sirius.web>
+        <sirius.web>dev-42.5.0</sirius.web>
         <sirius.db>ga-4.0.0</sirius.db>
     </properties>
 

--- a/src/main/resources/default/templates/biz/process/process-logs.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-logs.html.pasta
@@ -56,7 +56,7 @@
                     <i:for type="sirius.biz.process.logs.ProcessLog" var="log" items="logs.getItems()">
                         <tr>
                             <td class="left-border border-sirius-@log.getRowColor()">
-                                <div class="overflow-hidden text-monospace text-small text-break">
+                                <div class="overflow-hidden text-monospace text-small text-break whitespace-pre-line">
                                     @log.getMessage()
                                 </div>
                                 <div class="text-small text-muted mt-2">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2427877/134631462-8966866b-66c1-48cc-a2bb-d0e0b2cf8df9.png)

After:
![image](https://user-images.githubusercontent.com/2427877/134631508-47c12c8f-cbdb-4ca6-bbdd-cfaff5232523.png)


Fixes: OX-7441