### PR TITLE
Adds a proper Height Limitation to Dougnut Chart

### DIFF
--- a/src/main/resources/default/templates/biz/jobs/dougnutchart.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/dougnutchart.html.pasta
@@ -8,8 +8,8 @@
           job="job"
           context="context"
           additionalMetrics="additionalMetrics">
-    <div class="well">
-        <canvas id="chart" class="chart" style="display: block" height="180"></canvas>
+    <div style="height: 60vp;">
+        <canvas id="chart" class="chart" style="display: block"></canvas>
     </div>
 
     <script type="text/javascript">


### PR DESCRIPTION
and removes well class as it has no purpose anymore.

The previous set height of 180 was ignored and instead the doughnut chart was as high as it was wide.

- Fixes: SIRI-615