### PR TITLE
Sets a cookie manager when downloading files

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -43,6 +43,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.CookieManager;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
@@ -1297,6 +1298,10 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
 
             Outcall outcall = new Outcall(url);
             outcall.alwaysFollowRedirects();
+
+            CookieManager cookieManager = new CookieManager();
+            outcall.modifyClient().cookieHandler(cookieManager);
+
             if (mode != FetchFromUrlMode.ALWAYS_FETCH && exists() && lastModifiedDate() != null) {
                 outcall.setIfModifiedSince(lastModifiedDate());
             }
@@ -1468,6 +1473,9 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
             headRequest.markAsHeadRequest();
             headRequest.alwaysFollowRedirects();
             headRequest.modifyClient().connectTimeout(Duration.ofSeconds(10));
+
+            CookieManager cookieManager = new CookieManager();
+            headRequest.modifyClient().cookieHandler(cookieManager);
 
             String path = headRequest.parseFileNameFromContentDisposition()
                                      .filter(filename -> fileExtensionVerifier.test(Files.getFileExtension(filename)))


### PR DESCRIPTION
Upon receiving a redirect response, the response might include cookies which must be forwarded to the new redirect URL.

Fixes: [OX-8968](https://scireum.myjetbrains.com/youtrack/issue/OX-8968)