### PR TITLE
SIRI-615: Properly limits the height of Doughnut Charts.

### DIFF
--- a/src/main/resources/default/templates/biz/jobs/barchart.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/barchart.html.pasta
@@ -8,8 +8,8 @@
           job="job"
           context="context"
           additionalMetrics="additionalMetrics">
-    <div class="well">
-        <canvas id="chart" class="chart" style="display: block" height="400"></canvas>
+    <div style="height: 60vh;">
+        <canvas id="chart" class="chart" style="display: block"></canvas>
     </div>
 
     <script type="text/javascript">

--- a/src/main/resources/default/templates/biz/jobs/dougnutchart.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/dougnutchart.html.pasta
@@ -8,8 +8,8 @@
           job="job"
           context="context"
           additionalMetrics="additionalMetrics">
-    <div class="well">
-        <canvas id="chart" class="chart" style="display: block" height="180"></canvas>
+    <div style="height: 60vh;">
+        <canvas id="chart" class="chart" style="display: block"></canvas>
     </div>
 
     <script type="text/javascript">

--- a/src/main/resources/default/templates/biz/jobs/linechart.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/linechart.html.pasta
@@ -8,8 +8,8 @@
           job="job"
           context="context"
           additionalMetrics="additionalMetrics">
-    <div class="well">
-        <canvas id="chart" class="chart" style="display: block" height="400"></canvas>
+    <div style="height: 60vh;">
+        <canvas id="chart" class="chart" style="display: block"></canvas>
     </div>
 
     <script type="text/javascript">

--- a/src/main/resources/default/templates/biz/jobs/polarareachart.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/polarareachart.html.pasta
@@ -8,8 +8,8 @@
           job="job"
           context="context"
           additionalMetrics="additionalMetrics">
-    <div class="well">
-        <canvas id="chart" class="chart" style="display: block" height="200"></canvas>
+    <div style="height: 60vh;">
+        <canvas id="chart" class="chart" style="display: block"></canvas>
     </div>
 
     <script type="text/javascript">


### PR DESCRIPTION
Previously, the set height of 180 was already ignored and instead, the chart was defined by the columns width.
This however now far exceeds the displayed height of the website.

Example:
![Bildschirmfoto 2022-09-02 um 11 28 10](https://user-images.githubusercontent.com/53555813/188109954-6238781c-1554-481c-bda5-46b08a441471.png)
