### PR TITLE
We should really not attempt to bind a user "only" for event logging

### DIFF
--- a/src/main/java/sirius/biz/analytics/events/UserData.java
+++ b/src/main/java/sirius/biz/analytics/events/UserData.java
@@ -49,7 +49,7 @@ public class UserData extends Composite {
         if (ctx.getScope() != ScopeInfo.DEFAULT_SCOPE && Strings.isEmpty(scopeId)) {
             scopeId = ctx.getScope().getScopeId();
         }
-        if (ctx.getUser().isLoggedIn() && Strings.isEmpty(userId)) {
+        if (ctx.isUserPresent() && ctx.getUser().isLoggedIn() && Strings.isEmpty(userId)) {
             userId = ctx.getUser().getUserId();
             tenantId = ctx.getUser().getTenantId();
         }


### PR DESCRIPTION
This caused a problem where an event was logged during login (but before the login finished)
Fixes SE-11173