### PR TITLE
SIRI-619: Fixes setting the job name.

### DIFF
--- a/src/main/java/sirius/biz/jobs/JobConfigData.java
+++ b/src/main/java/sirius/biz/jobs/JobConfigData.java
@@ -91,7 +91,7 @@ public class JobConfigData extends Composite {
         }
 
         if (Strings.isFilled(job)) {
-            jobName = getJobFactory().getName();
+            jobName = getJobFactory().getLabel();
         }
     }
 


### PR DESCRIPTION
The job name in this context is the visible label of the job, not its internal identifier, as this is already set in the "job" field of the entity.

Existing entities can be fixed by resaving the entities.