### PR TITLE
Specifies a proper (and supported) TLS protocol to use for ftps.

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/FTPServer.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/FTPServer.java
@@ -66,6 +66,9 @@ public class FTPServer implements Startable, Stoppable {
     @ConfigValue("storage.layer3.downlink.ftp.forceSSL")
     private boolean forceSSL;
 
+    @ConfigValue("storage.layer3.downlink.ftp.tlsProtocol")
+    private String tlsProtocol;
+
     @Override
     public int getPriority() {
         return Priorized.DEFAULT_PRIORITY + 100;
@@ -169,6 +172,7 @@ public class FTPServer implements Startable, Stoppable {
         ssl.setKeystoreFile(new File(keystore));
         ssl.setKeystorePassword(keystorePassword);
         ssl.setKeyAlias(keyAlias);
+        ssl.setSslProtocol(tlsProtocol);
         factory.setSslConfiguration(ssl.createSslConfiguration());
         factory.setImplicitSsl(forceSSL);
     }

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1246,6 +1246,9 @@ storage {
 
                 # Determines if FTPS should be forced or not.
                 forceSSL = false
+
+                # Defines the actual TLS ("SSL") protocol to support.
+                tlsProtocol = "TLSv1.2"
             }
         }
 


### PR DESCRIPTION
The default ist "TLS" which is commonly outdated. We settle for TLSv1.2
as default, as this is pretty common and widely supported (and not
obsolete yet).