### PR TITLE
Allows to intercept before/after deletion of tenant aware entities

### DIFF
--- a/src/main/java/sirius/biz/codelists/jdbc/DeleteSQLCodeListsTask.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/DeleteSQLCodeListsTask.java
@@ -9,19 +9,18 @@
 package sirius.biz.codelists.jdbc;
 
 import sirius.biz.codelists.CodeList;
-import sirius.biz.tenants.jdbc.DeleteSQLEntitiesTask;
 import sirius.biz.tenants.deletion.DeleteTenantTask;
-import sirius.biz.tenants.jdbc.SQLTenantAware;
+import sirius.biz.tenants.jdbc.DeleteSQLEntitiesTask;
 import sirius.kernel.di.std.Register;
 
 /**
  * Deletes all {@link CodeList code lists} of the given tenant.
  */
 @Register(classes = DeleteTenantTask.class, framework = SQLCodeLists.FRAMEWORK_CODE_LISTS_JDBC)
-public class DeleteSQLCodeListsTask extends DeleteSQLEntitiesTask {
+public class DeleteSQLCodeListsTask extends DeleteSQLEntitiesTask<SQLCodeList> {
 
     @Override
-    protected Class<? extends SQLTenantAware> getEntityClass() {
+    protected Class<SQLCodeList> getEntityClass() {
         return SQLCodeList.class;
     }
 

--- a/src/main/java/sirius/biz/codelists/mongo/DeleteMongoCodeListsTask.java
+++ b/src/main/java/sirius/biz/codelists/mongo/DeleteMongoCodeListsTask.java
@@ -9,19 +9,18 @@
 package sirius.biz.codelists.mongo;
 
 import sirius.biz.codelists.CodeList;
-import sirius.biz.tenants.mongo.DeleteMongoEntitiesTask;
 import sirius.biz.tenants.deletion.DeleteTenantTask;
-import sirius.biz.tenants.mongo.MongoTenantAware;
+import sirius.biz.tenants.mongo.DeleteMongoEntitiesTask;
 import sirius.kernel.di.std.Register;
 
 /**
  * Deletes all {@link CodeList code lists} of the given tenant.
  */
 @Register(classes = DeleteTenantTask.class, framework = MongoCodeLists.FRAMEWORK_CODE_LISTS_MONGO)
-public class DeleteMongoCodeListsTask extends DeleteMongoEntitiesTask {
+public class DeleteMongoCodeListsTask extends DeleteMongoEntitiesTask<MongoCodeList> {
 
     @Override
-    protected Class<? extends MongoTenantAware> getEntityClass() {
+    protected Class<MongoCodeList> getEntityClass() {
         return MongoCodeList.class;
     }
 

--- a/src/main/java/sirius/biz/jobs/presets/jdbc/DeleteSQLJobPresetsTask.java
+++ b/src/main/java/sirius/biz/jobs/presets/jdbc/DeleteSQLJobPresetsTask.java
@@ -10,17 +10,16 @@ package sirius.biz.jobs.presets.jdbc;
 
 import sirius.biz.tenants.deletion.DeleteTenantTask;
 import sirius.biz.tenants.jdbc.DeleteSQLEntitiesTask;
-import sirius.biz.tenants.jdbc.SQLTenantAware;
 import sirius.kernel.di.std.Register;
 
 /**
  * Deletes all {@link sirius.biz.jobs.presets.JobPreset job presets} of the given tenant.
  */
 @Register(classes = DeleteTenantTask.class, framework = SQLJobPresets.FRAMEWORK_PRESETS_JDBC)
-public class DeleteSQLJobPresetsTask extends DeleteSQLEntitiesTask {
+public class DeleteSQLJobPresetsTask extends DeleteSQLEntitiesTask<SQLJobPreset> {
 
     @Override
-    protected Class<? extends SQLTenantAware> getEntityClass() {
+    protected Class<SQLJobPreset> getEntityClass() {
         return SQLJobPreset.class;
     }
 

--- a/src/main/java/sirius/biz/jobs/presets/mongo/DeleteMongoJobPresetsTask.java
+++ b/src/main/java/sirius/biz/jobs/presets/mongo/DeleteMongoJobPresetsTask.java
@@ -10,17 +10,16 @@ package sirius.biz.jobs.presets.mongo;
 
 import sirius.biz.tenants.deletion.DeleteTenantTask;
 import sirius.biz.tenants.mongo.DeleteMongoEntitiesTask;
-import sirius.biz.tenants.mongo.MongoTenantAware;
 import sirius.kernel.di.std.Register;
 
 /**
  * Deletes all {@link sirius.biz.jobs.presets.JobPreset job presets} of the given tenant.
  */
 @Register(classes = DeleteTenantTask.class, framework = MongoJobPresets.FRAMEWORK_PRESETS_MONGO)
-public class DeleteMongoJobPresetsTask extends DeleteMongoEntitiesTask {
+public class DeleteMongoJobPresetsTask extends DeleteMongoEntitiesTask<MongoJobPreset> {
 
     @Override
-    protected Class<? extends MongoTenantAware> getEntityClass() {
+    protected Class<MongoJobPreset> getEntityClass() {
         return MongoJobPreset.class;
     }
 

--- a/src/main/java/sirius/biz/jobs/scheduler/jdbc/DeleteSQLSchedulerEntriesTask.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/jdbc/DeleteSQLSchedulerEntriesTask.java
@@ -11,17 +11,16 @@ package sirius.biz.jobs.scheduler.jdbc;
 import sirius.biz.jobs.scheduler.SchedulerEntry;
 import sirius.biz.tenants.deletion.DeleteTenantTask;
 import sirius.biz.tenants.jdbc.DeleteSQLEntitiesTask;
-import sirius.biz.tenants.jdbc.SQLTenantAware;
 import sirius.kernel.di.std.Register;
 
 /**
  * Deletes all {@link SchedulerEntry scheduler entries} of the given tenant.
  */
 @Register(classes = DeleteTenantTask.class, framework = SQLSchedulerController.FRAMEWORK_SCHEDULER_JDBC)
-public class DeleteSQLSchedulerEntriesTask extends DeleteSQLEntitiesTask {
+public class DeleteSQLSchedulerEntriesTask extends DeleteSQLEntitiesTask<SQLSchedulerEntry> {
 
     @Override
-    protected Class<? extends SQLTenantAware> getEntityClass() {
+    protected Class<SQLSchedulerEntry> getEntityClass() {
         return SQLSchedulerEntry.class;
     }
 

--- a/src/main/java/sirius/biz/jobs/scheduler/mongo/DeleteMongoSchedulerEntriesTask.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/mongo/DeleteMongoSchedulerEntriesTask.java
@@ -11,17 +11,16 @@ package sirius.biz.jobs.scheduler.mongo;
 import sirius.biz.jobs.scheduler.SchedulerEntry;
 import sirius.biz.tenants.deletion.DeleteTenantTask;
 import sirius.biz.tenants.mongo.DeleteMongoEntitiesTask;
-import sirius.biz.tenants.mongo.MongoTenantAware;
 import sirius.kernel.di.std.Register;
 
 /**
  * Deletes {@link SchedulerEntry schedulerEntries} of the given tenant.
  */
 @Register(classes = DeleteTenantTask.class, framework = MongoSchedulerController.FRAMEWORK_SCHEDULER_MONGO)
-public class DeleteMongoSchedulerEntriesTask extends DeleteMongoEntitiesTask {
+public class DeleteMongoSchedulerEntriesTask extends DeleteMongoEntitiesTask<MongoSchedulerEntry> {
 
     @Override
-    protected Class<? extends MongoTenantAware> getEntityClass() {
+    protected Class<MongoSchedulerEntry> getEntityClass() {
         return MongoSchedulerEntry.class;
     }
 

--- a/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLEntitiesTask.java
@@ -20,8 +20,10 @@ import sirius.kernel.di.std.Part;
 
 /**
  * Deletes all entities of a given subclass of {@link SQLTenantAware} which belong to the given tenant.
+ *
+ * @param <E> the generic type of the entities being deleted
  */
-public abstract class DeleteSQLEntitiesTask extends DeleteEntitiesTask {
+public abstract class DeleteSQLEntitiesTask<E extends SQLTenantAware> extends DeleteEntitiesTask {
 
     @Part
     protected OMA oma;
@@ -43,7 +45,7 @@ public abstract class DeleteSQLEntitiesTask extends DeleteEntitiesTask {
      *
      * @param entityToDelete the entity that will be deleted
      */
-    protected void beforeDelete(SQLTenantAware entityToDelete) {
+    protected void beforeDelete(E entityToDelete) {
         // No work to do by default here.
     }
 
@@ -53,12 +55,12 @@ public abstract class DeleteSQLEntitiesTask extends DeleteEntitiesTask {
      *
      * @param entityToDelete the entity that was deleted
      */
-    protected void afterDelete(SQLTenantAware entityToDelete) {
+    protected void afterDelete(E entityToDelete) {
         // No work to do by default here.
     }
 
     @Override
-    protected SmartQuery<? extends SQLTenantAware> getQuery(Tenant<?> tenant) {
+    protected SmartQuery<E> getQuery(Tenant<?> tenant) {
         return oma.select(getEntityClass()).eq(TenantAware.TENANT, tenant);
     }
 
@@ -68,5 +70,5 @@ public abstract class DeleteSQLEntitiesTask extends DeleteEntitiesTask {
      * @return the class of the entities to be deleted
      */
     @Override
-    protected abstract Class<? extends SQLTenantAware> getEntityClass();
+    protected abstract Class<E> getEntityClass();
 }

--- a/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLEntitiesTask.java
@@ -30,9 +30,31 @@ public abstract class DeleteSQLEntitiesTask extends DeleteEntitiesTask {
     public void execute(ProcessContext processContext, Tenant<?> tenant) throws Exception {
         getQuery(tenant).iterateAll(entity -> {
             Watch watch = Watch.start();
+            beforeDelete(entity);
             oma.delete(entity);
+            afterDelete(entity);
             processContext.addTiming(DeleteTenantJobFactory.TIMING_DELETED_ITEMS, watch.elapsedMillis());
         });
+    }
+
+    /**
+     * Allows intercepting before an entity is deleted in the {@link #execute(ProcessContext, Tenant)} loop by
+     * overwriting this method.
+     *
+     * @param entityToDelete the entity that will be deleted
+     */
+    protected void beforeDelete(SQLTenantAware entityToDelete) {
+        // No work to do by default here.
+    }
+
+    /**
+     * Allows intercepting after an entity is deleted in the {@link #execute(ProcessContext, Tenant)} loop by
+     * overwriting this method.
+     *
+     * @param entityToDelete the entity that was deleted
+     */
+    protected void afterDelete(SQLTenantAware entityToDelete) {
+        // No work to do by default here.
     }
 
     @Override

--- a/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLUserAccountsTask.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLUserAccountsTask.java
@@ -16,10 +16,10 @@ import sirius.kernel.di.std.Register;
  * Deletes all {@link UserAccount user accounts} of the given tenant.
  */
 @Register(classes = DeleteTenantTask.class, framework = SQLTenants.FRAMEWORK_TENANTS_JDBC)
-public class DeleteSQLUserAccountsTask extends DeleteSQLEntitiesTask {
+public class DeleteSQLUserAccountsTask extends DeleteSQLEntitiesTask<SQLUserAccount> {
 
     @Override
-    protected Class<? extends SQLTenantAware> getEntityClass() {
+    protected Class<SQLUserAccount> getEntityClass() {
         return SQLUserAccount.class;
     }
 

--- a/src/main/java/sirius/biz/tenants/mongo/DeleteMongoEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/mongo/DeleteMongoEntitiesTask.java
@@ -20,8 +20,10 @@ import sirius.kernel.di.std.Part;
 
 /**
  * Deletes all entities of a given subclass of {@link MongoTenantAware} which belong to the given tenant.
+ *
+ * @param <E> the generic type of the entities being deleted
  */
-public abstract class DeleteMongoEntitiesTask extends DeleteEntitiesTask {
+public abstract class DeleteMongoEntitiesTask<E extends MongoTenantAware> extends DeleteEntitiesTask {
 
     @Part
     protected Mango mango;
@@ -43,7 +45,7 @@ public abstract class DeleteMongoEntitiesTask extends DeleteEntitiesTask {
      *
      * @param entityToDelete the entity that will be deleted
      */
-    protected void beforeDelete(MongoTenantAware entityToDelete) {
+    protected void beforeDelete(E entityToDelete) {
         // No work to do by default here.
     }
 
@@ -53,12 +55,12 @@ public abstract class DeleteMongoEntitiesTask extends DeleteEntitiesTask {
      *
      * @param entityToDelete the entity that was deleted
      */
-    protected void afterDelete(MongoTenantAware entityToDelete) {
+    protected void afterDelete(E entityToDelete) {
         // No work to do by default here.
     }
 
     @Override
-    protected MongoQuery<? extends MongoTenantAware> getQuery(Tenant<?> tenant) {
+    protected MongoQuery<E> getQuery(Tenant<?> tenant) {
         return mango.select(getEntityClass()).eq(TenantAware.TENANT, tenant);
     }
 
@@ -68,5 +70,5 @@ public abstract class DeleteMongoEntitiesTask extends DeleteEntitiesTask {
      * @return the class of the entities to be deleted
      */
     @Override
-    protected abstract Class<? extends MongoTenantAware> getEntityClass();
+    protected abstract Class<E> getEntityClass();
 }

--- a/src/main/java/sirius/biz/tenants/mongo/DeleteMongoEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/mongo/DeleteMongoEntitiesTask.java
@@ -30,9 +30,31 @@ public abstract class DeleteMongoEntitiesTask extends DeleteEntitiesTask {
     public void execute(ProcessContext processContext, Tenant<?> tenant) {
         getQuery(tenant).iterateAll(entity -> {
             Watch watch = Watch.start();
+            beforeDelete(entity);
             mango.delete(entity);
+            afterDelete(entity);
             processContext.addTiming(DeleteTenantJobFactory.TIMING_DELETED_ITEMS, watch.elapsedMillis());
         });
+    }
+
+    /**
+     * Allows intercepting before an entity is deleted in the {@link #execute(ProcessContext, Tenant)} loop by
+     * overwriting this method.
+     *
+     * @param entityToDelete the entity that will be deleted
+     */
+    protected void beforeDelete(MongoTenantAware entityToDelete) {
+        // No work to do by default here.
+    }
+
+    /**
+     * Allows intercepting after an entity is deleted in the {@link #execute(ProcessContext, Tenant)} loop by
+     * overwriting this method.
+     *
+     * @param entityToDelete the entity that was deleted
+     */
+    protected void afterDelete(MongoTenantAware entityToDelete) {
+        // No work to do by default here.
     }
 
     @Override

--- a/src/main/java/sirius/biz/tenants/mongo/DeleteMongoUserAccountTask.java
+++ b/src/main/java/sirius/biz/tenants/mongo/DeleteMongoUserAccountTask.java
@@ -16,10 +16,10 @@ import sirius.kernel.di.std.Register;
  * Deletes all {@link UserAccount user accounts} of the given tenant.
  */
 @Register(classes = DeleteTenantTask.class, framework = MongoTenants.FRAMEWORK_TENANTS_MONGO)
-public class DeleteMongoUserAccountTask extends DeleteMongoEntitiesTask {
+public class DeleteMongoUserAccountTask extends DeleteMongoEntitiesTask<MongoUserAccount> {
 
     @Override
-    protected Class<? extends MongoTenantAware> getEntityClass() {
+    protected Class<MongoUserAccount> getEntityClass() {
         return MongoUserAccount.class;
     }
 


### PR DESCRIPTION
**BREAKING:** It is advised to specify the generic types of custom delete tasks that inherit from `MongoEntityDeleteTask` or `SQLEntityDeleteTask`.

Fixes: OX-7558