### PR TITLE
Also removes failed variants from cache after delete

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLVariant.java
@@ -109,11 +109,11 @@ public class SQLVariant extends SQLEntity implements BlobVariant {
 
     @AfterDelete
     protected void onDelete() {
+        SQLBlob sqlBlob = sourceBlob.fetchValue();
         if (Strings.isFilled(physicalObjectKey)) {
-            SQLBlob sqlBlob = sourceBlob.fetchValue();
             sqlBlob.getStorageSpace().getPhysicalSpace().delete(physicalObjectKey);
-            sqlBlob.getStorageSpace().purgeVariantFromCache(sqlBlob, variantName);
         }
+        sqlBlob.getStorageSpace().purgeVariantFromCache(sqlBlob, variantName);
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoVariant.java
@@ -107,11 +107,11 @@ public class MongoVariant extends MongoEntity implements BlobVariant {
 
     @AfterDelete
     protected void onDelete() {
+        MongoBlob mongoBlob = blob.fetchValue();
         if (Strings.isFilled(physicalObjectKey)) {
-            MongoBlob mongoBlob = blob.fetchValue();
             mongoBlob.getStorageSpace().getPhysicalSpace().delete(physicalObjectKey);
-            mongoBlob.getStorageSpace().purgeVariantFromCache(mongoBlob, variantName);
         }
+        mongoBlob.getStorageSpace().purgeVariantFromCache(mongoBlob, variantName);
     }
 
     @Override


### PR DESCRIPTION
Failed Variants are marked as "-" in the cache, this needs to be removed when they are deleted so new conversion attempts will be attempted