### PR TITLE
Auto-Creation of System Tenant with Correct ID

### DIFF
--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantAutoSetup.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantAutoSetup.java
@@ -9,12 +9,16 @@
 package sirius.biz.tenants.jdbc;
 
 import sirius.biz.tenants.BaseTenantAutoSetup;
+import sirius.biz.tenants.TenantData;
 import sirius.db.jdbc.OMA;
+import sirius.db.mixing.Mixing;
 import sirius.kernel.AutoSetup;
 import sirius.kernel.AutoSetupRule;
+import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
 
 /**
  * Creates an initial tenant and user if none are available.
@@ -29,6 +33,9 @@ public class SQLTenantAutoSetup extends BaseTenantAutoSetup {
     @Part
     private OMA oma;
 
+    @Part
+    private Mixing mixing;
+
     @Override
     public void setup() throws Exception {
         if (oma.select(SQLTenant.class).exists()) {
@@ -40,23 +47,34 @@ public class SQLTenantAutoSetup extends BaseTenantAutoSetup {
         }
 
         AutoSetup.LOG.INFO("Creating system tenant....");
-        SQLTenant tenant = new SQLTenant();
+
+        // The ID of the future system tenant will be set to "1" or another fixed value from the configuration files.
+        // This should normally be avoided at all cost, but in this case, it greatly simplifies the system config...
+        long systemTenantId = 1;
+        if (tenants != null) {
+            systemTenantId = Long.parseLong(tenants.getSystemTenantId());
+        }
+
+        // We can not modify the ID of a new tenant entity directly. Thus, we create an empty tenant with the proper ID
+        // using low-level techniques first, just to be filled properly in an instant.
+        oma.getDatabase(Mixing.DEFAULT_REALM)
+           .insertRow(mixing.getDescriptor(SQLTenant.class).getRelationName(),
+                      Context.create()
+                             .set(SQLTenant.ID.getName(), systemTenantId)
+                             .set(SQLTenant.TENANT_DATA.inner(TenantData.NAME).getName(), ""));
+
+        // We load the newly created empty tenant via high-level techniques, making use of default values set in the
+        // entity
+        SQLTenant tenant = oma.select(SQLTenant.class)
+                              .where(OMA.FILTERS.eq(SQLTenant.ID, systemTenantId))
+                              .one()
+                              .orElseThrow(() -> {
+                                  return Exceptions.createHandled().withSystemErrorMessage("oh nej").handle();
+                              });
+
+        // Having a semi-initialised tenant, it is now time to set it up as system tenant
         setupTenantData(tenant);
         oma.update(tenant);
-
-        if (tenants != null) {
-            try {
-                oma.updateStatement(SQLTenant.class)
-                   .set(SQLTenant.ID, Long.parseLong(tenants.getSystemTenantId()))
-                   .where(SQLTenant.ID, tenant.getId())
-                   .executeUpdate();
-            } catch (Exception e) {
-                AutoSetup.LOG.WARN("Failed to update ID of system tenant from %s to %s: %s",
-                                   tenant.getId(),
-                                   tenants.getSystemTenantId(),
-                                   e.getMessage());
-            }
-        }
 
         // We only create the system user, if no SAML settings are present...
         if (Strings.isEmpty(tenant.getTenantData().getSamlRequestIssuerName())) {


### PR DESCRIPTION
Attention, this is a **breaking change:** Systems can no longer rely on `wasCreated()` or `isNew()` to determine the need for extended setup routines, for instance in `@AfterSave` routines. Implement a `TenantAutoSetupExtender` to perform setup tasks explicitly.