### PR TITLE
Permits to return blobs into a different name with the same normalize…

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -923,7 +923,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * @param newName the new name to use
      */
     public void rename(B blob, String newName) {
-        if (blob.getParent().hasChildNamed(newName)) {
+        if (blob.getParent().hasChildNamed(newName, blob)) {
             throw Exceptions.createHandled().withNLSKey("BasicBlobStorageSpace.cannotRenameDuplicateName").handle();
         }
 

--- a/src/main/java/sirius/biz/storage/layer2/Directory.java
+++ b/src/main/java/sirius/biz/storage/layer2/Directory.java
@@ -79,6 +79,15 @@ public interface Directory {
     boolean hasChildNamed(String name);
 
     /**
+     * Determines if there is a child with the given name, except for the given blob.
+     *
+     * @param name the name to check
+     * @param exemptedBlob the blob to ignore when searching for children
+     * @return <tt>true</tt> if either a directory or a blob with the given name exists as child
+     */
+    boolean hasChildNamed(String name, @Nullable Blob exemptedBlob);
+
+    /**
      * Tries to find the sub directory with the given name.
      *
      * @param name the name of the sub directory to resolve

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -497,12 +497,16 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                                                       UPDATE_BLOB_RETRIES));
     }
 
-    protected boolean hasExistingChild(SQLDirectory parent, String childName) {
+    protected boolean hasExistingChild(SQLDirectory parent, String childName, Blob exemptedBlob) {
         if (childDirectoryQuery(parent, childName).exists()) {
             return true;
         }
 
-        return childBlobQuery(parent, childName).exists();
+        SmartQuery<SQLBlob> childBlobQuery = childBlobQuery(parent, childName);
+        if (exemptedBlob != null) {
+            childBlobQuery.ne(SQLBlob.BLOB_KEY, exemptedBlob.getBlobKey());
+        }
+        return childBlobQuery.exists();
     }
 
     private SmartQuery<SQLDirectory> childDirectoryQuery(SQLDirectory parent, String childName) {
@@ -771,7 +775,8 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                       .error(e)
                       .withSystemErrorMessage(
                               "Layer 2/SQL: An error occurred, when marking the variant '%s' of blob '%s' as failed: %s (%s)",
-                              variant.getIdAsString(), variant.getSourceBlob().getIdAsString())
+                              variant.getIdAsString(),
+                              variant.getSourceBlob().getIdAsString())
                       .handle();
         }
     }
@@ -794,7 +799,8 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                       .error(e)
                       .withSystemErrorMessage(
                               "Layer 2/SQL: An error occurred, when marking the variant '%s' of blob '%s' as converted: %s (%s)",
-                              variant.getIdAsString(), variant.getSourceBlob().getIdAsString())
+                              variant.getIdAsString(),
+                              variant.getSourceBlob().getIdAsString())
                       .handle();
         }
     }

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
@@ -163,7 +163,12 @@ public class SQLDirectory extends SQLEntity implements Directory, OptimisticCrea
 
     @Override
     public boolean hasChildNamed(String name) {
-        return getStorageSpace().hasExistingChild(this, name);
+        return hasChildNamed(name, null);
+    }
+
+    @Override
+    public boolean hasChildNamed(String name, @Nullable Blob exemptedBlob) {
+        return getStorageSpace().hasExistingChild(this, name, exemptedBlob);
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -426,12 +426,17 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                                                       UPDATE_BLOB_RETRIES));
     }
 
-    protected boolean hasExistingChild(MongoDirectory parent, String childName) {
+    protected boolean hasExistingChild(MongoDirectory parent, String childName, Blob exemptedBlob) {
         if (childDirectoryQuery(parent, childName).exists()) {
             return true;
         }
 
-        return childBlobQuery(parent, childName).exists();
+        MongoQuery<MongoBlob> childBlobQuery = childBlobQuery(parent, childName);
+        if (exemptedBlob != null) {
+            childBlobQuery.ne(MongoBlob.BLOB_KEY, exemptedBlob.getBlobKey());
+        }
+
+        return childBlobQuery.exists();
     }
 
     private MongoQuery<MongoDirectory> childDirectoryQuery(MongoDirectory parent, String childName) {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
@@ -163,7 +163,12 @@ public class MongoDirectory extends MongoEntity implements Directory, Optimistic
 
     @Override
     public boolean hasChildNamed(String name) {
-        return getStorageSpace().hasExistingChild(this, name);
+        return hasChildNamed(name, null);
+    }
+
+    @Override
+    public boolean hasChildNamed(String name, @Nullable Blob exemptedBlob) {
+        return getStorageSpace().hasExistingChild(this, name, exemptedBlob);
     }
 
     @Override


### PR DESCRIPTION
…dFilename.

So if abc.jpg is renamed to ABC.jpg, this wasn't possible as a blob
(the one being renamed) did already exist. Therefore we now exempt this
blob from the check to support such renames.