### PR TITLE
ErrorContext: permits to only log messages under the current context

### DIFF
--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -9,6 +9,7 @@
 package sirius.biz.process;
 
 import sirius.biz.process.logs.ProcessLog;
+import sirius.biz.process.logs.ProcessLogType;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.SubContext;
 import sirius.kernel.async.TaskContext;
@@ -165,9 +166,9 @@ public class ErrorContext implements SubContext {
     private void logException(HandledException exception, ProcessLogType processLogType) {
         TaskContext taskContext = TaskContext.get();
         if (taskContext.getAdapter() instanceof ProcessContext processContext) {
-            processContext.log(ProcessLog.error()
-                                         .withHandledException(exception)
-                                         .withMessage(enhanceMessage(exception.getMessage())));
+            processContext.log(new ProcessLog().withType(processLogType)
+                                               .withHandledException(exception)
+                                               .withMessage(enhanceMessage(exception.getMessage())));
         } else {
             taskContext.log(enhanceMessage(exception.getMessage()));
         }
@@ -282,10 +283,11 @@ public class ErrorContext implements SubContext {
         try {
             return Optional.ofNullable(producer.create());
         } catch (HandledException exception) {
-            logException(exception);
+            logException(exception, ProcessLogType.ERROR);
         } catch (Exception exception) {
             String message = exception.getMessage() + " (" + exception.getClass().getName() + ")";
-            logException(Exceptions.handle().to(Log.BACKGROUND).error(exception).withDirectMessage(message).handle());
+            logException(Exceptions.handle().to(Log.BACKGROUND).error(exception).withDirectMessage(message).handle(),
+                         ProcessLogType.ERROR);
         } finally {
             removeContext(label);
         }

--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -147,7 +147,7 @@ public class ErrorContext implements SubContext {
      *
      * @param exception the exception to log
      */
-    public void logError(HandledException exception) {
+    public void logExceptionAsError(HandledException exception) {
         logException(exception, ProcessLogType.ERROR);
     }
 
@@ -159,7 +159,7 @@ public class ErrorContext implements SubContext {
      *
      * @param exception the exception to log
      */
-    public void logWarning(HandledException exception) {
+    public void logExceptionAsWarning(HandledException exception) {
         logException(exception, ProcessLogType.WARNING);
     }
 

--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -138,7 +138,31 @@ public class ErrorContext implements SubContext {
                       .collect(Collectors.joining(", "));
     }
 
-    private void logException(HandledException exception) {
+    /**
+     * Logs an {@link ProcessLogType#ERROR error} including the current context.
+     * <p>
+     * This will obey hints provided with the exception, such as the ones used to limit the amount
+     * of entries logged for a specific type.
+     *
+     * @param exception the exception to log
+     */
+    public void logError(HandledException exception) {
+        logException(exception, ProcessLogType.ERROR);
+    }
+
+    /**
+     * Logs an {@link ProcessLogType#WARNING warning} including the current context.
+     * <p>
+     * This will obey hints provided with the exception, such as the ones used to limit the amount
+     * of entries logged for a specific type.
+     *
+     * @param exception the exception to log
+     */
+    public void logWarning(HandledException exception) {
+        logException(exception, ProcessLogType.WARNING);
+    }
+
+    private void logException(HandledException exception, ProcessLogType processLogType) {
         TaskContext taskContext = TaskContext.get();
         if (taskContext.getAdapter() instanceof ProcessContext processContext) {
             processContext.log(ProcessLog.error()

--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -152,7 +152,7 @@ public class ErrorContext implements SubContext {
     }
 
     /**
-     * Logs an {@link ProcessLogType#WARNING warning} including the current context.
+     * Logs a {@link ProcessLogType#WARNING warning} including the current context.
      * <p>
      * This will obey hints provided with the exception, such as the ones used to limit the amount
      * of entries logged for a specific type.


### PR DESCRIPTION
Exposes methods to only log an exception as either error or warning (haven't seen a case for info yet, can add as the need arise).

The current logic handles errors thrown nicely logging them under the current context, but this is not sufficient.
Many times we need to log a warning, respecting the current context but carry on with processing.
This way we expose 2 methods which can be used to simply log the HandledException given.
This way we also profit from the hints attached to the message, especially the ones used to limit the number of incidences to be logged.

Fixes: OX-8105