### PR TITLE
Fixes the w:blobSoftRefField taglib

### DIFF
--- a/src/main/resources/default/assets/javascript/blobreffield.js
+++ b/src/main/resources/default/assets/javascript/blobreffield.js
@@ -111,7 +111,7 @@ function initBlobSoftRefField(element, blobKeyField, blobStorageSpace, originalU
 
         const currentPath = element.dataset.path || blobStorageSpacePath;
 
-        selectVFSFile(currentPath, blobStorageSpacePath).then(function (selectedValue) {
+        selectVFSFile(currentPath, blobStorageSpacePath, '').then(function (selectedValue) {
             $.getJSON('/dasd/blob-info-for-path/' + blobStorageSpace, {
                 path: selectedValue.substring(blobStorageSpacePath.length)
             }, function (json) {


### PR DESCRIPTION
The extensions parameter needs to be specified even if the files should not be filtered based on the extension.