### PR TITLE
Permits to clear PerformanceData entirely.

### DIFF
--- a/src/main/java/sirius/biz/analytics/flags/PerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/PerformanceData.java
@@ -47,7 +47,7 @@ public abstract class PerformanceData extends Composite {
     /**
      * Clears all performance flags on the entity.
      * <p>
-     * Note that the owner as to be {@link sirius.db.mixing.BaseMapper#update(BaseEntity) persisted} to actually
+     * Note that the owner has to be {@link sirius.db.mixing.BaseMapper#update(BaseEntity) persisted} to actually
      * perform the changes.
      */
     public abstract void clear();

--- a/src/main/java/sirius/biz/analytics/flags/PerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/PerformanceData.java
@@ -45,6 +45,14 @@ public abstract class PerformanceData extends Composite {
     public abstract PerformanceFlagModifier modify();
 
     /**
+     * Clears all performance flags on the entity.
+     * <p>
+     * Note that the owner as to be {@link sirius.db.mixing.BaseMapper#update(BaseEntity) persisted} to actually
+     * perform the changes.
+     */
+    public abstract void clear();
+
+    /**
      * Determines if a given performance flag is set.
      *
      * @param flag the flag  to check

--- a/src/main/java/sirius/biz/analytics/flags/jdbc/SQLPerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/jdbc/SQLPerformanceData.java
@@ -44,6 +44,11 @@ public class SQLPerformanceData extends PerformanceData {
     }
 
     @Override
+    public void clear() {
+        flags = 0;
+    }
+
+    @Override
     public boolean isSet(PerformanceFlag flag) {
         return (flags & (1L << flag.getBitIndex())) != 0;
     }

--- a/src/main/java/sirius/biz/analytics/flags/mongo/MongoPerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/mongo/MongoPerformanceData.java
@@ -46,6 +46,11 @@ public class MongoPerformanceData extends PerformanceData {
     }
 
     @Override
+    public void clear() {
+        flags.clear();
+    }
+
+    @Override
     public boolean isSet(PerformanceFlag flag) {
         return flags.contains(String.valueOf(flag.getBitIndex()));
     }


### PR DESCRIPTION
This is e.g. required when cloning / copying entities.