### PR TITLE
Operates path cache by normalized names if space does

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -389,7 +389,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
 
     @Nonnull
     private String determinePathCacheKey(String tenantId, String path) {
-        return spaceName + "-" + tenantId + "-" + path;
+        return spaceName + "-" + tenantId + "-" + (useNormalizedNames ? path.toLowerCase() : path);
     }
 
     protected Blob fetchByPath(String tenantId, @Nonnull String path) {


### PR DESCRIPTION
Previously this could mean that when removing a key from the cache, an unnormalized path could still be mapped to 'null' because only the normalized path has been removed from the cache.

Fixes: OX-7712