### PR TITLE
Marries VirtualFile with BlobStorageSpace

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
@@ -19,6 +19,7 @@ import sirius.kernel.settings.Extension;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -73,7 +74,7 @@ public class ObjectStorage {
             spaceMap = initializeSpaceMap();
         }
 
-        return spaceMap;
+        return Collections.unmodifiableMap(spaceMap);
     }
 
     private Map<String, ObjectStorageSpace> initializeSpaceMap() {

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -157,6 +157,11 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     private static final String CONFIG_KEY_SORT_BY_LAST_MODIFIED = "sortByLastModified";
 
     /**
+     * Determines if the space is considered a work-directory, where its contents are considered of temporary character.
+     */
+    private static final String CONFIG_KEY_WORK_DIRECTORY = "workDirectory";
+
+    /**
      * Contains the name of the executor in which requests are moved which might be blocked while waiting for
      * a conversion to happen. We do not want to jam our main executor of the web server for this, therefore
      * a separator one is used.
@@ -243,6 +248,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     protected boolean touchTracking;
     protected boolean sortByLastModified;
     protected ObjectStorageSpace objectStorageSpace;
+    protected boolean workDirectory;
 
     /**
      * Creates a new instance by loading all settings from the given config section.
@@ -261,6 +267,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         this.retentionDays = config.get(CONFIG_KEY_RETENTION_DAYS).asInt(0);
         this.touchTracking = config.get(CONFIG_KEY_TOUCH_TRACKING).asBoolean();
         this.sortByLastModified = config.get(CONFIG_KEY_SORT_BY_LAST_MODIFIED).asBoolean();
+        this.workDirectory = config.get(CONFIG_KEY_WORK_DIRECTORY).asBoolean();
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
@@ -185,8 +185,8 @@ public interface BlobStorageSpace {
      * This is used by the {@link BlobContainer} to reference arbitrary blobs from an entity. This is mainly used,
      * if the blobs are not referenced by their filename.
      *
-     * @param objectKey           the blob to reference
-     * @param referencingEntity   the unique name of the entity
+     * @param objectKey         the blob to reference
+     * @param referencingEntity the unique name of the entity
      */
     void attachTemporaryBlob(String objectKey, String referencingEntity);
 
@@ -194,7 +194,7 @@ public interface BlobStorageSpace {
      * Fetches a blob attached to an entity via a {@link BlobContainer}.
      *
      * @param referencingEntity the referencing entity
-     * @param blobKey          the blob key to lookup
+     * @param blobKey           the blob key to lookup
      * @return the matching blob wrapped as optional or an empty optional if no matching blob was found
      */
     Optional<? extends Blob> findAttachedBlobByKey(String referencingEntity, String blobKey);
@@ -336,4 +336,11 @@ public interface BlobStorageSpace {
      * @param blobKeys the set of keys to mark as accessed
      */
     void markTouched(Set<String> blobKeys);
+
+    /**
+     * Determines if this space is considered a work directory.
+     *
+     * @return <tt>true</tt> if a work directory, <tt>false</tt> otherwise
+     */
+    boolean isWorkDirectory();
 }

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -117,10 +117,10 @@ public class L3Uplink implements VFSRoot {
          * Creates a placeholder for the given parent and name.
          *
          * @param parentDirectory the directory which (if present) is used to determine if the underlying storage space
-         *                        is readonly. In this case an empty optional is returned
+         *                        is readonly. In this case null is returned
          * @param parent          the parent to pass on
          * @param name            the name of the placeholder
-         * @return a placeholder representing a non existent file or directory
+         * @return a placeholder representing a non-existent file or directory
          */
         @Nullable
         protected VirtualFile createPlaceholder(@Nullable Directory parentDirectory, VirtualFile parent, String name) {
@@ -131,6 +131,14 @@ public class L3Uplink implements VFSRoot {
             MutableVirtualFile file = MutableVirtualFile.checkedCreate(parent, name);
             file.attach(new Placeholder(parent, name));
             attachHandlers(file, false);
+
+            if (parentDirectory != null) {
+                file.withStorageSpaceSupplier(parentDirectory::getStorageSpace);
+            } else {
+                // when the parentDirectory is null, we likely started from a real space, but have non-existent
+                // sub-folders, so we supply the space from the direct parent
+                file.withStorageSpaceSupplier(() -> parent.getStorageSpace().orElse(null));
+            }
 
             return file;
         }

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -926,6 +926,11 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
     }
 
     @Override
+    public boolean isWorkDirectory() {
+        return workDirectory;
+    }
+
+    @Override
     protected void purgeVariantFromCache(SQLBlob blob, String variantName) {
         blobKeyToPhysicalCache.remove(buildCacheLookupKey(blob.getBlobKey(), variantName));
     }

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -822,6 +822,11 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
     }
 
     @Override
+    public boolean isWorkDirectory() {
+        return workDirectory;
+    }
+
+    @Override
     protected void purgeVariantFromCache(MongoBlob blob, String variantName) {
         blobKeyToPhysicalCache.remove(buildCacheLookupKey(blob.getBlobKey(), variantName));
     }

--- a/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
@@ -28,7 +28,7 @@ import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 
 /**
- * Represents the mutable version of a {@link VirtualFile} which can be used to provide all necessarry callbacks.
+ * Represents the mutable version of a {@link VirtualFile} which can be used to provide all necessary callbacks.
  */
 public class MutableVirtualFile extends VirtualFile {
 

--- a/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
@@ -9,6 +9,7 @@
 package sirius.biz.storage.layer3;
 
 import sirius.biz.storage.layer1.FileHandle;
+import sirius.biz.storage.layer2.BlobStorageSpace;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
@@ -25,6 +26,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 
 /**
@@ -429,6 +431,17 @@ public class MutableVirtualFile extends VirtualFile {
      */
     public MutableVirtualFile withTouchHandler(Consumer<VirtualFile> touchHandler) {
         this.touchHandler = touchHandler;
+        return this;
+    }
+
+    /**
+     * Sets the supplier responsible to deliver the storage space sitting on top of the file.
+     *
+     * @param storageSpaceSupplier the supplier for a {@link BlobStorageSpace}
+     * @return the file itself for fluent method calls
+     */
+    public MutableVirtualFile withStorageSpaceSupplier(Supplier<BlobStorageSpace> storageSpaceSupplier) {
+        this.storageSpaceSupplier = storageSpaceSupplier;
         return this;
     }
 }

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -15,6 +15,7 @@ import io.netty.handler.codec.http.QueryStringDecoder;
 import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.storage.layer1.FileHandle;
 import sirius.biz.storage.layer2.Blob;
+import sirius.biz.storage.layer2.BlobStorageSpace;
 import sirius.biz.storage.util.Attempt;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.kernel.async.TaskContext;
@@ -63,6 +64,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
@@ -113,6 +115,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     protected Predicate<VirtualFile> canRenameHandler;
     protected BiPredicate<VirtualFile, String> renameHandler;
     protected Consumer<VirtualFile> touchHandler;
+    protected Supplier<BlobStorageSpace> storageSpaceSupplier;
 
     @Part
     private static StorageUtils utils;
@@ -439,6 +442,24 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
             }
         } catch (Exception e) {
             throw handleErrorInCallback(e, "touchHandler");
+        }
+    }
+
+    /**
+     * Returns the blob storage space on top of the virtual file.
+     *
+     * @return the {@link BlobStorageSpace} encapsulated by an optional or empty if this virtual file or directory does
+     * not derive from a storage space
+     */
+    public Optional<BlobStorageSpace> getStorageSpace() {
+        if (storageSpaceSupplier == null) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.ofNullable(storageSpaceSupplier.get());
+        } catch (Exception e) {
+            throw handleErrorInCallback(e, "storageSpaceSupplier");
         }
     }
 

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1000,6 +1000,10 @@ storage {
                 # Determines if files are sorted by their name ascending (false) or by their last modification
                 # timestamp descending. Note that directories will always be sorted by name ascending.
                 sortByLastModified = false
+
+                # Signalizes that the space is used as a work directory and its files are usually treated as temporary
+                # For example: they are deleted after processed by a job
+                workDirectory = false
             }
 
             # Defines a work space which is shared by all users of a tenant and can be used to provide
@@ -1008,6 +1012,7 @@ storage {
                 description = "$BlobStorageSpace.work.description"
                 retentionDays = 30
                 sortByLastModified = true
+                workDirectory = true
             }
 
             # Provides a temporary storage location which will be cleaned up every once in a while.


### PR DESCRIPTION
A new config key allows to mark a storage space as a "work directory", intended for files supposed to have a short life (eg. deleted after processed by a job).

Respectively, this information is made public with `BlobStorageSpace.isWorkDirectory()`

Finally, VirtualFiles initialized from a storage space via _L3UpLink_ will contain the information about their originating storage space. This will work for real files, sitting under a Directory hierarchy, but also placeholders. Therefore:

Both these paths would return the storage space `work`:
* /work/real-directory/real-file and
* /work/foo/bar 

Sample call to verify is a virtual file belongs to a working directory:
``` java
virtualFile.getStorageSpace()
           .filter(BlobStorageSpace::isWorkDirectory)
           .ifPresent(storageSpace -> ...)
```

Fixes: SIRI-502