### PR TITLE
Fixes Lookup of Blobs via Filename.

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -46,6 +46,9 @@ import java.util.function.Predicate;
  */
 public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirectory, SQLVariant> {
 
+    @Part
+    private static StorageUtils storageUtils;
+
     /**
      * Determines the number of attempts when updating the contents of a blob.
      */
@@ -171,10 +174,10 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
 
     private String effectiveFilename(String filename) {
         if (useNormalizedNames && filename != null) {
-            return filename.toLowerCase();
+            return storageUtils.sanitizePath(filename).toLowerCase();
         }
 
-        return filename;
+        return storageUtils.sanitizePath(filename);
     }
 
     private Mapping effectiveFilenameMapping() {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -57,6 +57,9 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
     @Part
     private static Mixing mixing;
 
+    @Part
+    private static StorageUtils storageUtils;
+
     protected MongoBlobStorageSpace(String spaceName, Extension config) {
         super(spaceName, config);
     }
@@ -168,10 +171,10 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
 
     private String effectiveFilename(String filename) {
         if (useNormalizedNames && filename != null) {
-            return filename.toLowerCase();
+            return storageUtils.sanitizePath(filename).toLowerCase();
         }
 
-        return filename;
+        return storageUtils.sanitizePath(filename);
     }
 
     private Mapping effectiveFilenameMapping() {


### PR DESCRIPTION
SQLBlob & MongoBlob and SQLDirectory & MongoDirectory sanitize the filename and additionally lowercase it for the normalized filename in a @BeforeSave method.

Thus, when looking up a blob via its filename, it also has to be sanitized before the lookup, as no blob will be found otherwise in case the filename contains characters that are removed or replaced when sanitizing.

This issue occurred in a file export job where the file to be exported included the time that was formatted with colons (which are replaced by underscores during the sanitizing). This lead to the uniqueness check failing in `BasicBlobStorageSpace#isAttachedBlobUnique` and subsequently failing the job.

The bug was introduced in #1319

- Fixes: SIRI-519