### PR TITLE
Increases the max runtime for blob changes

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -48,6 +48,11 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
         return FREQUENCY_EVERY_FIFTEEN_SECONDS;
     }
 
+    @Override
+    public double maxRuntimeInSeconds() {
+        return 600d;
+    }
+
     @Nullable
     @Override
     protected String doWork() throws Exception {


### PR DESCRIPTION
to **10 min** and so avoiding a warning that the loop exceeded its runtime.

When processing a large amount of changes (eg. deleting a directory with several files), the loop might take a while to run as it fires the deletion of the physical file in the target storage.

Fixes: [SIRI-613](https://scireum.myjetbrains.com/youtrack/issue/SIRI-613)