### PR TITLE
Update jcifs dependency 2.1.11 -> 2.1.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.codelibs</groupId>
             <artifactId>jcifs</artifactId>
-            <version>2.1.11</version>
+            <version>2.1.27</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
DEROutputStream is accessed directly in NegTokenInit which is not possible anymore and thus throws an exception while accessing cifs mounts.