### PR TITLE
Validates missing fallback text for multi-language strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>dev-25.1.0</sirius.kernel>
         <sirius.web>dev-43.0.0</sirius.web>
-        <sirius.db>dev-32.0.0</sirius.db>
+        <sirius.db>dev-32.1.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -32,6 +32,7 @@ import sirius.kernel.commons.Value;
 import sirius.kernel.commons.Values;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
+import sirius.kernel.nls.NLS;
 import sirius.web.http.WebContext;
 
 import java.lang.reflect.Field;
@@ -153,6 +154,21 @@ public class MultiLanguageStringProperty extends BaseMapProperty
                                                    .set(PARAM_FIELD, getFullLabel())
                                                    .handle();
                                });
+        }
+    }
+
+    @Override
+    protected void onValidate(Object entity, Consumer<String> validationConsumer) {
+        MultiLanguageString multiLanguageString = getMultiLanguageString(entity);
+
+        if (!multiLanguageString.isWithFallback() || multiLanguageString.data().isEmpty()) {
+            return;
+        }
+
+        if (Strings.isEmpty(multiLanguageString.fetchText(MultiLanguageString.FALLBACK_KEY))) {
+            validationConsumer.accept(NLS.fmtr("MultiLanguageStringProperty.fallbackNotSet")
+                                         .set(PARAM_FIELD, getFullLabel())
+                                         .format());
         }
     }
 


### PR DESCRIPTION
when fallback is set, and text exists for any language code but the standard text.

Needs: https://github.com/scireum/sirius-db/pull/466

Fixes: SIRI-446