### PR TITLE
Properly unlocks the lock for a background loop on system shutdown.

### DIFF
--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -17,7 +17,6 @@ import sirius.kernel.async.AsyncExecutor;
 import sirius.kernel.async.BackgroundLoop;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.Orchestration;
-import sirius.kernel.async.TaskContext;
 import sirius.kernel.async.Tasks;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
@@ -268,7 +267,6 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
             String syncName = BACKGROUND_LOOP_PREFIX + name;
             SynchronizeType type = syncSettings.getOrDefault(syncName, SynchronizeType.LOCAL);
             if (type == SynchronizeType.CLUSTER
-                && CallContext.getCurrent().get(TaskContext.class).isActive()
                 && redis.isConfigured()) {
                 redis.unlock(syncName);
             }


### PR DESCRIPTION
Even if the system is about to be halted, it is wise to unlock the
loop-lock here, as our work has been completed. Otherwise, the
lock might hang for quite a time and block processing, even after
a restart.