### PR TITLE
Creates a line-based archive import job class

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -29,12 +29,12 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 /**
- * Provides an import job which allows to import line based data from multiple archived files in a specific order.
+ * Provides an import job which allows importing dictionary-based data from multiple archived files in a specific order.
  */
 public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
 
-    private static final String ERROR_CONTEXT_FILE_PATH = "$DictionaryBasedArchiveImportJob.file";
-    private static final String ERROR_CONTEXT_ROW = "$LineBasedJob.row";
+    protected static final String ERROR_CONTEXT_FILE_PATH = "$DictionaryBasedArchiveImportJob.file";
+    protected static final String ERROR_CONTEXT_ROW = "$LineBasedJob.row";
 
     /**
      * Describes a file to be imported from an archive.
@@ -58,6 +58,17 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
         public ImportFile(String filename, ImportDictionary dictionary, Callback<Tuple<Integer, Context>> rowHandler) {
             this.filename = filename;
             this.dictionary = dictionary;
+            this.rowHandler = rowHandler;
+        }
+
+        /**
+         * Creates a new instance for the given name.
+         *
+         * @param filename   the name of the file to import
+         * @param rowHandler the row handler used to process each row
+         */
+        public ImportFile(String filename, Callback<Tuple<Integer, Context>> rowHandler) {
+            this.filename = filename;
             this.rowHandler = rowHandler;
         }
 
@@ -162,7 +173,7 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
         });
     }
 
