### PR TITLE
SIRI-615: Moves Interactive Jobs Pages to Tycho.

### DIFF
--- a/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
@@ -86,4 +86,5 @@
         </div>
     </i:if>
 
+    <i:invoke template="/templates/biz/jobs/job-parameters-logic.html.pasta" job="@job"/>
 </t:page>

--- a/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
@@ -17,17 +17,19 @@
         </li>
     </i:block>
 
-    <t:pageHeader>
-        <i:block name="title">@job.getCurrentLabel(context)</i:block>
-        <t:iconInlineInfo icon="fa fa-info-circle">@job.getCurrentDescription(context)</t:iconInlineInfo>
-        <i:block name="actions">
-            <i:if test="!job.getJobInfos().isEmpty()">
-                <a class="btn btn-outline-link" href="/jobs/infos/@job.getName()">
-                    <span><i class="fa fa-book"></i></span> @i18n("JobsController.showInfos")
-                </a>
-            </i:if>
-        </i:block>
-    </t:pageHeader>
+    <i:block name="page-header">
+        <t:pageHeader>
+            <i:block name="title">@job.getCurrentLabel(context)</i:block>
+            <t:iconInlineInfo icon="fa fa-info-circle">@job.getCurrentDescription(context)</t:iconInlineInfo>
+            <i:block name="actions">
+                <i:if test="!job.getJobInfos().isEmpty()">
+                    <a class="btn btn-outline-link" href="/jobs/infos/@job.getName()">
+                        <span><i class="fa fa-book"></i></span> @i18n("JobsController.showInfos")
+                    </a>
+                </i:if>
+            </i:block>
+        </t:pageHeader>
+    </i:block>
 
     <div class="row">
         <i:if test="hasVisibleParameters">

--- a/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
@@ -35,15 +35,13 @@
         <i:if test="hasVisibleParameters">
             <div class="col-md-3">
                 <t:editForm url="@apply('/job/%s', job.getName())">
-                    <div class="well">
-                        <div class="row">
-                            <i:for type="sirius.biz.jobs.params.Parameter" var="param" items="parameters">
-                                <i:dynamicInvoke template="@param.getTemplateName()"
-                                                 param="@param" context="@context"/>
-                            </i:for>
-                        </div>
-                        <t:formBar btnLabelKey="JobFactory.execute"/>
+                    <div class="row">
+                        <i:for type="sirius.biz.jobs.params.Parameter" var="param" items="parameters">
+                            <i:dynamicInvoke template="@param.getTemplateName()"
+                                             param="@param" context="@context"/>
+                        </i:for>
                     </div>
+                    <t:formBar btnLabelKey="JobFactory.execute"/>
                 </t:editForm>
             </div>
         </i:if>

--- a/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
@@ -3,7 +3,11 @@
 <i:arg type="List" name="additionalMetrics"/>
 <i:arg type="boolean" name="fullWidth" default="false"/>
 
-<w:page title="@job.getLabel()">
+<i:local name="parameters" value="job.getParameters()"/>
+<i:local name="hasVisibleParameters" value="job.hasVisibleParameters(context)"/>
+<i:local name="hasAdditionalMetrics" value="!additionalMetrics.isEmpty()"/>
+
+<t:page title="@job.getLabel()">
     <i:block name="breadcrumbs">
         <li>
             <a href="/jobs">@i18n("JobFactory.plural")</a>
@@ -13,84 +17,73 @@
         </li>
     </i:block>
 
-    <w:pageHeader>
-        <div class="row">
-            <div class="col-md-8">
-                @job.getCurrentLabel(context)
-            </div>
-            <div class="col-md-4 align-right">
-                <i:if test="!job.getJobInfos().isEmpty()">
-                    <a class="btn btn-default" href="/jobs/infos/@job.getName()">@i18n("JobsController.showInfos")</a>
-                </i:if>
-            </div>
-        </div>
-    </w:pageHeader>
+    <t:pageHeader>
+        <i:block name="title">@job.getCurrentLabel(context)</i:block>
+        <t:iconInlineInfo icon="fa fa-info-circle">@job.getCurrentDescription(context)</t:iconInlineInfo>
+        <i:block name="actions">
+            <i:if test="!job.getJobInfos().isEmpty()">
+                <a class="btn btn-outline-link" href="/jobs/infos/@job.getName()">
+                    <span><i class="fa fa-book"></i></span> @i18n("JobsController.showInfos")
+                </a>
+            </i:if>
+        </i:block>
+    </t:pageHeader>
 
     <div class="row">
