### PR TITLE
Enables large file detection for /fs and /ps.

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1266,7 +1266,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             if (physicalKey != null) {
                 response.addHeader(HEADER_VARIANT_SOURCE,
                                    Boolean.TRUE.equals(physicalKey.getSecond()) ? "cache" : "lookup");
-                getPhysicalSpace().deliver(response, physicalKey.getFirst());
+                getPhysicalSpace().deliver(response, physicalKey.getFirst(), false);
             } else {
                 if (markAsLongRunning != null) {
                     markAsLongRunning.run();
@@ -1283,9 +1283,12 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     }
 
     @Override
-    public void deliverPhysical(@Nullable String blobKey, @Nonnull String physicalKey, @Nonnull Response response) {
+    public void deliverPhysical(@Nullable String blobKey,
+                                @Nonnull String physicalKey,
+                                @Nonnull Response response,
+                                boolean largeFileExpected) {
         touch(blobKey);
-        getPhysicalSpace().deliver(response, physicalKey);
+        getPhysicalSpace().deliver(response, physicalKey, largeFileExpected);
     }
 
     /**
@@ -1739,7 +1742,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
                          } else {
                              response.addHeader(HEADER_VARIANT_SOURCE,
                                                 Boolean.TRUE.equals(physicalKey.getSecond()) ? "cache" : "computed");
-                             getPhysicalSpace().deliver(response, physicalKey.getFirst());
+                             getPhysicalSpace().deliver(response, physicalKey.getFirst(), false);
                          }
                      } catch (Exception e) {
                          handleFailedConversion(blobKey, variant, e);

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
@@ -185,8 +185,8 @@ public interface BlobStorageSpace {
      * This is used by the {@link BlobContainer} to reference arbitrary blobs from an entity. This is mainly used,
      * if the blobs are not referenced by their filename.
      *
-     * @param objectKey           the blob to reference
-     * @param referencingEntity   the unique name of the entity
+     * @param objectKey         the blob to reference
+     * @param referencingEntity the unique name of the entity
      */
     void attachTemporaryBlob(String objectKey, String referencingEntity);
 
@@ -194,7 +194,7 @@ public interface BlobStorageSpace {
      * Fetches a blob attached to an entity via a {@link BlobContainer}.
      *
      * @param referencingEntity the referencing entity
-     * @param blobKey          the blob key to lookup
+     * @param blobKey           the blob key to lookup
      * @return the matching blob wrapped as optional or an empty optional if no matching blob was found
      */
     Optional<? extends Blob> findAttachedBlobByKey(String referencingEntity, String blobKey);
@@ -307,11 +307,15 @@ public interface BlobStorageSpace {
     /**
      * Delivers the contents of the given blob by using the already known physicalKey.
      *
-     * @param blobKey     the id of the blob to deliver (mostly for touch tracking)
-     * @param physicalKey the physical object to deliver
-     * @param response    the response to populate
+     * @param blobKey           the id of the blob to deliver (mostly for touch tracking)
+     * @param physicalKey       the physical object to deliver
+     * @param response          the response to populate
+     * @param largeFileExpected determines that a very large file is expected
      */
-    void deliverPhysical(@Nullable String blobKey, @Nonnull String physicalKey, @Nonnull Response response);
+    void deliverPhysical(@Nullable String blobKey,
+                         @Nonnull String physicalKey,
+                         @Nonnull Response response,
+                         boolean largeFileExpected);
 
     /**
      * Performs some housekeeping and maintenance tasks.

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -172,11 +172,20 @@ public class URLBuilder {
         if (Strings.isFilled(blobKey) && blob == null) {
             space.findByBlobKey(blobKey).ifPresent(resolvedBlob -> this.blob = resolvedBlob);
         }
-        if (blob != null && blob.getSize() > largeFileLimit) {
+        if (isConsideredLarge(blob)) {
             this.largeFile = true;
         }
 
         return this;
+    }
+
+    /**
+     * Determines if the given blob is considered a {@link #largeFileLimit} large file.
+     * @param blob the blob to check
+     * @return <tt>true</tt> if the blob is considered large, <tt>false</tt> otherwise@
+     */
+    public static boolean isConsideredLarge(@Nullable Blob blob) {
+        return blob != null && blob.getSize() > largeFileLimit;
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -288,7 +288,10 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
     @Override
     public void deliver(Response response) {
-        getStorageSpace().deliver(getBlobKey(), URLBuilder.VARIANT_RAW, response, null);
+        getStorageSpace().deliverPhysical(getBlobKey(),
+                                          getPhysicalObjectKey(),
+                                          response,
+                                          URLBuilder.isConsideredLarge(this));
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -295,7 +295,10 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
     @Override
     public void deliver(Response response) {
-        getStorageSpace().deliver(getBlobKey(), URLBuilder.VARIANT_RAW, response, null);
+        getStorageSpace().deliverPhysical(getBlobKey(),
+                                          getPhysicalObjectKey(),
+                                          response,
+                                          URLBuilder.isConsideredLarge(this));
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -198,7 +198,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     /**
      * Returns the relative path to the given root parent.
      * <p>
-     * If this would be <tt>/foo/bar/baz</tt> and the given root parent is <tt>/foo</tt> then this would
+     * If this be <tt>/foo/bar/baz</tt> and the given root parent is <tt>/foo</tt> then this would
      * return <tt>bar/baz</tt>. Therefore, this is the inverse of {@link #resolve(String)}.
      *
      * @param rootParent one of the parent directories of <tt>this</tt>

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystemController.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystemController.java
@@ -9,6 +9,7 @@
 package sirius.biz.storage.layer3;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
+import sirius.biz.storage.layer2.Blob;
 import sirius.biz.web.BizController;
 import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Streams;
@@ -64,7 +65,13 @@ public class VirtualFileSystemController extends BizController {
         VirtualFile file = resolveToExistingFile(path);
 
         if (!file.isDirectory()) {
-            file.deliverDownloadTo(webContext);
+            // Note that we violate our architectural layers here a bit, as we directly check for the presence of a
+            // Layer2 Blob. In this case, we can redirect to an optimized download URL. We *could* bury this in yet
+            // another interface, but for now, we directly resolve the Blob and create a URL this way...
+            file.tryAs(Blob.class)
+                .flatMap(blob -> file.as(Blob.class).url().enableLargeFileDetection().asDownload(file.name()).buildURL())
+                .ifPresentOrElse(blobDeliveryUrl -> webContext.respondWith().redirectTemporarily(blobDeliveryUrl),
+                                 () -> file.deliverDownloadTo(webContext));
         } else {
             webContext.respondWith()
                       .template("/templates/biz/storage/list.html.pasta",

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -335,7 +335,7 @@ async {
             queueLength = 0
         }
 
-        # Interctive jobs should actually execute quite instantly. Therefore
+        # Interactive jobs should actually execute quite instantly. Therefore
         # we only permit a low parallelism but a certain queue length for peak loads.
         interactive-jobs {
             poolSize = 2
@@ -386,6 +386,14 @@ async {
         storage-conversion {
             poolSize = 8
             queueLength = 1024
+        }
+
+        # Large files are tunneled via a blocking approach within the Layer 1 of the storage framework. Most notably,
+        # this is enabled by the BlobDispatcher for file known to be large. We use this approach, to safely shovel
+        # multi-gigabyte files without the risk of a consuming all IO buffers for a single download due to contention.
+        storage-deliver-large-file {
+            poolSize = 128
+            queueLength = 512
         }
     }
 

--- a/src/main/resources/default/templates/biz/process/process.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process.html.pasta
@@ -118,7 +118,7 @@
 
             <t:navbox labelKey="Process.files">
                 <i:for type="sirius.biz.storage.layer2.Blob" var="file" items="process.getFiles().findAttachedBlobs()">
-                    <i:local name="url" value="file.url().asDownload().buildURL()"/>
+                    <i:local name="url" value="file.url().enableLargeFileDetection().asDownload().buildURL()"/>
                     <i:if test="url.isPresent()">
                         <t:navboxLink icon="fa fa-file" url="@url.get()">
                             @file.getFilename()


### PR DESCRIPTION
For large downloads via the Layer2 storage, we want to generate
/dasd/xxl/... URLs which can then be detected by a downstream
proxy like Varnish and permit to optimize cache behavior.

This way, such files can be piped through without allocating large
parts of the memory in the load balancer.

This has now been enabled for blob downloads via /fs and
also for process files within /ps.