### PR TITLE
Removes parent reference on deletion propagation of sql directories

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -77,10 +77,12 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
         try {
             oma.updateStatement(SQLDirectory.class)
                .set(SQLDirectory.DELETED, true)
+               .set(SQLDirectory.PARENT, null)
                .where(SQLDirectory.PARENT, directoryId)
                .executeUpdate();
             oma.updateStatement(SQLBlob.class)
                .set(SQLBlob.DELETED, true)
+               .set(SQLBlob.PARENT, null)
                .where(SQLBlob.PARENT, directoryId)
                .executeUpdate();
         } catch (SQLException e) {


### PR DESCRIPTION
- this prevents an fk error on first parent deletion try in case of subdirectory/ files in directory
- removes an error message as previous implementation could delete on next loop run