### PR TITLE
Bugfix: Only applies empty checkbox marker for boolean properties

### DIFF
--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -21,6 +21,7 @@ import sirius.db.mixing.Mapping;
 import sirius.db.mixing.Mixing;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.properties.BaseEntityRefProperty;
+import sirius.db.mixing.properties.BooleanProperty;
 import sirius.db.mixing.types.BaseEntityRef;
 import sirius.db.mongo.Mango;
 import sirius.db.util.BaseEntityCache;
@@ -337,7 +338,8 @@ public class BizController extends BasicController {
                 return true;
             }
             Value parameterValue = webContext.get(propertyName).replaceIfEmpty(() -> {
-                if (webContext.hasParameter(propertyName + CHECKBOX_PRESENCE_MARKER)) {
+                if (property instanceof BooleanProperty && webContext.hasParameter(propertyName
+                                                                                   + CHECKBOX_PRESENCE_MARKER)) {
                     // If there is no value but a checkbox presence marker we have a unchecked checkbox - set value to false
                     return "false";
                 }


### PR DESCRIPTION
This fixes a bug where lists filled by checkboxes could not be properly be emptied.

We have to check for a BooleanProperty here, because checkboxes might also be used in templates with different values and the same name to let the user fill/unfill a ListProperty or BaseEntityRefListProperty - and these templates will also send markers for the given propertyName, so this lead to these lists be filled with a single entry 'false' when they were supposed to be empty.

Fixes: OX-7503