-        <i:local name="parameters"
-                 value="job.getParameters()" />
-        <i:if test="@job.hasVisibleParameters(context) || !additionalMetrics.isEmpty()">
+        <i:if test="hasVisibleParameters">
             <div class="col-md-3">
-                <i:if test="@job.hasVisibleParameters(context)">
-                    <w:editForm url="@apply('/job/%s', job.getName())">
-                        <div class="well">
-                            <div class="row">
-                                <i:for type="sirius.biz.jobs.params.Parameter" var="param" items="parameters">
-                                    <i:dynamicInvoke template="@param.getTemplateName()" param="@param" context="@context" />
-                                </i:for>
-                            </div>
-                            <div class="row">
-                                <div class="col-md-12">
-                                    <a class="btn btn-primary submit-link btn-block">
-                                        <i class="fa fa-check"></i> @i18n("JobFactory.execute")
-                                    </a>
-                                </div>
-                            </div>
-
-                        </div>
-                    </w:editForm>
-                </i:if>
-                <i:if test="!additionalMetrics.isEmpty()">
-                    <w:infobox titleKey="InteractiveJobFactory.additionalMetrics">
-                        <i:for type="Tuple" var="metric" items="additionalMetrics">
-                            <w:infoboxCell label="@toUserString(metric.getFirst())"
-                                           value="metric.getSecond().as(sirius.biz.analytics.reports.Cell.class)" />
-                        </i:for>
-                    </w:infobox>
-                </i:if>
-                <div>
-                    <a href="/jobs" class="btn btn-block">@i18n("NLS.back")</a>
-                </div>
-            </div>
-            <div class="col-md-9">
-                <i:local name="description" value="job.getCurrentDescription(context)" />
-                <i:if test="isFilled(description)">
+                <t:editForm url="@apply('/job/%s', job.getName())">
                     <div class="well">
-                        @description
-                    </div>
-                </i:if>
-                <div>
-                    <i:render name="body" />
-                </div>
-            </div>
-            <i:else>
-                <div class="@if (fullWidth) { col-md-12 } else { col-md-10 col-md-offset-1 }">
-                    <i:local name="description" value="job.getCurrentDescription(context)" />
-                    <i:if test="isFilled(description)">
-                        <div class="well">
-                            @description
+                        <div class="row">
+                            <i:for type="sirius.biz.jobs.params.Parameter" var="param" items="parameters">
+                                <i:dynamicInvoke template="@param.getTemplateName()"
+                                                 param="@param" context="@context"/>
+                            </i:for>
                         </div>
-                    </i:if>
-                    <div>
-                        <i:render name="body" />
+                        <t:formBar btnLabelKey="JobFactory.execute"/>
                     </div>
-                </div>
-                <div class="col-md-12">
-                    <div class="form-actions">
-                        <a href="/jobs" class="btn">@i18n("NLS.back")</a>
-                    </div>
-                </div>
-            </i:else>
+                </t:editForm>
+            </div>
+        </i:if>
+
+        <!--@ Calculate col-md value as some charts may not calculate a correct width otherwise -->
+        <i:local name="bodyColClass"
+                 value="(hasVisibleParameters && hasAdditionalMetrics) ? 'col-md-6' : ((hasVisibleParameters || hasAdditionalMetrics) ? 'col-md-9' : 'col-md-12')"/>
+        <div class="@bodyColClass">
+            <div class="card card-border p-2 mt-sm-3">
+                <i:render name="body"/>
+            </div>
+        </div>
+
+        <i:if test="hasAdditionalMetrics">
+            <div class="col-md-3 mt-sm-3">
+                <t:infobox labelKey="InteractiveJobFactory.additionalMetrics" class="card card-border p-2">
+                    <i:for type="Tuple" var="metric" items="additionalMetrics">
+                        <div class="d-flex flex-row pt-1 mb-1 border-top border-sirius-gray">
+                            <div class="text-small text-ellipsis overflow-hidden flex-grow-0">
+                                @toUserString(metric.getFirst())
+                            </div>
+                            <div class="text-small font-weight-bold text-right flex-grow-1 pl-2 pr-2">
+                                <i:raw>
+                                    @metric.getSecond().as(sirius.biz.analytics.reports.Cell.class).render()
+                                </i:raw>
+                            </div>
+                        </div>
+                    </i:for>
+                </t:infobox>
+            </div>
         </i:if>
     </div>
