### PR TITLE
Supports creating uplinks to FTPS servers

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -573,8 +573,8 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
      * Tries to resolve the relative path within this directory.
      *
      * @param relativePath the path to resolve
-     * @return the relative path wrapped as optional or an  empty optional if the given relative path cannot be
-     * resolved into a file.
+     * @return the relative path wrapped as a VirtualFile
+     * @throws IllegalArgumentException when the given path is empty after sanitization
      */
     @Nonnull
     public VirtualFile resolve(String relativePath) {

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplink.java
@@ -1,0 +1,52 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.layer3.uplink.ftp;
+
+import sirius.biz.storage.layer3.uplink.ConfigBasedUplink;
+import sirius.biz.storage.layer3.uplink.UplinkFactory;
+import sirius.biz.storage.layer3.uplink.util.RemotePath;
+import sirius.kernel.commons.Value;
+import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nonnull;
+import java.util.function.Function;
+
+/**
+ * Provides an uplink which connects to a remote FTPS server.
+ */
+public class FTPSUplink extends FTPUplink {
+
+    /**
+     * Creates a new uplink for config sections which use "ftp" as type.
+     */
+    @Register
+    public static class Factory implements UplinkFactory {
+
+        @Override
+        public ConfigBasedUplink make(String id, Function<String, Value> config) {
+            return new FTPSUplink(id,
+                                  config,
+                                  new FTPSUplinkConnectorConfig(id, config),
+                                  new RemotePath(config.apply(CONFIG_BASE_PATH).asString("/")));
+        }
+
+        @Nonnull
+        @Override
+        public String getName() {
+            return "ftps";
+        }
+    }
+
+    protected FTPSUplink(String id,
+                         Function<String, Value> config,
+                         FTPUplinkConnectorConfig connectorConfig,
+                         RemotePath basePath) {
+        super(id, config, connectorConfig, basePath);
+    }
+}

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
@@ -49,10 +49,10 @@ class FTPSUplinkConnectorConfig extends FTPUplinkConnectorConfig {
             client.enterLocalPassiveMode();
 
             return client;
-        } catch (IOException e) {
+        } catch (IOException exception) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
-                            .error(e)
+                            .error(exception)
                             .withSystemErrorMessage(
                                     "Layer 3/FTP: An error occurred while connecting the uplink %s: %s (%s)",
                                     this)

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
@@ -100,10 +100,10 @@ public class FTPUplink extends ConfigBasedUplink {
     private ValueHolder<Boolean> performMLSDFeatureCheck(FTPClient client) {
         try {
             return ValueHolder.of(client.hasFeature(FEATURE_MLSD));
-        } catch (Exception e) {
+        } catch (Exception exception) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)
-                      .error(e)
+                      .error(exception)
                       .withSystemErrorMessage("Layer 3/FTP: Cannot determine MLSD support for uplink '%s' - %s (%s)",
                                               ftpConfig)
                       .handle();
@@ -125,12 +125,12 @@ public class FTPUplink extends ConfigBasedUplink {
             try {
                 processListing(parent, search, relativeParent, connector);
                 return;
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage(
                                             "Layer 3/FTP: Cannot iterate over children of '%s' in uplink '%s' - %s (%s)",
                                             parent,
@@ -232,12 +232,12 @@ public class FTPUplink extends ConfigBasedUplink {
                 } else {
                     return Optional.empty();
                 }
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage("Layer 3/FTP: Cannot resolve '%s' for uplink '%s' - %s (%s)",
                                                             file,
                                                             ftpConfig)
@@ -288,12 +288,12 @@ public class FTPUplink extends ConfigBasedUplink {
                          .rename(file.as(RemotePath.class).getPath(),
                                  newParent.as(RemotePath.class).child(file.name()).getPath());
                 return true;
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage(
                                             "Layer 3/FTP: Cannot move '%s' to '%s' in uplink '%s': %s (%s)",
                                             file,
@@ -317,12 +317,12 @@ public class FTPUplink extends ConfigBasedUplink {
                          .rename(file.as(RemotePath.class).getPath(),
                                  file.parent().as(RemotePath.class).child(newName).getPath());
                 return true;
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage(
                                             "Layer 3/FTP: Cannot rename '%s' to '%s' in uplink '%s': %s (%s)",
                                             file,
@@ -344,12 +344,12 @@ public class FTPUplink extends ConfigBasedUplink {
             UplinkConnector<FTPClient> connector = connectorPool.obtain(ftpConfig);
             try {
                 return connector.connector().makeDirectory(relativePath);
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage(
                                             "Layer 3/FTP: Failed to create a directory for '%s' in uplink '%s': %s (%s)",
                                             relativePath,
@@ -378,12 +378,12 @@ public class FTPUplink extends ConfigBasedUplink {
             UplinkConnector<FTPClient> connector = connectorPool.obtain(ftpConfig);
             try {
                 return connector.connector().deleteFile(relativePath);
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage("Layer 3/FTP: Failed to delete '%s' in uplink '%s': %s (%s)",
                                                             relativePath,
                                                             ftpConfig)
@@ -402,12 +402,12 @@ public class FTPUplink extends ConfigBasedUplink {
             UplinkConnector<FTPClient> connector = connectorPool.obtain(ftpConfig);
             try {
                 return connector.connector().removeDirectory(relativePath);
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage("Layer 3/FTP: Failed to delete '%s' in uplink '%s': %s (%s)",
                                                             relativePath,
                                                             ftpConfig)
@@ -435,13 +435,13 @@ public class FTPUplink extends ConfigBasedUplink {
                 watchableInputStream.getCompletionFuture()
                                     .then(() -> completePendingCommand(connector, path, "download"));
                 return watchableInputStream;
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
                 connector.safeClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage(
                                             "Layer 3/FTP: Failed to initiate a download for '%s' in uplink '%s': %s (%s)",
                                             path,
@@ -466,10 +466,10 @@ public class FTPUplink extends ConfigBasedUplink {
                           .handle();
                 connector.forceClose();
             }
-        } catch (IOException e) {
+        } catch (IOException exception) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)
-                      .error(e)
+                      .error(exception)
                       .withSystemErrorMessage("Layer 3/FTP: Failed to complete the %s for '%s' in uplink '%s': %s (%s)",
                                               command,
                                               path,
@@ -495,13 +495,13 @@ public class FTPUplink extends ConfigBasedUplink {
                 watchableOutputStream.getCompletionFuture()
                                      .then(() -> completePendingCommand(connector, path, "upload"));
                 return watchableOutputStream;
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 connector.forceClose();
                 connector.safeClose();
-                if (attempt.shouldThrow(e)) {
+                if (attempt.shouldThrow(exception)) {
                     throw Exceptions.handle()
                                     .to(StorageUtils.LOG)
-                                    .error(e)
+                                    .error(exception)
                                     .withSystemErrorMessage(
                                             "Layer 3/FTP: Failed to initiate an upload for '%s' in uplink '%s': %s (%s)",
                                             path,

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
@@ -58,7 +58,10 @@ public class FTPUplink extends ConfigBasedUplink {
 
         @Override
         public ConfigBasedUplink make(String id, Function<String, Value> config) {
-            return new FTPUplink(id, config);
+            return new FTPUplink(id,
+                                 config,
+                                 new FTPUplinkConnectorConfig(id, config),
+                                 new RemotePath(config.apply(CONFIG_BASE_PATH).asString("/")));
         }
 
         @Nonnull
@@ -70,17 +73,20 @@ public class FTPUplink extends ConfigBasedUplink {
 
     private static final String FEATURE_MLSD = "MLSD";
 
-    private final FTPUplinkConnectorConfig ftpConfig;
+    protected final FTPUplinkConnectorConfig ftpConfig;
     private ValueHolder<Boolean> supportsMLSD;
-    private final RemotePath basePath;
+    protected final RemotePath basePath;
 
     @Part
     private static UplinkConnectorPool connectorPool;
 
-    protected FTPUplink(String id, Function<String, Value> config) {
+    protected FTPUplink(String id,
+                        Function<String, Value> config,
+                        FTPUplinkConnectorConfig connectorConfig,
+                        RemotePath basePath) {
         super(id, config);
-        this.ftpConfig = new FTPUplinkConnectorConfig(id, config);
-        this.basePath = new RemotePath(config.apply(CONFIG_BASE_PATH).asString("/"));
+        this.ftpConfig = connectorConfig;
+        this.basePath = basePath;
     }
 
     private boolean checkForMLSD(FTPClient client) {

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
@@ -60,10 +60,10 @@ class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {
             client.enterLocalPassiveMode();
 
             return client;
-        } catch (IOException e) {
+        } catch (IOException exception) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
-                            .error(e)
+                            .error(exception)
                             .withSystemErrorMessage(
                                     "Layer 3/FTP: An error occurred while connecting the uplink %s: %s (%s)",
                                     this)
@@ -80,10 +80,10 @@ class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {
     protected void safeClose(FTPClient connector) {
         try {
             connector.disconnect();
-        } catch (IOException e) {
+        } catch (IOException exception) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)
-                      .error(e)
+                      .error(exception)
                       .withSystemErrorMessage(
                               "Layer 3/FTP: An error occurred while disconnecting the uplink %s: %s (%s)",
                               this)


### PR DESCRIPTION
To connect to an FTPS server successfully not the FTPClient has to be used but its subclass FTPSClient. To do this we extend the FTPUplink and FTPUplinkConnectorConfig and setup the new client internally.

Fixes: SIRI-584