### PR TITLE
Reimplements the enable/disable functionality in pure js

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>dev-31.3.1</sirius.kernel>
-        <sirius.web>dev-54.2.0</sirius.web>
+        <sirius.web>dev-54.8.0</sirius.web>
         <sirius.db>dev-41.10.1</sirius.db>
     </properties>
 

--- a/src/main/java/sirius/biz/process/ProcessController.java
+++ b/src/main/java/sirius/biz/process/ProcessController.java
@@ -156,10 +156,8 @@ public class ProcessController extends BizController {
                                 Tuple.create("$ProcessController.sortAsc", qry -> qry.orderAsc(ProcessLog.SORT_KEY)));
         pageHelper.withSearchFields(QueryField.contains(ProcessLog.SEARCH_FIELD));
 
-        boolean isAutoRefreshEnabled = webContext.get("autoRefresh").asBoolean(true);
-
         webContext.respondWith()
-                  .template("/templates/biz/process/process-logs.html.pasta", process, pageHelper.asPage(), isAutoRefreshEnabled);
+                  .template("/templates/biz/process/process-logs.html.pasta", process, pageHelper.asPage());
     }
 
     /**

--- a/src/main/resources/default/templates/biz/process/process-logs.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-logs.html.pasta
@@ -1,23 +1,13 @@
 <i:arg type="sirius.biz.process.Process" name="process"/>
 <i:arg type="Page" name="logs"/>
-<i:arg type="boolean" name="autoRefresh"/>
 
 <i:invoke template="/templates/biz/process/process.html.pasta"
           process="process"
-          page="logs"
-          autoRefresh="autoRefresh">
+          page="logs">
     <i:block name="sidebar">
         <t:filterbox page="logs" baseUrl="@apply('/ps/%s', process.getId())"/>
     </i:block>
     <i:block name="header-actions">
-        <i:if test="process.shouldAutorefresh()">
-            <i:if test="autoRefresh">
-                <a id="disableAutoRefresh" class="btn btn-link" href="@apply('/ps/%s?autoRefresh=false', process.getId())">@i18n("Process.disableAutoRefresh")</a>
-                <i:else>
-                    <a id="enableAutoRefresh" class="btn btn-link" href="@apply('/ps/%s?autoRefresh=true', process.getId())">@i18n("Process.enableAutoRefresh")</a>
-                </i:else>
-            </i:if>
-        </i:if>
         <i:if test="process.getState() == sirius.biz.process.ProcessState.TERMINATED">
             <t:permission permission="permission-manage-processes">
                 <t:dropdown labelKey="Process.persistencePeriod"

--- a/src/main/resources/default/templates/biz/process/process.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process.html.pasta
@@ -22,7 +22,17 @@
                 </span>
             </i:block>
             <i:block name="actions">
-                <div>@page</div>
+                <i:if test="process.shouldAutorefresh()">
+                    <a id="disableAutoRefresh"
+                       class="btn btn-link d-none"
+                       href="#">
+                        @i18n("Process.disableAutoRefresh")
+                    </a>
+                    <a id="enableAutoRefresh"
+                       class="btn btn-link d-none"
+                       href="#">@i18n("Process.enableAutoRefresh")
+                    </a>
+                </i:if>
                 <i:render name="header-actions"/>
             </i:block>
             <i:block name="additionalActions">
@@ -148,8 +158,38 @@
     <i:if test="process.shouldAutorefresh()">
         <script type="text/javascript">
             sirius.ready(function () {
-                setTimeout(function () {
-                    window.location.reload();
+                let autoRefreshStorageVariableName = "ps.isAutoRefreshEnabled";
+                let isAutoRefreshEnabled = sirius.readLocalStore(autoRefreshStorageVariableName) === "true" ? true : false;
+
+                let _enableAutoRefresh = document.getElementById("enableAutoRefresh");
+                let _disableAutoRefresh = document.getElementById("disableAutoRefresh");
+
+                if (isAutoRefreshEnabled === true) {
+                    _disableAutoRefresh.classList.remove("d-none");
+                } else {
+                    _enableAutoRefresh.classList.remove("d-none");
+                }
+
+                _enableAutoRefresh.onclick = function (event) {
+                    event.preventDefault();
+                    isAutoRefreshEnabled = true;
+                    sirius.writeLocalStore(autoRefreshStorageVariableName, true);
+                    _enableAutoRefresh.classList.add("d-none");
+                    _disableAutoRefresh.classList.remove("d-none");
+                };
+
+                _disableAutoRefresh.onclick = function (event) {
+                    event.preventDefault();
+                    isAutoRefreshEnabled = false;
+                    sirius.writeLocalStore(autoRefreshStorageVariableName, false);
+                    _disableAutoRefresh.classList.add("d-none");
+                    _enableAutoRefresh.classList.remove("d-none");
+                };
+
+                setInterval(function () {
+                    if (isAutoRefreshEnabled === true) {
+                        window.location.reload();
+                    }
                 }, 5000);
             });
         </script>

--- a/src/main/resources/default/templates/biz/process/process.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process.html.pasta
@@ -1,6 +1,5 @@
 <i:arg type="sirius.biz.process.Process" name="process"/>
 <i:arg type="String" name="page"/>
-<i:arg type="boolean" name="autoRefresh"/>
 
 <t:page title="@process.getTitle()">
     <i:block name="breadcrumbs">
@@ -23,6 +22,7 @@
                 </span>
             </i:block>
             <i:block name="actions">
+                <div>@page</div>
                 <i:render name="header-actions"/>
             </i:block>
             <i:block name="additionalActions">
@@ -145,7 +145,7 @@
         <i:render name="body"/>
     </t:sidebar>
 
-    <i:if test="process.shouldAutorefresh() && autoRefresh">
+    <i:if test="process.shouldAutorefresh()">
         <script type="text/javascript">
             sirius.ready(function () {
                 setTimeout(function () {

--- a/src/main/resources/default/templates/biz/process/process.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process.html.pasta
@@ -158,11 +158,11 @@
     <i:if test="process.shouldAutorefresh()">
         <script type="text/javascript">
             sirius.ready(function () {
-                let autoRefreshStorageVariableName = "ps.isAutoRefreshEnabled";
+                const autoRefreshStorageVariableName = "sirius.ps.isAutoRefreshEnabled";
                 let isAutoRefreshEnabled = sirius.readLocalStore(autoRefreshStorageVariableName) === "true" ? true : false;
 
-                let _enableAutoRefresh = document.getElementById("enableAutoRefresh");
-                let _disableAutoRefresh = document.getElementById("disableAutoRefresh");
+                const _enableAutoRefresh = document.getElementById("enableAutoRefresh");
+                const _disableAutoRefresh = document.getElementById("disableAutoRefresh");
 
                 if (isAutoRefreshEnabled === true) {
                     _disableAutoRefresh.classList.remove("d-none");


### PR DESCRIPTION
The reimplementation was necessary due to the filter options which were also added to the url, based on whatever option was chosen within the process view on the left side panel.

Fixes: [SIRI-608](https://scireum.myjetbrains.com/youtrack/issue/SIRI-608/Process-Refresh-gn%C3%A4diger-machen)