### PR TITLE
Uses Extension::getRaw to configure ConfigBasedUplinks.

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplink.java
@@ -14,6 +14,7 @@ import sirius.biz.storage.layer3.MutableVirtualFile;
 import sirius.biz.storage.layer3.VirtualFile;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
+import sirius.kernel.nls.NLS;
 import sirius.web.security.ScopeInfo;
 import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
@@ -112,7 +113,7 @@ public abstract class ConfigBasedUplink {
      * @return the virtual root directory
      */
     protected VirtualFile makeDirectory(@Nonnull VirtualFile parent) {
-        return createDirectoryFile(parent).withDescription(description)
+        return createDirectoryFile(parent).withDescription(NLS.smartGet(description))
                                           .markAsExistingDirectory()
                                           .withChildren(innerChildProvider);
     }

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplinksRoot.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplinksRoot.java
@@ -67,7 +67,7 @@ public class ConfigBasedUplinksRoot implements VFSRoot {
     private ConfigBasedUplink makeUplink(Extension extension) {
         try {
             return ctx.findPart(extension.get("type").asString(), UplinkFactory.class)
-                      .make(extension.get("name").asString(extension.getId()), extension::get);
+                      .make(extension.get("name").asString(extension.getId()), extension::getRaw);
         } catch (IllegalArgumentException e) {
             StorageUtils.LOG.SEVERE(Strings.apply(
                     "Layer 3: An error occurred while initializing the uplink '%s' from the system configuration: %s",


### PR DESCRIPTION
This way, we prevent a premature translation of a value,
which is done on demand now, as otherwise we'd cache
the first translation and use this for all users.