### PR TITLE
Permits to define an afterSaveHandler for EntityImportJob/RelationEntityImportJob

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
@@ -157,7 +157,7 @@ public class EntityImportJob<E extends BaseEntity<?>> extends DictionaryBasedImp
      * Overwrite this method do add additional parameters to the <tt>context</tt>.
      *
      * @param context the context containing all relevant data
-     * @return the entity which was either found in he database or create using the given data
+     * @return the entity which was either found in the database or create using the given data
      */
     protected E findAndLoad(Context context) {
         return importer.findAndLoad(type, context);
@@ -184,7 +184,7 @@ public class EntityImportJob<E extends BaseEntity<?>> extends DictionaryBasedImp
     /**
      * Creates or updates the given entity.
      * <p>
-     * This can be overwritten to use a custom way of persisting data. Also this can be used to perfrom
+     * This can be overwritten to use a custom way of persisting data. Also, this can be used to perform
      * post-save activities.
      * <p>
      * By default we instantly create or update the entity. Note that if this is set to batch updates,

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -15,6 +15,7 @@ import sirius.biz.jobs.infos.JobInfoCollector;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
 import sirius.db.mixing.BaseEntity;
+import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
@@ -42,7 +43,8 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
         return new EntityImportJob<>(getImportType(),
                                      getDictionary(),
                                      process,
-                                     getName()).withContextExtender(context -> context.putAll(parameterContext));
+                                     getName()).withContextExtender(context -> context.putAll(parameterContext))
+                                               .withAfterSaveHandler(this::afterSaveHandler);
     }
 
     /**
@@ -54,6 +56,19 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
      */
     protected void transferParameters(ImportContext context, ProcessContext processContext) {
         // nothing to transfer by default
+    }
+
+    /**
+     * Executes post-processing actions on a saved entity.
+     * <p>
+     * This method executes nothing by default and can be overridden whenever post-processing
+     * tasks should be executed after an entity is saved.
+     *
+     * @param entity  the entity saved
+     * @param context the original context used to create or update the entity
+     */
+    protected void afterSaveHandler(BaseEntity<?> entity, Context context) {
+        // nothing to execute by default
     }
 
     /**

--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJob.java
@@ -37,7 +37,7 @@ import java.util.function.Consumer;
 /**
  * Provides a job for importing line based files (CSV, Excel) as relational entities.
  * <p>
- * This job behaves alomost exactly like {@link EntityImportJob}. The only difference is that it is suited for
+ * This job behaves almost exactly like {@link EntityImportJob}. The only difference is that it is suited for
  * "relational" entities (entities which represent a relation between two other entities). These are often
  * synchronized as described by {@link SyncMode}, which is handled by this implementation.
  * <p>
@@ -45,7 +45,7 @@ import java.util.function.Consumer;
  * framework can provide efficient delta updates.
  *
  * @param <E> the type of entities being imported by this job
- * @param <Q> the generic type of queries for the entities being procesed
+ * @param <Q> the generic type of queries for the entities being processed
  */
 public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransactionalEntity, Q extends Query<Q, E, ?>>
         extends DictionaryBasedImportJob {
@@ -111,9 +111,9 @@ public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransacti
     }
 
     /**
-     * Specifies the delete query tuner to use.
+     * Specifies the deletion query tuner to use.
      * <p>
-     * This permits to control which enities will be deleted if the remain unmarked during an import.
+     * This permits to control which entities will be deleted if they remain unmarked during an import.
      *
      * @param queryTuner the tuner to invoke
      * @return the job itself for fluent method calls
@@ -168,7 +168,7 @@ public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransacti
     }
 
     /**
-     * Tunes the delete query of the import transaction so that all untouched entities will be deleted.
+     * Tunes the deletion query of the import transaction so that all untouched entities will be deleted.
      *
      * @param deleteQuery the query to enhance
      */
@@ -227,7 +227,7 @@ public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransacti
      * Overwrite this method do add additional parameters to the <tt>context</tt>.
      *
      * @param context the context containing all relevant data
-     * @return the entity which was either found in he database or create using the given data
+     * @return the entity which was either found in the database or create using the given data
      */
     protected E findAndLoad(Context context) {
         return importer.findAndLoad(type, context);
@@ -260,7 +260,7 @@ public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransacti
     /**
      * Creates or updates the given entity.
      * <p>
-     * This can be overwritten to use a custom way of persisting data. Also this can be used to perfrom
+     * This can be overwritten to use a custom way of persisting data. Also, this can be used to perform
      * post-save activities.
      * <p>
      * By default we instantly create or update the entity. Note that if this is set to batch updates,

--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
@@ -25,11 +25,11 @@ import sirius.kernel.health.Log;
 import java.util.function.Consumer;
 
 /**
- * Provides a base implementation for batch jobs which synchronize a set of entities based on line based files using a
+ * Provides a base implementation for batch jobs which synchronize a set of entities based on line-based files using a
  * {@link sirius.biz.importer.ImportHandler}.
  *
  * @param <E> the type of entities being imported by this job
- * @param <Q> the generic type of queries for the entities being procesed
+ * @param <Q> the generic type of queries for the entities being processed
  */
 public abstract class RelationalEntityImportJobFactory<E extends BaseEntity<?> & ImportTransactionalEntity, Q extends Query<Q, E, ?>>
         extends DictionaryBasedImportJobFactory {
@@ -55,7 +55,16 @@ public abstract class RelationalEntityImportJobFactory<E extends BaseEntity<?> &
                                                              .withAfterSaveHandler(this::afterSaveHandler);
     }
 
+    /**
+     * Enhances the deletion query.
+     * <p>
+     * This permits to control which entities will be deleted if they remain unmarked during an import.
+     *
+     * @param processContext the process context
+     * @param query          the query to enhance
+     */
     protected void tuneDeleteQuery(ProcessContext processContext, Q query) {
+        // nothing to execute by default
     }
 
     /**
@@ -72,7 +81,7 @@ public abstract class RelationalEntityImportJobFactory<E extends BaseEntity<?> &
     }
 
     /**
-     * Permits to transfer parameters into the import context.
+     * Permits transferring parameters into the import context.
      *
      * @param context        the context to enrich. This will be transferred to the underlying {@link Importer} and
      *                       {@link sirius.biz.importer.ImportHandler import handlers}
@@ -105,7 +114,7 @@ public abstract class RelationalEntityImportJobFactory<E extends BaseEntity<?> &
     protected abstract Class<E> getImportType();
 
     /**
-     * Adds the possibility to enhance a dicitonary during the setup of the job
+     * Adds the possibility to enhance a dictionary during the setup of the job.
      *
      * @param importer   the current importer which can be asked to provide a dictionary for an entity
      * @param dictionary the dictionary to enhance

--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
@@ -17,6 +17,7 @@ import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.query.Query;
+import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
@@ -50,10 +51,24 @@ public abstract class RelationalEntityImportJobFactory<E extends BaseEntity<?> &
                                                    process,
                                                    getName()).withDeleteQueryTuner(this::tuneDeleteQuery)
                                                              .withContextExtender(context -> context.putAll(
-                                                                     parameterContext));
+                                                                     parameterContext))
+                                                             .withAfterSaveHandler(this::afterSaveHandler);
     }
 
     protected void tuneDeleteQuery(ProcessContext processContext, Q query) {
+    }
+
+    /**
+     * Executes post-processing actions on a saved entity.
+     * <p>
+     * This method executes nothing by default and can be overridden whenever post-processing
+     * tasks should be executed after an entity is saved.
+     *
+     * @param entity  the entity saved
+     * @param context the original context used to create or update the entity
+     */
+    protected void afterSaveHandler(E entity, Context context) {
+        // nothing to execute by default
     }
 
     /**


### PR DESCRIPTION
This allows one to execute post-processing tasks from the **Factory** used to create either an EntityImportJob or RelationEntityImportJob.

These jobs already allow to override their `#createOrUpdate` method, but in most cases we use the standard job, creating only a new factory.

Fixes: OX-7792