### PR TITLE
VirtualFile new methods: root + isRootWorkingDirectory

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
@@ -124,6 +124,19 @@ public class ObjectStorage {
     }
 
     /**
+     * Determines if the storage space with the work-directory space.
+     *
+     * @param space the name of the space to check
+     * @return <tt>true</tt> if the space is known, <tt>false</tt> otherwise
+     */
+    public boolean isWorkDirectory(String space) {
+        if (!isKnown(space)) {
+            return false;
+        }
+        return WORK_SPACE_NAME.equals(getSpaceMap().get(space).getName());
+    }
+
+    /**
      * Returns all known layer 1 spaces.
      *
      * @return all known storage spaces of the layer 1

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
@@ -52,6 +52,10 @@ public class ObjectStorage {
      * to use for a space.
      */
     public static final String CONFIG_KEY_LAYER1_CIPHER = "cipher";
+    /**
+     * Contains the name of the storage space used for "work files".
+     */
+    public static final String WORK_SPACE_NAME = "work";
 
     @Part
     private StorageUtils utils;

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
@@ -19,6 +19,7 @@ import sirius.kernel.settings.Extension;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -77,7 +78,7 @@ public class ObjectStorage {
             spaceMap = initializeSpaceMap();
         }
 
-        return spaceMap;
+        return Collections.unmodifiableMap(spaceMap);
     }
 
     private Map<String, ObjectStorageSpace> initializeSpaceMap() {

--- a/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
@@ -28,7 +28,7 @@ import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 
 /**
- * Represents the mutable version of a {@link VirtualFile} which can be used to provide all necessarry callbacks.
+ * Represents the mutable version of a {@link VirtualFile} which can be used to provide all necessary callbacks.
  */
 public class MutableVirtualFile extends VirtualFile {
 

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -14,6 +14,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.storage.layer1.FileHandle;
+import sirius.biz.storage.layer1.ObjectStorage;
 import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.util.Attempt;
 import sirius.biz.storage.util.StorageUtils;
@@ -116,6 +117,9 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
 
     @Part
     private static StorageUtils utils;
+
+    @Part
+    private static ObjectStorage objectStorage;
 
     /**
      * Internal constructor to create the "/" directory.
@@ -245,6 +249,27 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
             current = current.parent();
         }
         return result;
+    }
+
+    /**
+     * Returns the root directory path of the current virtual file.
+     * <p>
+     * If the virtual file belongs to a known space, it is used as root, otherwise <tt>/</tt> is returned.
+     *
+     * @return the root directory path
+     */
+    @Nullable
+    public VirtualFile root() {
+        List<VirtualFile> fileList = pathList();
+        if (fileList.isEmpty()) {
+            return null;
+        }
+
+        if (fileList.size() > 1 && objectStorage.isKnown(fileList.get(1).name())) {
+            return fileList.get(1);
+        }
+
+        return fileList.get(0);
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -273,6 +273,16 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     }
 
     /**
+     * Indicates if the root directory is considered the working directory.
+     *
+     * @return <tt>true</tt> when the root is the working directory, <tt>false</tt> otherwise
+     * @see ObjectStorage#WORK_SPACE_NAME
+     */
+    public boolean isRootWorkDirectory() {
+        return objectStorage.isWorkDirectory(root().name());
+    }
+
+    /**
      * Returns the name of this file.
      *
      * @return the name of this file


### PR DESCRIPTION
VirtualFile.root() - determines the root directory of a VirtualFile, handling when the path is resolved from a known space.
```
/work/foo/bar -> /work
/foo/bar -> /
```

VirtualFile.isWootWorkDirectory():
```
/work/foo/bar -> true
/foo/bar -> false
```

Fixes: SIRI-502