### PR TITLE
Allows accessing the referenced Blobs a Property

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
@@ -57,7 +57,7 @@ abstract class BlobRefProperty extends Property implements SQLPropertyInfo, ESPr
      * @param entity The entity to get the reference from
      * @return a {@link BlobHardRef} or a subclass of it
      */
-    protected BlobHardRef getRef(Object entity) {
+    public BlobHardRef getRef(Object entity) {
         try {
             return (BlobHardRef) super.getValueFromField(this.accessPath.apply(entity));
         } catch (Exception e) {


### PR DESCRIPTION
This is needed in case we want to export the file path instead of the blob key via custom EntityImportHandlerExtender#createExtractor.

- Fixes: SE-11355