### PR TITLE
Fixes an NPE deleting variants

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLVariant.java
@@ -110,6 +110,9 @@ public class SQLVariant extends SQLEntity implements BlobVariant {
     @AfterDelete
     protected void onDelete() {
         SQLBlob sqlBlob = sourceBlob.fetchValue();
+        if (sqlBlob == null) {
+            return;
+        }
         if (Strings.isFilled(physicalObjectKey)) {
             sqlBlob.getStorageSpace().getPhysicalSpace().delete(physicalObjectKey);
         }

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoVariant.java
@@ -108,6 +108,9 @@ public class MongoVariant extends MongoEntity implements BlobVariant {
     @AfterDelete
     protected void onDelete() {
         MongoBlob mongoBlob = blob.fetchValue();
+        if (mongoBlob == null) {
+            return;
+        }
         if (Strings.isFilled(physicalObjectKey)) {
             mongoBlob.getStorageSpace().getPhysicalSpace().delete(physicalObjectKey);
         }


### PR DESCRIPTION
In a rare case a variant would have no parent, the deletion will not fail attempting to delete the physical object.

Fixes: OX-8586