### PR TITLE
No longer logs Interruptions when uploading from stream

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1186,9 +1186,13 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             } catch (Exception ex) {
                 Exceptions.ignore(ex);
             }
-            if (e.getCause() instanceof InterruptedIOException) {
-                Exceptions.ignore(e);
-                return;
+            if (e instanceof InterruptedIOException || e.getCause() instanceof InterruptedIOException) {
+                throw Exceptions.createHandled()
+                                .error(e)
+                                .withSystemErrorMessage("Layer 2: Interrupted updating contents of %s in %s: %s (%s)",
+                                                        blob.getBlobKey(),
+                                                        spaceName)
+                                .handle();
             }
 
             throw Exceptions.handle()

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.ConnectException;
 import java.net.MalformedURLException;
@@ -1184,6 +1185,10 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
                 getPhysicalSpace().delete(nextPhysicalId);
             } catch (Exception ex) {
                 Exceptions.ignore(ex);
+            }
+            if (e.getCause() instanceof InterruptedIOException) {
+                Exceptions.ignore(e);
+                return;
             }
 
             throw Exceptions.handle()

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -57,6 +57,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -733,6 +734,10 @@ public class ObjectStore {
             getClient().abortMultipartUpload(new AbortMultipartUploadRequest(bucket.getName(),
                                                                              objectId,
                                                                              multipartUpload.getUploadId()));
+            if (e.getCause() instanceof InterruptedIOException) {
+                Exceptions.ignore(e);
+                return;
+            }
             throw Exceptions.handle()
                             .to(ObjectStores.LOG)
                             .error(e)

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -734,9 +734,13 @@ public class ObjectStore {
             getClient().abortMultipartUpload(new AbortMultipartUploadRequest(bucket.getName(),
                                                                              objectId,
                                                                              multipartUpload.getUploadId()));
-            if (e.getCause() instanceof InterruptedIOException) {
-                Exceptions.ignore(e);
-                return;
+            if (e instanceof InterruptedIOException || e.getCause() instanceof InterruptedIOException) {
+                throw Exceptions.createHandled()
+                                .error(e)
+                                .withSystemErrorMessage("Interrupted multipart upload for %s (%s): %s (%s)",
+                                                        objectId,
+                                                        bucket.getName())
+                                .handle();
             }
             throw Exceptions.handle()
                             .to(ObjectStores.LOG)


### PR DESCRIPTION
This mainly happens when the user aborts the upload by closing the tab or navigating away from the upload

Fixes: SIRI-562

To consistently catch alle aborts this PR is needed:

- https://github.com/scireum/sirius-web/pull/1030