### PR TITLE
No longer logs conversion failures to storage log

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1593,7 +1593,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     protected abstract boolean markConversionAttempt(V variant) throws Exception;
 
     /**
-     * Spawns a thread which will actually  the appropriate conversion pipeline.
+     * Spawns a thread which will actually invoke the appropriate conversion pipeline.
      *
      * @param blob    the blob for which the variant is to be created
      * @param variant the variant to generate

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1616,9 +1616,8 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             eventRecorder.record(new BlobConversionEvent().withConversionProcess(conversionProcess)
                                                           .withConversionError(conversionException));
 
-            throw Exceptions.handle()
+            throw Exceptions.createHandled()
                             .error(conversionException)
-                            .to(StorageUtils.LOG)
                             .withSystemErrorMessage("Layer 2/Conversion: Failed to create %s (%s) of %s (%s): %s (%s)",
                                                     variant.getVariantName(),
                                                     variant.getIdAsString(),

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1593,7 +1593,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     protected abstract boolean markConversionAttempt(V variant) throws Exception;
 
     /**
-     * Spawns a thread which will actually invoke the appropriate conversion pipeline.
+     * Spawns a thread which will actually  the appropriate conversion pipeline.
      *
      * @param blob    the blob for which the variant is to be created
      * @param variant the variant to generate
@@ -1616,7 +1616,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             eventRecorder.record(new BlobConversionEvent().withConversionProcess(conversionProcess)
                                                           .withConversionError(conversionException));
 
-            throw Exceptions.createHandled()
+            throw Exceptions.handle()
                             .error(conversionException)
                             .withSystemErrorMessage("Layer 2/Conversion: Failed to create %s (%s) of %s (%s): %s (%s)",
                                                     variant.getVariantName(),

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1618,6 +1618,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
 
             throw Exceptions.handle()
                             .error(conversionException)
+                            .to(StorageUtils.LOG)
                             .withSystemErrorMessage("Layer 2/Conversion: Failed to create %s (%s) of %s (%s): %s (%s)",
                                                     variant.getVariantName(),
                                                     variant.getIdAsString(),

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -206,11 +206,13 @@ public class ConversionEngine {
                     resultFileHandle.close();
                 }
 
-                throw new IllegalArgumentException(Strings.apply(
-                        "The conversion engine created an empty result for variant %s of %s (%s)",
-                        conversionProcess.getVariantName(),
-                        conversionProcess.getBlobToConvert().getFilename(),
-                        conversionProcess.getBlobToConvert().getBlobKey()));
+                throw Exceptions.createHandled()
+                                .withSystemErrorMessage(Strings.apply(
+                                        "The conversion engine created an empty result for variant %s of %s (%s)",
+                                        conversionProcess.getVariantName(),
+                                        conversionProcess.getBlobToConvert().getFilename(),
+                                        conversionProcess.getBlobToConvert().getBlobKey()))
+                                .handle();
             }
 
             conversionDuration.addValue(conversionProcess.getConversionDuration());


### PR DESCRIPTION
As they are already logged in tenant standby processes and the ConversionEvent