### PR TITLE
Makes the fallback missing validation more robust

### DIFF
--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -165,7 +165,12 @@ public class MultiLanguageStringProperty extends BaseMapProperty
             return;
         }
 
-        if (Strings.isEmpty(multiLanguageString.fetchText(MultiLanguageString.FALLBACK_KEY))) {
+        if (Strings.isEmpty(multiLanguageString.fetchText(MultiLanguageString.FALLBACK_KEY))
+            && multiLanguageString.data()
+                                  .entrySet()
+                                  .stream()
+                                  .filter(entry -> !entry.getKey().equals(MultiLanguageString.FALLBACK_KEY))
+                                  .anyMatch(entry -> Strings.isFilled(entry.getValue()))) {
             validationConsumer.accept(NLS.fmtr("MultiLanguageStringProperty.fallbackNotSet")
                                          .set(PARAM_FIELD, getFullLabel())
                                          .format());


### PR DESCRIPTION
Older entities could contain empty values as either a fallback or a real language key, such as the samples below.
Therefore we make the validation more robust and additionally check if we have a filled text for any key but the fallback key.

``` json
"publicName" : [ 
    {
        "lang" : "de",
        "text" : ""
    }
]

"publicName" : [ 
    {
        "lang" : "fallback",
        "text" : ""
    }
]
```

Fixes: OX-7573