### PR TITLE
Renders parent structure of current kb article as breadcrumbs

### DIFF
--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseArticle.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseArticle.java
@@ -12,6 +12,7 @@ import sirius.biz.web.BizController;
 import sirius.kernel.commons.Strings;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -110,6 +111,24 @@ public class KnowledgeBaseArticle {
      */
     public Optional<KnowledgeBaseArticle> queryParent() {
         return knowledgeBase.resolve(language, entry.getParentId(), false);
+    }
+
+    /**
+     * Tries to resolve the parent structure of this article.
+     *
+     * @return a list of the roots of this article (ordered from near to far), or an empty list if the current article
+     * is already the root chapter or not placed in any chapter at all.
+     */
+    public List<KnowledgeBaseArticle> queryParents() {
+        List<KnowledgeBaseArticle> parents = new ArrayList<>();
+
+        KnowledgeBaseArticle parent = queryParent().orElse(null);
+        while (parent != null) {
+            parents.add(0, parent);
+            parent = parent.queryParent().orElse(null);
+        }
+
+        return parents;
     }
 
     public String getArticleId() {

--- a/src/main/resources/default/taglib/k/base.html.pasta
+++ b/src/main/resources/default/taglib/k/base.html.pasta
@@ -35,6 +35,16 @@
             <li>
                 <a href="/kb/@article.getLanguage()">@i18n('KnowledgeBase.kb')</a>
             </li>
+            <i:local name="parents" value="article.queryParents()"/>
+            <i:if test="!parents.isEmpty()">
+                <i:for type="sirius.biz.tycho.kb.KnowledgeBaseArticle" var="parent" items="parents">
+                    <i:if test="'00000' != parent.getArticleId()">
+                        <li>
+                            <a href="/kba/@parent.getLanguage()/@parent.getArticleId()">@parent.getTitle()</a>
+                        </li>
+                    </i:if>
+                </i:for>
+            </i:if>
             <i:if test="'00000' != article.getArticleId()">
                 <li>
                     <a href="/kba/@article.getLanguage()/@article.getArticleId()">@article.getTitle()</a>
@@ -67,13 +77,14 @@
                             <div class="dropdown-menu dropdown-menu-right p-4" style="width: 400px">
                                 <div class="mb-3">
                                     <label class="form-label">URL</label>
-                                    <input type="text" class="form-control" id="urlField" readonly value="@article.getPresignedUrl()">
+                                    <input type="text" class="form-control" id="urlField" readonly
+                                           value="@article.getPresignedUrl()">
                                     <small id="copy-msg" class="form-text text-muted text-sirius-green-dark"></small>
                                 </div>
                                 <div>@i18n('KnowledgeBase.urlCopyInfo')</div>
                             </div>
                             <script>
-                                sirius.ready(function() {
+                                sirius.ready(function () {
                                     $('#urlDropdown').on('shown.bs.dropdown', function () {
                                         const copyMsg = document.querySelector('#copy-msg');
                                         const copyTextarea = document.querySelector('#urlField');


### PR DESCRIPTION
This makes it easier to see the structure the user is currently in and jumping to overarching chapters to gain further knowledge.

Before:

![image](https://user-images.githubusercontent.com/2427877/165457335-706ff9a6-61f5-4996-999a-7bf736129a2d.png)

After:

![image](https://user-images.githubusercontent.com/2427877/165457272-9492b67d-8fdf-4f99-a841-93bc7b8510d6.png)

Fixes: SIRI-568