### PR TITLE
SIRI-524 fix a bug on moving files in the vfs

### DIFF
--- a/src/main/java/sirius/biz/importer/ImportHandlerFactory.java
+++ b/src/main/java/sirius/biz/importer/ImportHandlerFactory.java
@@ -32,7 +32,7 @@ public interface ImportHandlerFactory extends Priorized {
      * class, the method shouldn't be overloaded, as the default priority is appropriate for this case.
      * <p>
      * If a customization needs to change the behaviour of a default importer, a lower value must be selected,
-     * so that it is perferred over the standard.
+     * so that it is preferred over the standard.
      *
      * @return the priority used to sort the available factories (ascending)
      */

--- a/src/main/java/sirius/biz/storage/README.md
+++ b/src/main/java/sirius/biz/storage/README.md
@@ -20,7 +20,7 @@ The main entry point is [BlobStorage](layer2/BlobStorage.java) which provides ac
 [BlobStorageSpace](layer2/BlobStorageSpace.java).
 
 This layer is the central part of the storage framework as it provides utilities to reference blobs in entities,
-a HTTP dispatcher for efficient access and delivery as well as a conversion engine which provides variants
+an HTTP dispatcher for efficient access and delivery as well as a conversion engine which provides variants
 of the stored blobs (e.g. a properly resized JPG image of a given EPS file).
 
 More details can be found in the [Layer 2 documentation](layer2/).
@@ -29,10 +29,10 @@ More details can be found in the [Layer 2 documentation](layer2/).
 
 The virtual file system (VFS) provides a unified interface for all parts of the system which either provide or
 consume files or file systems. Having a built-in **FTP** and **SSH** server, it supports external applications
-access via familiar protocols such as **FTP, FTPS, SFTP, SCP**. Besides it can mount external file systems via
+access via familiar protocols such as **FTP, FTPS, SFTP, SCP**. Besides, it can mount external file systems via
 **FTP, FTPS, SFTP, SCP** and **CIFS** to make external files available to internal sub systems.
 
-Being a virtual file system, neither folders nor files have to exists anywhere physically. A [VFSRoot](layer3/VFSRoot.java)
+Being a virtual file system, neither folders nor files have to exist anywhere physically. A [VFSRoot](layer3/VFSRoot.java)
 can provide artificial folders and files and directly process the provided data.
 
 A central root which is automatically provided is the [L3Uplink](layer2/L3Uplink.java) of layer 2 which makes
@@ -45,7 +45,7 @@ More details can be found in the [Layer 3 documentation](layer3/).
 ## Utilities
 
 The [util](util/) package provides some helper classes which are mainly used by the framework itself and
-in most cases shoudln't be accessed externally.
+in most cases shouldn't be accessed externally.
 
 ## S3 API
 

--- a/src/main/java/sirius/biz/storage/layer3/BlockwiseIterator.java
+++ b/src/main/java/sirius/biz/storage/layer3/BlockwiseIterator.java
@@ -19,7 +19,7 @@ import java.util.NoSuchElementException;
  * Iterates over the children of a <tt>VirtualFile</tt> in a blockwise manner.
  * <p>
  * This permits to safely process even very large directories with the downside that a file might
- * be skipped or processed twice if a concurrent iteration happens (which shoud almost never be the case).
+ * be skipped or processed twice if a concurrent iteration happens (which should almost never be the case).
  */
 class BlockwiseIterator implements Iterator<VirtualFile> {
 

--- a/src/main/java/sirius/biz/storage/layer3/ChildProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/ChildProvider.java
@@ -21,7 +21,7 @@ public interface ChildProvider {
      * @param parent the directory to resolve the child in
      * @param name   the name of the child to resolve
      * @return resolved file (which may or may not exist) or <tt>null</tt> which will make the framework use a
-     * plain non-exisiting and unmodifyable placeholder
+     * plain non-existing and unmodifiable placeholder
      */
     @Nullable
     VirtualFile findChild(VirtualFile parent, String name);

--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -37,7 +37,7 @@ import java.util.function.Consumer;
 /**
  * Provides a job able to extract archives from the {@link VirtualFileSystem}.
  * <p>
- * This uses the {@link ArchiveExtractor} so depending if 7-ZIP is enabled this supports either a whole bunch
+ * This uses the {@link ArchiveExtractor} so depending on if 7-ZIP is enabled this supports either a bunch
  * of formats (rar, 7z, tar etc.) or "just" ZIP files using the Java API.
  */
 @Register(classes = {JobFactory.class, ExtractArchiveJob.class}, framework = StorageUtils.FRAMEWORK_STORAGE)

--- a/src/main/java/sirius/biz/storage/layer3/FetchFromUrlMode.java
+++ b/src/main/java/sirius/biz/storage/layer3/FetchFromUrlMode.java
@@ -12,12 +12,12 @@ import sirius.biz.jobs.params.EnumParameter;
 import sirius.biz.jobs.params.Parameter;
 import sirius.kernel.nls.NLS;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.function.Predicate;
 
 /**
- * Determines the behavior of {@link VirtualFile#loadFromUrl(URL, FetchFromUrlMode)} or
- * {@link VirtualFile#resolveOrLoadChildFromURL(URL, FetchFromUrlMode, Predicate)}.
+ * Determines the behavior of {@link VirtualFile#loadFromUrl(URI, FetchFromUrlMode)} or
+ * {@link VirtualFile#resolveOrLoadChildFromURL(URI, FetchFromUrlMode, Predicate)}.
  */
 public enum FetchFromUrlMode {
     /**

--- a/src/main/java/sirius/biz/storage/layer3/FileSearch.java
+++ b/src/main/java/sirius/biz/storage/layer3/FileSearch.java
@@ -86,7 +86,7 @@ public class FileSearch {
      * Adds a file extension to filter on.
      * <p>
      * Once added, only files with the given extension will be accepted. Note that this method can be invoked multiple
-     * time to accept several different file extensions.
+     * time to accept several file extensions.
      * <p>
      * Note that this filter doesn't apply to directories.
      *
@@ -200,7 +200,7 @@ public class FileSearch {
         }
 
         // We only apply the extension filter on files not on directory so that one can still browse
-        // through a directory structure when lookin for a file of a specific type.
+        // through a directory structure when looking for a file of a specific type.
         if (fileExtensionFilters != null && !file.isDirectory()) {
             String fileExtension = file.fileExtension();
             if (Strings.isEmpty(fileExtension)) {

--- a/src/main/java/sirius/biz/storage/layer3/TmpRoot.java
+++ b/src/main/java/sirius/biz/storage/layer3/TmpRoot.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
 /**
  * Provides a stealth directory to store temporary files.
  * <p>
- * Neither this directory itself nor its files are listed / enumerated in the VFS. However the directory as well
+ * Neither this directory itself nor its files are listed / enumerated in the VFS. However, the directory as well
  * as each blob in the <b>tmp</b> {@link sirius.biz.storage.layer2.BlobStorageSpace} can be resolved and therefore
  * be accessed.
  * <p>
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  * Note that these blobs will be deleted after a given period (usually 10 days).
  * <p>
  * One user of this framework is the {@link sirius.biz.jobs.JobsRoot} which accepts incoming files, stores them
- * in the <tt>tmp</tt> space and then uses the VFS path as noted above to pass these files on to the jobs framework.
+ * in the <tt>tmp</tt> space and then uses the VFS path as noted above to pass these files on to the jobs-framework.
  */
 @Register(framework = StorageUtils.FRAMEWORK_STORAGE)
 public class TmpRoot implements VFSRoot {

--- a/src/main/java/sirius/biz/storage/layer3/Transfer.java
+++ b/src/main/java/sirius/biz/storage/layer3/Transfer.java
@@ -101,7 +101,7 @@ public class Transfer {
     }
 
     /**
-     * Notifies the transfer that a batch/proces context is available.
+     * Notifies the transfer that a batch/process context is available.
      * <p>
      * As soon as a process context is available no limits are enforced anymore (e.g. {@link #canMoveInteractive()}.
      * Also, we provide some metrics and debug messages.
@@ -131,7 +131,7 @@ public class Transfer {
      * Enables smart transfers for copy operations.
      * <p>
      * Using this approach a copy will only happen if the source and destination sizes don't match or if the source
-     * if newer than the destination. Otherwise the operation is skipped.
+     * is newer than the destination. Otherwise, the operation is skipped.
      *
      * @return the transfer helper itself for fluent method calls
      */
@@ -146,7 +146,7 @@ public class Transfer {
      * <p>
      * Note that most probably calling {@link #move()} and letting the framework handle everything else is wiser.
      *
-     * @return <tt>true</tt> if the fast move succeded, <tt>false</tt> otherwise
+     * @return <tt>true</tt> if the fast move succeeded, <tt>false</tt> otherwise
      */
     public boolean tryFastMove() {
         return source.tryFastMoveTo(destination);
@@ -370,7 +370,7 @@ public class Transfer {
                                     .to(StorageUtils.LOG)
                                     .error(e)
                                     .withSystemErrorMessage(
-                                            "Layer 3/VFS: An error occurred when transfering '%s' to '%s': %s (%s)",
+                                            "Layer 3/VFS: An error occurred when transferring '%s' to '%s': %s (%s)",
                                             sourceFile.path(),
                                             destinationFile.path())
                                     .handle();

--- a/src/main/java/sirius/biz/storage/layer3/Transfer.java
+++ b/src/main/java/sirius/biz/storage/layer3/Transfer.java
@@ -350,6 +350,9 @@ public class Transfer {
                 child.delete();
             }
         });
+        if (delete) {
+            sourceDirectory.delete();
+        }
     }
 
     protected void transferFileTo(VirtualFile sourceFile, VirtualFile destinationFile, boolean forceTransfer) {

--- a/src/main/java/sirius/biz/storage/layer3/TreeVisitorBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer3/TreeVisitorBuilder.java
@@ -101,7 +101,7 @@ public class TreeVisitorBuilder {
     /**
      * Determines if a directory should be visited.
      * <p>
-     * This this returns <tt>false</tt>, the directory will be neither traversed, nor reported by the iterator.
+     * This returns <tt>false</tt>, the directory will be neither traversed, nor reported by the iterator.
      *
      * @param directoryFilter the filter which returns <tt>true</tt> to signal that the directory should be visited
      *                        or <tt>false</tt> otherwise
@@ -139,7 +139,7 @@ public class TreeVisitorBuilder {
     /**
      * Provides a stream over all matching  <tt>VirtualFiles</tt> for the filters specified by this builder.
      *
-     * @return a stream which perfroms a DFS (depth first search) directory traveral of the files matching the given
+     * @return a stream which performs a DFS (depth first search) directory traversal of the files matching the given
      * filters
      */
     public Stream<VirtualFile> stream() {

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -200,7 +200,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
      * Returns the relative path to the given root parent.
      * <p>
      * If this would be <tt>/foo/bar/baz</tt> and the given root parent is <tt>/foo</tt> then this would
-     * return <tt>bar/baz</tt>. Therefore this is the inverse of {@link #resolve(String)}.
+     * return <tt>bar/baz</tt>. Therefore, this is the inverse of {@link #resolve(String)}.
      *
      * @param rootParent one of the parent directories of <tt>this</tt>
      * @return the relative path from the given root parent to <tt>this</tt>
@@ -574,7 +574,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
      * Tries to resolve the relative path within this directory.
      *
      * @param relativePath the path to resolve
-     * @return the relative path wrapped as optional or an  empty optional if the given relaive path cannot be
+     * @return the relative path wrapped as optional or an  empty optional if the given relative path cannot be
      * resolved into a file.
      */
     @Nonnull
@@ -1038,7 +1038,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     /**
      * Determines if the content can be provided as {@link FileHandle}.
      *
-     * @return <tt>true</tt> if a the contents of this file can be provided as file handle, <tt>false</tt> otherwise
+     * @return <tt>true</tt> if the contents of this file can be provided as file handle, <tt>false</tt> otherwise
      */
     public boolean canDownload() {
         try {
@@ -1052,12 +1052,12 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                 return true;
             }
         } catch (Exception e) {
-            throw handleErrorInCallback(e, "canProvidFileHandle");
+            throw handleErrorInCallback(e, "canProvideFileHandle");
         }
     }
 
     /**
-     * Tries to provides the contents of this file as {@link FileHandle}.
+     * Tries to provide the contents of this file as {@link FileHandle}.
      *
      * @return a <tt>FileHandle</tt> with the contents of the file or an empty optional if no handle can be obtained
      */
@@ -1104,7 +1104,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     }
 
     /**
-     * Determines if this file can (probably) be move in an efficient way.
+     * Determines if this file can (probably) be moved in an efficient way.
      *
      * @param newParent the new parent directory
      * @return <tt>true</tt> if this file can be efficiently moved or <tt>false</tt> otherwise
@@ -1141,7 +1141,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     /**
      * Tries to efficiently move the file in the given directory.
      * <p>
-     * This is only an interal API as the public API is accessible via {@link #transferTo(VirtualFile)}.
+     * This is only an internal API as the public API is accessible via {@link #transferTo(VirtualFile)}.
      *
      * @param newParent the new parent directory
      * @return <tt>true</tt> if the operation was successful, <tt>false</tt> otherwise
@@ -1161,7 +1161,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     /**
      * Provides various ways of copying or moving the contents of this file to the given destination.
      *
-     * @param destination the desntiantion to transer the contents to
+     * @param destination the destination to transfer the contents to
      * @return a helper which permits to transfer the contents of this file to the given destination
      */
     @CheckReturnValue
@@ -1200,7 +1200,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                                     .to(StorageUtils.LOG)
                                     .error(e)
                                     .withSystemErrorMessage(
-                                            "Layer 3/VFS: An error occurred when transferting '%s' to %s in '%s': %s (%s)",
+                                            "Layer 3/VFS: An error occurred when transferring '%s' to %s in '%s': %s (%s)",
                                             path(),
                                             destination.getStorageSpace().getName(),
                                             destination.getBlobKey())
@@ -1478,7 +1478,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
             URI lastConnectedURL = headRequest.getResponse().request().uri();
 
             if (Strings.isEmpty(path) && !url.getPath().equals(lastConnectedURL.getPath())) {
-                // We don't have a path yet but we followed redirects so we check the new URL
+                // We don't have a path yet, but we followed redirects, so we check the new URL
                 if (headRequest.getResponseCode() == HttpResponseStatus.NOT_FOUND.code() && lastConnectedURL.toString()
                                                                                                             .contains(
                                                                                                                     "Ã")) {

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
@@ -158,7 +158,7 @@ public class VirtualFileSystem {
      * Injects a default handling which sets a shorter idle timeout for temporary uplinks.
      * <p>
      * If we're done using a temporary uplink, we can probably discard the connection pretty quickly and don't need
-     * it to hang around for 10 mins.
+     * it to hang around for 10 minutes.
      *
      * @param config the original config provider
      * @return an enhanced config provider which sets {@link UplinkConnectorConfig#CONFIG_IDLE_TIMEOUT_MILLIS} to

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileWalker.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileWalker.java
@@ -15,7 +15,7 @@ import java.util.Spliterator;
 import java.util.function.Consumer;
 
 /**
- * Implements a spliterator which is used to stream through sub trees of the VFS via {@link VirtualFile#tree()} etc.
+ * Implements a spliterator which is used to stream through sub-trees of the VFS via {@link VirtualFile#tree()} etc.
  */
 class VirtualFileWalker implements Spliterator<VirtualFile> {
 

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileWalker.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileWalker.java
@@ -82,7 +82,7 @@ class VirtualFileWalker implements Spliterator<VirtualFile> {
     }
 
     private boolean shouldEnterDirectory() {
-        return settings.maxDepth < 0 || stack.size() < settings.maxDepth;
+        return (settings.maxDepth < 0 || stack.size() < settings.maxDepth) && children.hasNext();
     }
 
     private boolean shouldProcessAsDirectory() {


### PR DESCRIPTION
If you want to move a directory from one root to another root folder - it fails with a NoSuchElementException.
Because the next() tries to enter the directory. If there is no children anymore it should not do the same again.
Moving over root-folders is handled as a transfer, but the delete-param is ignored for directories until now...
...and fixes x typos :)