### PR TITLE
Marries VirtualFiles with BlobStorageSpace - Take 3

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -297,6 +297,11 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         return touchTracking;
     }
 
+    @Override
+    public int getRetentionDays() {
+        return retentionDays;
+    }
+
     /**
      * Provides the skeleton of most of the optimistic locking algorithms used by this class.
      * <p>

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
@@ -336,4 +336,11 @@ public interface BlobStorageSpace {
      * @param blobKeys the set of keys to mark as accessed
      */
     void markTouched(Set<String> blobKeys);
+
+    /**
+     * Returns how many days files are kept in the storage space before being deleted.
+     *
+     * @return the amount of days, 0 when indefinite
+     */
+    int getRetentionDays();
 }

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -227,6 +227,7 @@ public class L3Uplink implements VFSRoot {
     public MutableVirtualFile wrapDirectory(VirtualFile parent, Directory directory, boolean forceReadonly) {
         MutableVirtualFile file = MutableVirtualFile.checkedCreate(parent, directory.getName());
         file.attach(Directory.class, directory);
+        file.attach(directory.getStorageSpace());
         attachHandlers(file, forceReadonly);
 
         return file;
@@ -245,6 +246,7 @@ public class L3Uplink implements VFSRoot {
     public MutableVirtualFile wrapBlob(VirtualFile parent, Blob blob, boolean forceReadonly) {
         MutableVirtualFile file = MutableVirtualFile.checkedCreate(parent, blob.getFilename());
         file.attach(Blob.class, blob);
+        file.attach(blob.getStorageSpace());
         attachHandlers(file, forceReadonly);
 
         return file;

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -15,6 +15,7 @@ import sirius.biz.storage.layer3.FileSearch;
 import sirius.biz.storage.layer3.MutableVirtualFile;
 import sirius.biz.storage.layer3.VFSRoot;
 import sirius.biz.storage.layer3.VirtualFile;
+import sirius.biz.storage.layer3.VirtualFileSystem;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Strings;
@@ -45,6 +46,9 @@ public class L3Uplink implements VFSRoot {
 
     @Part
     private BlobStorage storage;
+
+    @Part
+    private VirtualFileSystem vfs;
 
     /**
      * Represents a non-existent file or directory which might be created by
@@ -130,6 +134,7 @@ public class L3Uplink implements VFSRoot {
 
             MutableVirtualFile file = MutableVirtualFile.checkedCreate(parent, name);
             file.attach(new Placeholder(parent, name));
+            vfs.fetchBlobStorageSpace(parent).ifPresent(file::attach);
             attachHandlers(file, false);
 
             return file;

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -134,8 +134,8 @@ public class L3Uplink implements VFSRoot {
 
             MutableVirtualFile file = MutableVirtualFile.checkedCreate(parent, name);
             file.attach(new Placeholder(parent, name));
-            vfs.fetchBlobStorageSpace(parent)
-               .ifPresent(blobStorageSpace -> file.attach(BlobStorageSpace.class, blobStorageSpace));
+            parent.tryAs(BlobStorageSpace.class)
+                  .ifPresent(blobStorageSpace -> file.attach(BlobStorageSpace.class, blobStorageSpace));
             attachHandlers(file, false);
 
             return file;

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -124,7 +124,7 @@ public class L3Uplink implements VFSRoot {
          *                        is readonly. In this case an empty optional is returned
          * @param parent          the parent to pass on
          * @param name            the name of the placeholder
-         * @return a placeholder representing a non existent file or directory
+         * @return a placeholder representing a non-existent file or directory
          */
         @Nullable
         protected VirtualFile createPlaceholder(@Nullable Directory parentDirectory, VirtualFile parent, String name) {
@@ -158,7 +158,7 @@ public class L3Uplink implements VFSRoot {
         }
 
         private VirtualFile findChildInDirectory(VirtualFile parent, Directory parentDir, String name) {
-            // If there is a file extension, this is most probably a file / blob. Therefore we first
+            // If there is a file extension, this is most probably a file / blob. Therefore, we first
             // try to resolve it as such and then fallback to resolving as directory...
             if (Strings.isFilled(Files.getFileExtension(name))) {
                 return priorizedLookup(() -> parentDir.findChildBlob(name)
@@ -225,7 +225,7 @@ public class L3Uplink implements VFSRoot {
      * @param parent        the parent file to use
      * @param directory     the directory to wrap
      * @param forceReadonly determines if the directory should be forcefully set to readonly (independent of
-     *                      {@link BlobStorageSpace#isReadonly()}. Note that setting this to <tt>false</tt> will not
+     *                      {@link BlobStorageSpace#isReadonly()}). Note that setting this to <tt>false</tt> will not
      *                      make the directory writable if <tt>BlobStorageSpace#isReadonly()</tt> returns <tt>true</tt>
      * @return the resulting mutable virtual file
      */
@@ -244,7 +244,7 @@ public class L3Uplink implements VFSRoot {
      * @param parent        the parent file to use
      * @param blob          the blob to wrap
      * @param forceReadonly determines if the blob should be forcefully set to readonly (independent of
-     *                      {@link BlobStorageSpace#isReadonly()}. Note that setting this to <tt>false</tt> will not
+     *                      {@link BlobStorageSpace#isReadonly()}). Note that setting this to <tt>false</tt> will not
      *                      make the blob writable if <tt>BlobStorageSpace#isReadonly()</tt> returns <tt>true</tt>
      * @return the resulting mutable virtual file
      */

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -134,7 +134,8 @@ public class L3Uplink implements VFSRoot {
 
             MutableVirtualFile file = MutableVirtualFile.checkedCreate(parent, name);
             file.attach(new Placeholder(parent, name));
-            vfs.fetchBlobStorageSpace(parent).ifPresent(file::attach);
+            vfs.fetchBlobStorageSpace(parent)
+               .ifPresent(blobStorageSpace -> file.attach(BlobStorageSpace.class, blobStorageSpace));
             attachHandlers(file, false);
 
             return file;
@@ -232,7 +233,7 @@ public class L3Uplink implements VFSRoot {
     public MutableVirtualFile wrapDirectory(VirtualFile parent, Directory directory, boolean forceReadonly) {
         MutableVirtualFile file = MutableVirtualFile.checkedCreate(parent, directory.getName());
         file.attach(Directory.class, directory);
-        file.attach(directory.getStorageSpace());
+        file.attach(BlobStorageSpace.class, directory.getStorageSpace());
         attachHandlers(file, forceReadonly);
 
         return file;
@@ -251,7 +252,7 @@ public class L3Uplink implements VFSRoot {
     public MutableVirtualFile wrapBlob(VirtualFile parent, Blob blob, boolean forceReadonly) {
         MutableVirtualFile file = MutableVirtualFile.checkedCreate(parent, blob.getFilename());
         file.attach(Blob.class, blob);
-        file.attach(blob.getStorageSpace());
+        file.attach(BlobStorageSpace.class, blob.getStorageSpace());
         attachHandlers(file, forceReadonly);
 
         return file;

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
@@ -141,4 +141,20 @@ public class VirtualFileSystem {
 
         return blobStorageSpace;
     }
+
+    /**
+     * Checks if the file belongs to a work directory, dictated by storage spaces with retention days greater than zero.
+     *
+     * @param virtualFile the virtual file to check
+     * @return <tt>true</tt> when the owner space specifies retention days greater than zero, <tt>false</tt> otherwise
+     */
+    public boolean isWorkFile(VirtualFile virtualFile) {
+        Optional<? extends BasicBlobStorageSpace<?, ?, ?>> blobStorageSpace = fetchBlobStorageSpace(virtualFile);
+
+        if (blobStorageSpace.isEmpty()) {
+            return false;
+        }
+
+        return blobStorageSpace.get().getRetentionDays() > 0;
+    }
 }

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
@@ -124,12 +124,15 @@ public class VirtualFileSystem {
     }
 
     /**
-     * Checks if the file belongs to a work directory, dictated by storage spaces with retention days greater than zero.
+     * Checks if the file belongs to a storage space configured with retention days greater than zero.
+     * <p>
+     * This represents a file with a temporary character so the caller can use this information to decide
+     * if a file can be deleted after being processed.
      *
      * @param virtualFile the virtual file to check
      * @return <tt>true</tt> when the owner space specifies retention days greater than zero, <tt>false</tt> otherwise
      */
-    public boolean isWorkFile(VirtualFile virtualFile) {
+    public boolean isAutoCleanupBlob(VirtualFile virtualFile) {
         Optional<BlobStorageSpace> blobStorageSpace = virtualFile.tryAs(BlobStorageSpace.class);
 
         if (blobStorageSpace.isEmpty()) {

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
@@ -8,9 +8,7 @@
 
 package sirius.biz.storage.layer3;
 
-import sirius.biz.storage.layer2.BasicBlobStorageSpace;
-import sirius.biz.storage.layer2.jdbc.SQLBlobStorageSpace;
-import sirius.biz.storage.layer2.mongo.MongoBlobStorageSpace;
+import sirius.biz.storage.layer2.BlobStorageSpace;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
@@ -126,30 +124,13 @@ public class VirtualFileSystem {
     }
 
     /**
-     * Returns the storage space associated with the given file.
-     *
-     * @param virtualFile the virtual file to obtain the storage space
-     * @return the {@link BasicBlobStorageSpace} sitting on top of the virtual file
-     */
-    public Optional<? extends BasicBlobStorageSpace<?, ?, ?>> fetchBlobStorageSpace(VirtualFile virtualFile) {
-        Optional<? extends BasicBlobStorageSpace<?, ?, ?>> blobStorageSpace =
-                virtualFile.tryAs(MongoBlobStorageSpace.class);
-
-        if (blobStorageSpace.isEmpty()) {
-            blobStorageSpace = virtualFile.tryAs(SQLBlobStorageSpace.class);
-        }
-
-        return blobStorageSpace;
-    }
-
-    /**
      * Checks if the file belongs to a work directory, dictated by storage spaces with retention days greater than zero.
      *
      * @param virtualFile the virtual file to check
      * @return <tt>true</tt> when the owner space specifies retention days greater than zero, <tt>false</tt> otherwise
      */
     public boolean isWorkFile(VirtualFile virtualFile) {
-        Optional<? extends BasicBlobStorageSpace<?, ?, ?>> blobStorageSpace = fetchBlobStorageSpace(virtualFile);
+        Optional<BlobStorageSpace> blobStorageSpace = virtualFile.tryAs(BlobStorageSpace.class);
 
         if (blobStorageSpace.isEmpty()) {
             return false;

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
@@ -8,6 +8,9 @@
 
 package sirius.biz.storage.layer3;
 
+import sirius.biz.storage.layer2.BasicBlobStorageSpace;
+import sirius.biz.storage.layer2.jdbc.SQLBlobStorageSpace;
+import sirius.biz.storage.layer2.mongo.MongoBlobStorageSpace;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
@@ -17,6 +20,7 @@ import sirius.kernel.di.std.Register;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Provides the main entrypoint into the <b>Virtual File System</b>.
@@ -119,5 +123,22 @@ public class VirtualFileSystem {
         // Note that this is currently a very simple implementation but might be enhanced with additional
         // checks or cleanups...
         return "/" + Strings.join("/", parts);
+    }
+
+    /**
+     * Returns the storage space associated with the given file.
+     *
+     * @param virtualFile the virtual file to obtain the storage space
+     * @return the {@link BasicBlobStorageSpace} sitting on top of the virtual file
+     */
+    public Optional<? extends BasicBlobStorageSpace<?, ?, ?>> fetchBlobStorageSpace(VirtualFile virtualFile) {
+        Optional<? extends BasicBlobStorageSpace<?, ?, ?>> blobStorageSpace =
+                virtualFile.tryAs(MongoBlobStorageSpace.class);
+
+        if (blobStorageSpace.isEmpty()) {
+            blobStorageSpace = virtualFile.tryAs(SQLBlobStorageSpace.class);
+        }
+
+        return blobStorageSpace;
     }
 }


### PR DESCRIPTION
Now using Composables to attach the blob storage space to virtual files.
Existing files are handled in wrapBlob and wrapDirectory.
Non-existing files inherit the information from their parent (if exists).

In addition, we also detect if a virtual file is a work file using the `retentionDays` config, which controls how many days files are visible before being deleted automatically by the system.

Replaces https://github.com/scireum/sirius-biz/pull/1328

Fixes: SIRI-502