### PR TITLE
Enables automatic contention control when moving large objects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>dev-31.1.0</sirius.kernel>
-        <sirius.web>dev-51.2.2</sirius.web>
+        <sirius.web>dev-52.0.0</sirius.web>
         <sirius.db>dev-41.5.1</sirius.db>
     </properties>
 

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -29,13 +29,13 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Counter;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.settings.Extension;
+import sirius.web.http.ChunkedOutputStream;
 import sirius.web.http.Response;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.IntConsumer;
@@ -503,7 +503,8 @@ public abstract class ObjectStorageSpace {
         tasks.executor("storage-deliver-large-file").fork(() -> {
             InputStream input = safeObtainInputStream(objectId, response);
             if (input != null) {
-                try (InputStream in = input; OutputStream out = response.outputStream(HttpResponseStatus.OK, null)) {
+                try (InputStream in = input; ChunkedOutputStream out = response.outputStream(HttpResponseStatus.OK, null)) {
+                    out.enableContentionControl();
                     Streams.transfer(in, out);
                 } catch (Exception exception) {
                     handleDeliveryError(response, objectId, exception);

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -947,7 +947,7 @@ storage {
         # Determines the limit when the URLBuilder switches to /dasd/xxl/... URLs. These can be detected by
         # upstream reverse proxies and used to detect large files which aren't worth or healthy to cache.
         # Note that this check has to be enabled manually using URLBuilder.enableLargeFileDetection.
-        largeFileLimit = 512M
+        largeFileLimit = 128M
 
         # Controls the conversion settings used by the BlobStorageSpace to generate variants of a blob.
         conversion {


### PR DESCRIPTION
Also lowers the limit for the large file detection, as some downstream
proxies/caches have smaller buffers.

Requires:
* https://github.com/scireum/sirius-web/pull/1057