### PR TITLE
Improves the deletion of old / temporary blobs

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -57,6 +57,7 @@ import java.util.Optional;
 @Index(name = "blob_created_renamed_loop", columns = "createdOrRenamed")
 @Index(name = "blob_deleted_loop", columns = "deleted")
 @Index(name = "blob_parent_changed_loop", columns = "parentChanged")
+@Index(name = "blob_delete_old_temporary_loop", columns = {"spaceName", "deleted", "lastModified", "temporary"})
 public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
     @Transient

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -72,6 +72,9 @@ import java.util.Optional;
 @Index(name = "blob_created_renamed_loop", columns = "createdOrRenamed", columnSettings = Mango.INDEX_ASCENDING)
 @Index(name = "blob_deleted_loop", columns = "deleted", columnSettings = Mango.INDEX_ASCENDING)
 @Index(name = "blob_parent_changed_loop", columns = "parentChanged", columnSettings = Mango.INDEX_ASCENDING)
+@Index(name = "blob_delete_old_temporary_loop",
+        columns = {"spaceName", "deleted", "lastModified", "temporary"},
+        columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
 public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
     @Transient


### PR DESCRIPTION
By adding the required indices.
We can't share the 'blob_sort_by_last_modified' since the loops to delete old / temporary blobs do not provide a parent

Fixes: OX-7598