### PR TITLE
Adds text breaks to process output table cells

### DIFF
--- a/src/main/resources/default/templates/biz/process/process-output-table.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-output-table.html.pasta
@@ -45,7 +45,7 @@
                         <tr>
                             <i:for type="String" var="column" items="columns">
                                 <i:raw>
-                                    <td class="cell">@cells.render(column, row.getContext().data())</td>
+                                    <td class="cell text-break overflow-hidden">@cells.render(column, row.getContext().data())</td>
                                 </i:raw>
                             </i:for>
                         </tr>


### PR DESCRIPTION


To prevent long filenames to make the report wider than intended

Fixes: SIRI-569


Before
<img width="1739" alt="Screenshot 2022-04-28 at 12 48 33" src="https://user-images.githubusercontent.com/10437176/165736531-8f866b59-cf5d-49a3-a583-433e04512bb0.png">


After
<img width="1314" alt="Screenshot 2022-04-28 at 09 50 08" src="https://user-images.githubusercontent.com/10437176/165736551-83984177-7986-4cd3-bc63-b15a6d27b9d0.png">
