### PR TITLE
Fixes an NPE when checking if a BlobSoftRef points to a temporary space

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
@@ -210,7 +210,8 @@ public class BlobSoftRefProperty extends BlobRefProperty {
             return;
         }
 
-        if (ref.getBlob().isTemporary()) {
+        Blob blob = ref.getBlob();
+        if (blob != null && blob.isTemporary()) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage(

--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
@@ -201,8 +201,12 @@ public class BlobSoftRefProperty extends BlobRefProperty {
 
     @Override
     protected void onBeforeSaveChecks(Object entity) {
+        if (!isChanged(entity)) {
+            return;
+        }
+
         BlobSoftRef ref = (BlobSoftRef) getRef(entity);
-        if (isChanged(entity) && ref.isFilled() && !ref.isURL() && ref.getBlob().isTemporary()) {
+        if (ref.isFilled() && !ref.isURL() && ref.getBlob().isTemporary()) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage(

--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
@@ -206,7 +206,11 @@ public class BlobSoftRefProperty extends BlobRefProperty {
         }
 
         BlobSoftRef ref = (BlobSoftRef) getRef(entity);
-        if (ref.isFilled() && !ref.isURL() && ref.getBlob().isTemporary()) {
+        if (ref.isEmpty() || ref.isURL()) {
+            return;
+        }
+
+        if (ref.getBlob().isTemporary()) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage(


### PR DESCRIPTION
If the blob cannot be obtained, calling blob.isTemporary runs into a NullPointerException.

Also improves the code readability with some early returns.

Fixes: OX-8698