### PR TITLE
Normalizes VFS to Unicode NFC Form

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -51,6 +51,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.text.Normalizer;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -125,6 +126,9 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * <p>
      * Setting this to true makes the file system effectively case-insensitive. Whereas using false
      * makes it case-sensitive.
+     * Note that this only determines case sensitivity:
+     * Unicode normalization is not configured with this key, its always applied -
+     * all directory and blob names are normalized to Unicode {@link Normalizer.Form#NFC combined form}.
      */
     private static final String CONFIG_KEY_USE_NORMALIZED_NAMES = "useNormalizedNames";
 

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -61,11 +61,11 @@ import java.util.Optional;
 @Index(name = "blob_delete_old_temporary_loop", columns = {"spaceName", "deleted", "lastModified", "temporary"})
 public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
+    @Part
+    private static StorageUtils storageUtils;
+
     @Transient
     private SQLBlobStorageSpace space;
-
-    @Part
-    private StorageUtils storageUtils;
 
     /**
      * Contains the name of the space this blob resides in.

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -15,6 +15,7 @@ import sirius.biz.storage.layer2.Directory;
 import sirius.biz.storage.layer2.OptimisticCreate;
 import sirius.biz.storage.layer2.URLBuilder;
 import sirius.biz.storage.layer2.variants.BlobVariant;
+import sirius.biz.storage.util.StorageUtils;
 import sirius.db.KeyGenerator;
 import sirius.db.jdbc.SQLEntity;
 import sirius.db.jdbc.SQLEntityRef;
@@ -62,6 +63,9 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
     @Transient
     private SQLBlobStorageSpace space;
+
+    @Part
+    private StorageUtils storageUtils;
 
     /**
      * Contains the name of the space this blob resides in.
@@ -239,7 +243,7 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
     protected void updateFilenameFields() {
         if (Strings.isFilled(filename)) {
-            this.filename = filename.trim();
+            this.filename = storageUtils.sanitizePath(filename);
             if (Strings.isFilled(filename)) {
                 this.normalizedFilename = filename.toLowerCase();
                 this.fileExtension = Files.getFileExtension(normalizedFilename);

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
@@ -45,7 +45,7 @@ import java.util.function.Predicate;
 public class SQLDirectory extends SQLEntity implements Directory, OptimisticCreate {
 
     @Part
-    private StorageUtils storageUtils;
+    private static StorageUtils storageUtils;
 
     /**
      * Contains the tenant which owns this directory.

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
@@ -12,6 +12,7 @@ import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.layer2.BlobStorage;
 import sirius.biz.storage.layer2.Directory;
 import sirius.biz.storage.layer2.OptimisticCreate;
+import sirius.biz.storage.util.StorageUtils;
 import sirius.db.jdbc.SQLEntity;
 import sirius.db.jdbc.SQLEntityRef;
 import sirius.db.mixing.Mapping;
@@ -42,6 +43,9 @@ import java.util.function.Predicate;
         columns = {"spaceName", "parent", "deleted", "normalizedDirectoryName"})
 @Index(name = "directory_renamed_loop", columns = "renamed")
 public class SQLDirectory extends SQLEntity implements Directory, OptimisticCreate {
+
+    @Part
+    private StorageUtils storageUtils;
 
     /**
      * Contains the tenant which owns this directory.
@@ -123,7 +127,7 @@ public class SQLDirectory extends SQLEntity implements Directory, OptimisticCrea
     @BeforeSave
     protected void beforeSave() {
         if (Strings.isFilled(directoryName)) {
-            this.directoryName = directoryName.trim();
+            this.directoryName = storageUtils.sanitizePath(directoryName);
             if (Strings.isFilled(directoryName)) {
                 this.normalizedDirectoryName = directoryName.toLowerCase();
             } else {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -78,11 +78,11 @@ import java.util.Optional;
         columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
 public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
+    @Part
+    private static StorageUtils storageUtils;
+
     @Transient
     private MongoBlobStorageSpace space;
-
-    @Part
-    private StorageUtils storageUtils;
 
     /**
      * Contains the name of the space this blob resides in.

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -15,6 +15,7 @@ import sirius.biz.storage.layer2.Directory;
 import sirius.biz.storage.layer2.OptimisticCreate;
 import sirius.biz.storage.layer2.URLBuilder;
 import sirius.biz.storage.layer2.variants.BlobVariant;
+import sirius.biz.storage.util.StorageUtils;
 import sirius.db.KeyGenerator;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.BeforeSave;
@@ -79,6 +80,9 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
     @Transient
     private MongoBlobStorageSpace space;
+
+    @Part
+    private StorageUtils storageUtils;
 
     /**
      * Contains the name of the space this blob resides in.
@@ -246,7 +250,7 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
     protected void updateFilenameFields() {
         if (Strings.isFilled(filename)) {
-            this.filename = filename.trim();
+            this.filename = storageUtils.sanitizePath(filename);
             if (Strings.isFilled(filename)) {
                 this.normalizedFilename = filename.toLowerCase();
                 this.fileExtension = Files.getFileExtension(normalizedFilename);

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
@@ -50,7 +50,7 @@ import java.util.function.Predicate;
 public class MongoDirectory extends MongoEntity implements Directory, OptimisticCreate {
 
     @Part
-    private StorageUtils storageUtils;
+    private static StorageUtils storageUtils;
 
     /**
      * Contains the tenant which owns this directory.

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
@@ -12,6 +12,7 @@ import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.layer2.BlobStorage;
 import sirius.biz.storage.layer2.Directory;
 import sirius.biz.storage.layer2.OptimisticCreate;
+import sirius.biz.storage.util.StorageUtils;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.Index;
@@ -47,6 +48,9 @@ import java.util.function.Predicate;
         columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
 @Index(name = "directory_renamed_loop", columns = "renamed", columnSettings = Mango.INDEX_ASCENDING)
 public class MongoDirectory extends MongoEntity implements Directory, OptimisticCreate {
+
+    @Part
+    private StorageUtils storageUtils;
 
     /**
      * Contains the tenant which owns this directory.
@@ -123,7 +127,7 @@ public class MongoDirectory extends MongoEntity implements Directory, Optimistic
     @BeforeSave
     protected void beforeSave() {
         if (Strings.isFilled(directoryName)) {
-            this.directoryName = directoryName.trim();
+            this.directoryName = storageUtils.sanitizePath(directoryName);
             if (Strings.isFilled(directoryName)) {
                 this.normalizedDirectoryName = directoryName.toLowerCase();
             } else {

--- a/src/main/java/sirius/biz/storage/util/StorageUtils.java
+++ b/src/main/java/sirius/biz/storage/util/StorageUtils.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.text.Normalizer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -166,9 +167,10 @@ public class StorageUtils {
     /**
      * Sanitizes the given path.
      * <p>
-     * This will replace backslashes with forward slashes, and remove successive slashes. Trailing slashes are removed
-     * from directory paths, and absolute paths are made relative by removing leading slashes. Also replaces chars that
-     * may be illegal in file systems with {@code _}.
+     * Normalizes the text to {@link Normalizer.Form#NFC combined unicode}, replaces backslashes with forward slashes,
+     * and removes successive slashes. Trailing slashes are removed from directory paths,
+     * and absolute paths are made relative by removing leading slashes.
+     * Also replaces chars that may be illegal in file systems with {@code _}.
      *
      * @param path the path to cleanup
      * @return the sanitized path without illegal characters
@@ -182,6 +184,8 @@ public class StorageUtils {
         }
 
         path = replaceIllegalFileChars(path, false);
+
+        path = Normalizer.normalize(path, Normalizer.Form.NFC);
 
         if (path.startsWith("/")) {
             path = path.substring(1);


### PR DESCRIPTION
Fixes SIRI-491

Normalizes to Unicode NFC Form when sanitizing a path. 

This effectively means that all lookups and therefore each new blob creation is normalized to the NFC form. This also means that existing NFD forms an no longer be found, even when querying for exactly the NFD form (as it will get normalized). Therefore all existing DB objects (MongoDirectory,Mongoblob, SQlBlob...) need to be normalized to NFC. An appropriate job for this task will be provided in the next commit.

Additionally sanitizes the filename in beforeSave of vfs db objects 

This makes sure that the data in the db is consistent with the actual names we search for, even if the file or directory was not created by findByPath.
This also means that in order for existing objects to be normalized we can use a simple resave entities job.


### **_BREAKING: No code changes needed, but in order for all exisiting files/directory to still be found a resave entities job for MongoBlob+MongoDirectory or SQLBlob+SQLDirectory needs to be executed._**