-</w:page>
+
+    <i:if test="!hasVisibleParameters">
+        <div class="row">
+            <div class="col-md-12 mt-3">
+                <a href="javascript:window.history.back()"
+                   class="btn btn-outline-secondary back-button">
+                    <i class="fa fa-chevron-left"></i> @i18n("NLS.back")
+                </a>
+            </div>
+        </div>
+    </i:if>
+
+</t:page>

--- a/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/interactive-job.html.pasta
@@ -86,5 +86,5 @@
         </div>
     </i:if>
 
-    <i:invoke template="/templates/biz/jobs/job-parameters-logic.html.pasta" job="@job"/>
+    <i:invoke template="/templates/biz/jobs/job-parameters-logic.html.pasta" job="@job" context="@context"/>
 </t:page>

--- a/src/main/resources/default/templates/biz/jobs/job-parameters-logic.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/job-parameters-logic.html.pasta
@@ -1,4 +1,5 @@
 <i:arg name="job" type="sirius.biz.jobs.JobFactory"/>
+<i:arg name="context" type="Map"/>
 
 <script type="text/javascript">
     sirius.ready(function () {
@@ -29,7 +30,7 @@
                 if (typeof param.validation !== 'undefined') {
                     const html = Mustache.render(
                         "<div class='mt-1 py-1 px-3 border-top param-{{name}}-validation alert-{{style}} border-{{style}}'>" +
-                        "<small>{{html}}</small>" +
+                        "<small>{{{html}}}</small>" +
                         "</div>", Object.assign({
                             name: name,
                         }, param.validation));
@@ -45,7 +46,7 @@
             _input.addEventListener("tokens-changed", onChange);
         });
         handleParameterUpdates({
-            params: <i:raw>@job.computeRequiredParameterUpdates(null).toString()</i:raw>
+            params: <i:raw>@job.computeRequiredParameterUpdates(context).toString()</i:raw>
         });
     });
 </script>

--- a/src/main/resources/default/templates/biz/jobs/job-parameters-logic.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/job-parameters-logic.html.pasta
@@ -1,0 +1,51 @@
+<i:arg name="job" type="sirius.biz.jobs.JobFactory"/>
+
+<script type="text/javascript">
+    sirius.ready(function () {
+        function onChange() {
+            const formData = getFormData(sirius.querySelector(".edit-form"));
+            sirius.getJSON("/job/params/___job.getName()", formData).then(handleParameterUpdates);
+        }
+
+        function handleParameterUpdates(json) {
+            for (const name in json.params) {
+                const _element = sirius.querySelector('.param-' + name);
+                let param = json.params[name];
+                if (param.visible) {
+                    _element.removeAttribute("hidden");
+                } else {
+                    _element.setAttribute("hidden", true);
+                }
+                if (param.clear) {
+                    sirius.dispatchEvent("clear", _element);
+                }
+                if (typeof param.updatedValue !== 'undefined') {
+                    sirius.dispatchEvent("updated-value", _element, param.updatedValue);
+                }
+                const _message = sirius.querySelector('.param-' + name + '-validation');
+                if (_message) {
+                    _message.parentNode.removeChild(_message);
+                }
+                if (typeof param.validation !== 'undefined') {
+                    const html = Mustache.render(
+                        "<div class='mt-1 py-1 px-3 border-top param-{{name}}-validation alert-{{style}} border-{{style}}'>" +
+                        "<small>{{html}}</small>" +
+                        "</div>", Object.assign({
+                            name: name,
+                        }, param.validation));
+                    _element.insertAdjacentHTML("beforeend", html);
+                }
+            }
+        }
+
+        document.querySelectorAll('.edit-form input[name]').forEach(function (_input) {
+            _input.addEventListener("change", onChange);
+        });
+        document.querySelectorAll('.edit-form .token-autocomplete-container').forEach(function (_input) {
+            _input.addEventListener("tokens-changed", onChange);
+        });
+        handleParameterUpdates({
+            params: <i:raw>@job.computeRequiredParameterUpdates(null).toString()</i:raw>
+        });
+    });
+</script>

--- a/src/main/resources/default/templates/biz/jobs/job.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/job.html.pasta
@@ -111,7 +111,7 @@
         <t:formBar btnLabelKey="JobFactory.execute"/>
     </t:editForm>
 
