### PR TITLE
Adds an optional file extension filter for file picker modal

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VFSController.java
+++ b/src/main/java/sirius/biz/storage/layer3/VFSController.java
@@ -31,6 +31,7 @@ import sirius.web.util.LinkBuilder;
 
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -304,6 +305,13 @@ public class VFSController extends BizController {
             search.withOnlyDirectories();
         }
         search.withPrefixFilter(webContext.get("filter").asString());
+        webContext.get("extensions").ifFilled(extensionString -> {
+            Arrays.stream(extensionString.asString().split(","))
+                  .map(Strings::trim)
+                  .filter(Strings::isFilled)
+                  .map(string -> string.startsWith(".") ? string.substring(1) : string)
+                  .forEach(search::withFileExtension);
+        });
 
         // because of the additional ".."-entry for the parent, we need to adjust the pagination skip/limit
         boolean hasParent = parent.parent() != null;

--- a/src/main/resources/default/assets/scripts/vfs-modals.js
+++ b/src/main/resources/default/assets/scripts/vfs-modals.js
@@ -59,12 +59,13 @@ function selectVFSFile(config) {
             } else {
                 pagination._previousBtn.classList.remove("disabled");
             }
-            const url = Mustache.render("/fs/list?path={{path}}&onlyDirectories={{onlyDirectories}}&skip={{skip}}&maxItems={{maxItems}}&filter={{filter}}", {
+            const url = Mustache.render("/fs/list?path={{path}}&onlyDirectories={{onlyDirectories}}&skip={{skip}}&maxItems={{maxItems}}&filter={{filter}}&extensions={{extensions}}", {
                 path: encodeURIComponent(config.path),
                 onlyDirectories: config.allowDirectories && !config.allowFiles,
                 skip: page * pageSize,
                 maxItems: pageSize + 1,
-                filter: encodeURIComponent(_searchForm.value)
+                filter: encodeURIComponent(_searchForm.value),
+                extensions: encodeURIComponent(config.allowedExtensions)
             });
             fetch(url).then(function (response) {
                 if (!response.ok) {
@@ -124,6 +125,7 @@ function selectVFSFile(config) {
                             sendFileAsBody: true,
                             parallelUploads: 1,
                             maxFilesize: null,
+                            acceptedFiles: config.allowedExtensions,
                             previewTemplate: '' +
                                 '<div class="dropzone-item">\n' +
                                 '   <div class="dropzone-file">\n' +

--- a/src/main/resources/default/extensions/wondergem-page/storage-vfs-modals.html.pasta
+++ b/src/main/resources/default/extensions/wondergem-page/storage-vfs-modals.html.pasta
@@ -67,15 +67,16 @@
                 });
             }
 
-            function selectVFSFile(path, pathRestriction) {
+            function selectVFSFile(path, pathRestriction, extensions) {
                 document.querySelector("#select-file-modal .modal-title").textContent = "___i18n('VFSController.selectFile')";
                 return selectFileOrDirectoryModal({
                     path: path,
                     onlyDirectories: false,
                     pathRestriction: pathRestriction,
                     allowUpload: true,
+                    extensions: extensions,
                     filter: function (child) {
-                        return pathRestriction === undefined || child.path.startsWith(pathRestriction);
+                        return !pathRestriction || child.path.startsWith(pathRestriction);
                     },
                     createRow: function (child, _modal, resolve, changeDirectory) {
                         const _self = this;
@@ -115,12 +116,13 @@
                         } else {
                             pagination._previousBtn.classList.remove("disabled");
                         }
-                        const url = Mustache.render("/fs/list?path={{path}}&onlyDirectories={{onlyDirectories}}&skip={{skip}}&maxItems={{maxItems}}&filter={{filter}}", {
+                        const url = Mustache.render("/fs/list?path={{path}}&onlyDirectories={{onlyDirectories}}&skip={{skip}}&maxItems={{maxItems}}&filter={{filter}}&extensions={{extensions}}", {
                             path: encodeURIComponent(config.path),
                             onlyDirectories: config.onlyDirectories,
                             skip: page * pageSize,
                             maxItems: pageSize + 1,
-                            filter: encodeURIComponent(_searchForm.value)
+                            filter: encodeURIComponent(_searchForm.value),
+                            extensions: encodeURIComponent(config.extensions)
                         });
                         fetch(url).then(function (response) {
                             if (!response.ok) {

--- a/src/main/resources/default/taglib/t/fileField.html.pasta
+++ b/src/main/resources/default/taglib/t/fileField.html.pasta
@@ -5,6 +5,8 @@
 <i:arg name="value" type="String"/>
 <i:arg name="basePath" type="String" default=""
        description="Provides the base path which is first opened in the modal when no value is present."/>
+<i:arg type="String" name="allowedExtensions" default=""
+       description="This is a comma separated list allowed file extensions. Eg.: .mp4,.mpeg"/>
 <i:arg name="labelKey" type="String" default=""/>
 <i:arg name="label" type="String" default="@i18n(labelKey)"/>
 <i:arg name="helpKey" type="String" default=""/>
@@ -62,6 +64,7 @@
                     allowUpload: true,
                     allowDirectories: ___allowDirectories,
                     allowFiles: ___allowFiles,
+                    allowedExtensions: '___allowedExtensions',
                     modalTitle: ___allowDirectories ? (___allowFiles ? '___i18n("VFSController.selectFileOrDirectory")' : '___i18n("VFSController.selectDirectory")') : '___i18n("VFSController.selectFile")'
                 }).then(function (selectedValue) {
                     document.querySelector('#___localId input').value = selectedValue;

--- a/src/main/resources/default/taglib/w/filefield.html.pasta
+++ b/src/main/resources/default/taglib/w/filefield.html.pasta
@@ -17,6 +17,8 @@
 <i:arg name="id" type="String" default=""/>
 <i:arg name="placeholder" type="String" default=""/>
 <i:arg name="tabIndex" type="String" default=""/>
+<i:arg type="String" name="allowedExtensions" default=""
+       description="This is a comma separated list allowed file extensions. Eg.: mp4,mpeg"/>
 <i:local name="localId" value="@generateId('filefield-%s')"/>
 
 <i:pragma name="description"
@@ -53,7 +55,7 @@
                     value = value.substr(0, value.lastIndexOf("/"))
                 }
 
-                selectVFSFile(value).then(function (selectedValue) {
+                selectVFSFile(value, null, '___allowedExtensions').then(function (selectedValue) {
                     $('.___localId input').val(selectedValue);
                 });
             });


### PR DESCRIPTION
In wondergem, this will only limit the files displayed.
In tycho, this will also restrict the upload box to the given file types.
We use a comma seperated list of file extensions, each prefixed with '.' so we can easily feed the list directly into the dropzone library, and we can easily convert the string into a list(stream) on the server.

Fixes: SIRI-469