### PR TITLE
restore logic for uplinkRoot to get correct name (and id only as fallback)

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplinksRoot.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplinksRoot.java
@@ -67,7 +67,7 @@ public class ConfigBasedUplinksRoot implements VFSRoot {
     private ConfigBasedUplink makeUplink(Extension extension) {
         try {
             return ctx.findPart(extension.get("type").asString(), UplinkFactory.class)
-                      .make(extension.getId(), extension::get);
+                      .make(extension.get("name").asString(extension.getId()), extension::get);
         } catch (IllegalArgumentException e) {
             StorageUtils.LOG.SEVERE(Strings.apply(
                     "Layer 3: An error occurred while initializing the uplink '%s' from the system configuration: %s",

--- a/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
@@ -300,7 +300,7 @@ public class CIFSUplink extends ConfigBasedUplink {
     protected void enumerateDirectoryChildren(@Nonnull VirtualFile parent, FileSearch search) {
         SmbFile parentFile = parent.tryAs(SmbFile.class)
                                    .orElseThrow(() -> new IllegalArgumentException(Strings.apply(
-                                           "Invalid parent: %s! Expecte a SmbFile!",
+                                           "Invalid parent: %s! Expected a SmbFile!",
                                            parent)));
         try {
             SmbFile[] children = parentFile.listFiles();

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 
 /**
- * Keeps the configuration used to build a FTP connector using the
+ * Keeps the configuration used to build an FTP connector using the
  * {@link sirius.biz.storage.layer3.uplink.util.UplinkConnectorPool}.
  */
 class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {


### PR DESCRIPTION

<img width="846" alt="Bildschirmfoto 2022-02-15 um 10 57 52" src="https://user-images.githubusercontent.com/55080004/154038175-5186546d-dc76-4229-b8f5-56c77eb02296.png">

this logic was changed on https://github.com/scireum/sirius-biz/commit/4ceef427cf47ebb875a918c5f04c352ec012cfda#diff-13c6ca1150f69873e9db7d8895f3f61af6bfd141f9dce2c4560dd35f6e832527R62 accidentially