-    private void handleFile(ImportFile importFile, ExtractedFile extractedFile) throws Exception {
+    protected void handleFile(ImportFile importFile, ExtractedFile extractedFile) throws Exception {
         process.log(ProcessLog.info()
                               .withNLSKey("DictionaryBasedArchiveImportJob.msgImportFile")
                               .withContext("file", importFile.filename));

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedArchiveImportJob.java
@@ -117,7 +117,7 @@ public abstract class LineBasedArchiveImportJob extends DictionaryBasedArchiveIm
 
         Context context = Context.create();
         for (int index = 0; index < row.length(); index++) {
-            context.put(columnNames.get(index), row.at(index).asString());
+            context.put(columnNames.get(index), row.at(index).getRawString());
         }
 
         importFile.rowHandler.invoke(Tuple.create(line, context));

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedArchiveImportJob.java
@@ -1,0 +1,125 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.batch.file;
+
+import sirius.biz.process.ProcessContext;
+import sirius.biz.process.logs.ProcessLog;
+import sirius.biz.util.ExtractedFile;
+import sirius.kernel.async.TaskContext;
+import sirius.kernel.commons.Context;
+import sirius.kernel.commons.Tuple;
+import sirius.kernel.commons.Values;
+import sirius.kernel.health.Exceptions;
+import sirius.web.data.LineBasedProcessor;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides an import job which allows importing line-based data from multiple archived files in a specific order.
+ */
+public abstract class LineBasedArchiveImportJob extends DictionaryBasedArchiveImportJob {
+
+    /**
+     * Creates a new job for the given process context.
+     *
+     * @param process the process context in which the job is executed
+     */
+    protected LineBasedArchiveImportJob(ProcessContext process) {
+        super(process);
+    }
+
+    @Override
+    protected void handleFile(ImportFile importFile, ExtractedFile extractedFile) throws Exception {
+        process.log(ProcessLog.info()
+                              .withNLSKey("DictionaryBasedArchiveImportJob.msgImportFile")
+                              .withContext("file", importFile.filename));
+        errorContext.withContext(ERROR_CONTEXT_FILE_PATH, extractedFile.getFilePath());
+        try (InputStream stream = extractedFile.openInputStream()) {
+            Map<Integer, String> columnNames = new HashMap<>();
+            LineBasedProcessor.create(importFile.filename, stream, false).run((lineNumber, row) -> {
+                errorContext.handleInContext(ERROR_CONTEXT_ROW, lineNumber, () -> {
+                    if (lineNumber == 1) {
+                        try {
+                            handleHeaderRow(row, columnNames);
+                        } catch (Exception exception) {
+                            if (importFile.required) {
+                                TaskContext.get().cancel();
+                            }
+                            throw exception;
+                        }
+                    } else {
+                        handleRow(row, lineNumber, columnNames, importFile);
+                    }
+                });
+            }, error -> {
+                process.handle(error);
+                errorContext.removeContext(ERROR_CONTEXT_ROW);
+                return true;
+            });
+        } finally {
+            errorContext.removeContext(ERROR_CONTEXT_FILE_PATH);
+        }
+
+        if (importFile.completionHandler != null) {
+            importFile.completionHandler.execute();
+        }
+    }
+
+    /**
+     * Normalizes how columns are exposed in each row's context.
+     * <p>
+     * By default this method returns the column name as read from the input file.
+     * Use this method to normalize headers, such as converting them to lower case,
+     * replacing characters or translating aliases into expected names.
+     *
+     * @param header the original header name
+     * @return the modified header name
+     */
+    protected String normalizeHeader(String header) {
+        return header;
+    }
+
+    private void handleHeaderRow(Values row, Map<Integer, String> columnNames) {
+        for (int index = 0; index < row.length(); index++) {
+            String headerName = normalizeHeader(row.at(index).asString());
+            if (columnNames.containsValue(headerName)) {
+                columnNames.clear();
+                throw Exceptions.createHandled()
+                                .withNLSKey("LineBasedArchiveImportJob.duplicateColumn")
+                                .set("column", headerName)
+                                .handle();
+            }
+            columnNames.put(index, headerName);
+        }
+    }
+
+    private void handleRow(Values row, int line, Map<Integer, String> columnNames, ImportFile importFile)
+            throws Exception {
+        if (row.length() == 0 || columnNames.isEmpty()) {
+            return;
+        }
+
+        if (row.length() > columnNames.size()) {
+            throw Exceptions.createHandled()
+                            .withNLSKey("ImportDictionary.tooManyColumns")
+                            .set("count", row.length())
+                            .set("columns", columnNames.size())
+                            .handle();
+        }
+
+        Context context = Context.create();
+        for (int index = 0; index < row.length(); index++) {
+            context.put(columnNames.get(index), row.at(index).asString());
+        }
+
+        importFile.rowHandler.invoke(Tuple.create(line, context));
+    }
+}

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -409,6 +409,7 @@ Language.zh = Chinesisch
 LengthCheck.errorMsg = Der Wert darf nicht länger als ${maxLength} Zeichen sein. (Länge: ${length}).
 LengthCheck.remark = Maximale Feldlänge: ${maxLength}
 LineBasedAliases.column = Spalte ${column}
+LineBasedArchiveImportJob.duplicateColumn = Die Spalte '${column}' wurde mehrfach angegeben.
 LineBasedExportJobFactory.fileType = Datei-Typ
 LineBasedExportJobFactory.fileType.help = Wählen Sie hier den Typ der zu exportierenden Datei aus. Falls Sie bereits eine Ziel-Datei ausgewählt haben, wird das Format an deren Datei-Endung ermittelt.
 LineBasedImportExportJobFactory.outputFile = Ausgabedatei

--- a/src/main/resources/biz_en.properties
+++ b/src/main/resources/biz_en.properties
@@ -409,6 +409,7 @@ Language.zh = Chinese
 LengthCheck.errorMsg = The value must not be longer than ${maxLength} characters. (length: ${length}).
 LengthCheck.remark = Maximum field length: ${maxLength}
 LineBasedAliases.column = Column ${column}
+LineBasedArchiveImportJob.duplicateColumn = The column '${column}' was specified multiple times.
 LineBasedExportJobFactory.fileType = File type
 LineBasedExportJobFactory.fileType.help = Select the type of the file to be exported here. If you have already selected a target file, the format is determined by its file extension.
 LineBasedImportExportJobFactory.outputFile = Output file


### PR DESCRIPTION
which behaves similar to the DictionaryBasedArchiveImportJob, but WITHOUT using dictionaries.

The first row is used to define the headers later found in the context. The header can be normalized by implementing jobs, eg: to convert case or map aliases to expected names.

The following validations occur:
- rows containing more columns than the header are skipped
- header with duplicated column names will abort the file. If the file is marked as required, the entire job aborts

Fixes: OX-8345