-    <i:invoke template="/templates/biz/jobs/job-parameters-logic.html.pasta" job="@job"/>
+    <i:invoke template="/templates/biz/jobs/job-parameters-logic.html.pasta" job="@job" context="@context"/>
 
     <script type="text/javascript">
         function showCreatePresetModal() {

--- a/src/main/resources/default/templates/biz/jobs/job.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/job.html.pasta
@@ -111,55 +111,9 @@
         <t:formBar btnLabelKey="JobFactory.execute"/>
     </t:editForm>
 
+    <i:invoke template="/templates/biz/jobs/job-parameters-logic.html.pasta" job="@job"/>
+
     <script type="text/javascript">
-        sirius.ready(function () {
-            function onChange() {
-                const formData = getFormData(sirius.querySelector(".edit-form"));
-                sirius.getJSON("/job/params/___job.getName()", formData).then(handleParameterUpdates);
-            }
-
-            function handleParameterUpdates(json) {
-                for (const name in json.params) {
-                    const _element = sirius.querySelector('.param-' + name);
-                    let param = json.params[name];
-                    if (param.visible) {
-                        _element.removeAttribute("hidden");
-                    } else {
-                        _element.setAttribute("hidden", true);
-                    }
-                    if (param.clear) {
-                        sirius.dispatchEvent("clear", _element);
-                    }
-                    if (typeof param.updatedValue !== 'undefined') {
-                        sirius.dispatchEvent("updated-value", _element, param.updatedValue);
-                    }
-                    const _message = sirius.querySelector('.param-' + name + '-validation');
-                    if (_message) {
-                        _message.parentNode.removeChild(_message);
-                    }
-                    if (typeof param.validation !== 'undefined') {
-                        const html = Mustache.render(
-                            "<div class='mt-1 py-1 px-3 border-top param-{{name}}-validation alert-{{style}} border-{{style}}'>" +
-                            "<small>{{html}}</small>" +
-                            "</div>", Object.assign({
-                                name: name,
-                            }, param.validation));
-                        _element.insertAdjacentHTML("beforeend", html);
-                    }
-                }
-            }
-
-            document.querySelectorAll('.edit-form input[name]').forEach(function (_input) {
-                _input.addEventListener("change", onChange);
-            });
-            document.querySelectorAll('.edit-form .token-autocomplete-container').forEach(function (_input) {
-                _input.addEventListener("tokens-changed", onChange);
-            });
-            handleParameterUpdates({
-                params: <i:raw>@job.computeRequiredParameterUpdates(null).toString()</i:raw>
-            });
-        });
-
         function showCreatePresetModal() {
             $('#createPreset').on('shown.bs.modal', function () {
                 $('*[name="presetName"]').focus();


### PR DESCRIPTION
As the page is now wider, the additional metrics block is moved to its own column on the right in order to simplify the logic in the template as well as use the additional space instead of cramming it below the job parameters.
This change also comes with using the existing execute and back buttons used in other jobs instead of splitting them up like before. In case no parameters can be set, a back button will be inserted below the graph.

Note, that the column width of the graph in the middle is defined manually instead of relying on the bootstrap framework by simply using "col-md", as some graphs like the bar chart do not calculate a correct width otherwise.


Examples including one with multiple parameters, showing that splitting the display into 3 columns keeps the page height low and uses the full width.

Before:

![Bildschirmfoto 2022-08-22 um 09 52 05](https://user-images.githubusercontent.com/53555813/185871169-81bc5dc6-3f55-4db1-b711-5ca4fdfd9762.png)
![Bildschirmfoto 2022-08-22 um 09 52 10](https://user-images.githubusercontent.com/53555813/185871186-3e6ef7e9-4ddb-404d-a33e-b563ea94051f.png)
![Bildschirmfoto 2022-08-22 um 10 10 25](https://user-images.githubusercontent.com/53555813/185872143-ac9e571b-8726-4501-8094-14a1f5ac81ab.png)


After:

![Bildschirmfoto 2022-08-22 um 09 52 33](https://user-images.githubusercontent.com/53555813/185871259-2b46102d-7e95-4d61-8479-54e124e92ead.png)
![Bildschirmfoto 2022-08-22 um 09 52 37](https://user-images.githubusercontent.com/53555813/185871276-8b32f60a-0c6a-420b-bc4a-3d543acacb17.png)
![Bildschirmfoto 2022-08-22 um 09 44 31 (1)](https://user-images.githubusercontent.com/53555813/185873193-0b7afb17-f8bc-4029-b50c-b53fdbcf8603.png)




- Fixes: SIRI-615