### PR TITLE
Does not delete source directory when transferring content.

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/Transfer.java
+++ b/src/main/java/sirius/biz/storage/layer3/Transfer.java
@@ -331,6 +331,8 @@ public class Transfer {
                 destination.createAsDirectory();
             }
 
+            // Transfer directory and delete all files and directories including the source directory at the source
+            // location if the action is a move.
             transferDirectory(source, destination.findChild(source.name()), delete, delete);
         }
     }
@@ -347,6 +349,7 @@ public class Transfer {
             if (child.isFile()) {
                 transferFileTo(child, destinationDirectory.findChild(child.name()), deleteContent);
             } else {
+                // Transfer and delete the child directory in case content should be deleted.
                 transferDirectory(child, destinationDirectory.findChild(child.name()), deleteContent, deleteContent);
             }
             if (deleteContent) {
@@ -419,6 +422,7 @@ public class Transfer {
                             .handle();
         }
 
+        // Transfer content of the directory but don't delete the source directory.
         transferDirectory(source, destination, delete, false);
     }
 }

--- a/src/main/java/sirius/biz/storage/layer3/Transfer.java
+++ b/src/main/java/sirius/biz/storage/layer3/Transfer.java
@@ -331,26 +331,29 @@ public class Transfer {
                 destination.createAsDirectory();
             }
 
-            transferDirectory(source, destination.findChild(source.name()), delete);
+            transferDirectory(source, destination.findChild(source.name()), delete, delete);
         }
     }
 
-    private void transferDirectory(VirtualFile sourceDirectory, VirtualFile destinationDirectory, boolean delete) {
+    private void transferDirectory(VirtualFile sourceDirectory,
+                                   VirtualFile destinationDirectory,
+                                   boolean deleteContent,
+                                   boolean deleteSourceDirectory) {
         if (!destinationDirectory.isDirectory()) {
             destinationDirectory.createAsDirectory();
         }
 
         sourceDirectory.allChildren().stream().forEach(child -> {
             if (child.isFile()) {
-                transferFileTo(child, destinationDirectory.findChild(child.name()), delete);
+                transferFileTo(child, destinationDirectory.findChild(child.name()), deleteContent);
             } else {
-                transferDirectory(child, destinationDirectory.findChild(child.name()), delete);
+                transferDirectory(child, destinationDirectory.findChild(child.name()), deleteContent, deleteContent);
             }
-            if (delete) {
+            if (deleteContent) {
                 child.delete();
             }
         });
-        if (delete) {
+        if (deleteSourceDirectory) {
             sourceDirectory.delete();
         }
     }
@@ -416,6 +419,6 @@ public class Transfer {
                             .handle();
         }
 
-        transferDirectory(source, destination, delete);
+        transferDirectory(source, destination, delete, false);
     }
 }


### PR DESCRIPTION
This is done as the source directory should probably not (or even can't) be deleted and deleting the source directory at the source location can be accomplished via TransferMode#MOVE.

- Fixes: SE-11421