### PR TITLE
Only sets name and description of a lookup table entry, if they are filled

### DIFF
--- a/src/main/java/sirius/biz/codelists/LookupTableController.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableController.java
@@ -11,7 +11,6 @@ package sirius.biz.codelists;
 import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.web.BizController;
 import sirius.kernel.commons.Limit;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
@@ -120,7 +119,7 @@ public class LookupTableController extends BizController {
             output.property("showCode", true);
             output.property("label", labelDisplay.makeDisplayString(entry));
             output.property("name", entry.getName());
-            output.property("description", Strings.isEmpty(entry.getDescription()) ? null : entry.getDescription());
+            output.property("description", entry.getDescription());
             output.property("deprecated", entry.isDeprecated());
             if (showSource) {
                 output.property("source", entry.getSource());

--- a/src/main/java/sirius/biz/codelists/LookupTableEntry.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableEntry.java
@@ -11,7 +11,10 @@ package sirius.biz.codelists;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import sirius.kernel.commons.Limit;
+import sirius.kernel.commons.Strings;
 import sirius.web.controller.AutocompleteHelper;
+
+import javax.annotation.Nullable;
 
 /**
  * Represents an entry within a {@link LookupTable}.
@@ -36,8 +39,8 @@ public class LookupTableEntry {
      */
     public LookupTableEntry(String code, String name, String description) {
         this.code = code;
-        this.name = name;
-        this.description = description;
+        this.name = Strings.isEmpty(name) ? null : name;
+        this.description = Strings.isEmpty(description) ? null : description;
     }
 
     public LookupTableEntry markDeprecated() {
@@ -59,10 +62,12 @@ public class LookupTableEntry {
         return code;
     }
 
+    @Nullable
     public String getName() {
         return name;
     }
 
+    @Nullable
     public String getDescription() {
         return description;
     }


### PR DESCRIPTION
In many cases for IDB Lookup Tables, name and description are only present for certain languages. Missing ones would then be treated as empty strings instead of `null`. This has lead to issues with the fallback to outputting an entry's code, when generating display strings.

Fixes: SIRI-461