### PR TITLE
Provides a NO-OP shell for our built-in SSH server.

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/NoopShell.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/NoopShell.java
@@ -1,0 +1,111 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.layer3.downlink.ssh;
+
+import org.apache.sshd.common.io.IoInputStream;
+import org.apache.sshd.common.io.IoOutputStream;
+import org.apache.sshd.common.io.IoReadFuture;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.ExitCallback;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.apache.sshd.server.command.AsyncCommand;
+import sirius.kernel.health.Exceptions;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Provides NO_OP shell.
+ * <p>
+ * This is required by some SFTP clients, which first initiate SSH and then switch over to SFTP.
+ */
+public class NoopShell implements AsyncCommand {
+
+    private ExitCallback exitCallback;
+    private IoInputStream inputStream;
+    private IoOutputStream outputStream;
+
+    private final ByteArrayBuffer readBuffer = new ByteArrayBuffer(1);
+    private final ChannelSession session;
+
+    public NoopShell(ChannelSession channelSession) {
+        this.session = channelSession;
+    }
+
+    @Override
+    public void setInputStream(InputStream in) {
+        // ignored
+    }
+
+    @Override
+    public void setOutputStream(OutputStream out) {
+        // ignored
+    }
+
+    @Override
+    public void setErrorStream(OutputStream err) {
+        // ignored
+    }
+
+    @Override
+    public void setExitCallback(ExitCallback callback) {
+        this.exitCallback = callback;
+    }
+
+    @Override
+    public void start(ChannelSession channelSession, Environment environment) throws IOException {
+        inputStream.read(readBuffer).addListener(this::processInput);
+    }
+
+    @Override
+    public void destroy(ChannelSession channelSession) throws Exception {
+        // Ignored...
+    }
+
+    private void processInput(IoReadFuture future) {
+        try {
+            if (future.getRead() == 0) {
+                exitCallback.onExit(-2);
+                return;
+            }
+
+            // Properly handle CTRL+C...
+            byte data = future.getBuffer().rawByte(0);
+            if (data == 0x03) {
+                exitCallback.onExit(0);
+                return;
+            }
+
+            // Simply echo the input...
+            outputStream.writeBuffer(future.getBuffer());
+            readBuffer.clear();
+            inputStream.read(readBuffer).addListener(this::processInput);
+        } catch (IOException e) {
+            Exceptions.ignore(e);
+            exitCallback.onExit(-1);
+        }
+    }
+
+    @Override
+    public void setIoInputStream(IoInputStream in) {
+        this.inputStream = in;
+    }
+
+    @Override
+    public void setIoOutputStream(IoOutputStream out) {
+        this.outputStream = out;
+    }
+
+    @Override
+    public void setIoErrorStream(IoOutputStream err) {
+        // ignored
+    }
+}

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/NoopShell.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/NoopShell.java
@@ -27,17 +27,16 @@ import java.io.OutputStream;
  * <p>
  * This is required by some SFTP clients, which first initiate SSH and then switch over to SFTP.
  */
-public class NoopShell implements AsyncCommand {
+class NoopShell implements AsyncCommand {
 
     private ExitCallback exitCallback;
     private IoInputStream inputStream;
     private IoOutputStream outputStream;
 
     private final ByteArrayBuffer readBuffer = new ByteArrayBuffer(1);
-    private final ChannelSession session;
 
-    public NoopShell(ChannelSession channelSession) {
-        this.session = channelSession;
+    NoopShell(ChannelSession channelSession) {
+        // The given session isn't needed...
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/SSHServer.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/SSHServer.java
@@ -96,12 +96,17 @@ public class SSHServer implements Startable, Stoppable, Killable {
             installPasswordAuthenticator();
             installFileSystemFactory();
             installSFTPSubsystem();
+            installNoopShell();
 
             server.start();
             StorageUtils.LOG.INFO("Layer 3/SSH: Successfully started the SSH server on port %s", port);
         } catch (IOException e) {
             StorageUtils.LOG.WARN("Layer 3/SSH: Failed to start the SSH server: %s", e.getMessage());
         }
+    }
+
+    private void installNoopShell() {
+        server.setShellFactory(NoopShell::new);
     }
 
     private void disableLogging() {


### PR DESCRIPTION
This is required by some SFTP clients, which first start a SSH
session and then switch over to SFTP.