### PR TITLE
Uses the importAllSheets in the RelationEntityImportJob

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJob.java
@@ -126,7 +126,10 @@ public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransacti
     protected void executeForStream(String filename, Producer<InputStream> inputSupplier) throws Exception {
         importTransactionHelper.start();
         try (InputStream in = inputSupplier.create()) {
-            LineBasedProcessor.create(filename, in).run((rowNumber, row) -> {
+            LineBasedProcessor.create(filename,
+                                      in,
+                                      process.getParameter(LineBasedImportJob.IMPORT_ALL_SHEETS_PARAMETER)
+                                             .orElse(false)).run((rowNumber, row) -> {
                 errorContext.withContext(ERROR_CONTEXT_ROW, rowNumber);
                 this.handleRow(rowNumber, row);
                 errorContext.removeContext(ERROR_CONTEXT_ROW);


### PR DESCRIPTION
The parameter is parsed in the LineBasedImportJob but has been fully forgotten to be evaluated here.

Fixes: OX-8606