### PR TITLE
SIRI-627: Fixes Icons for Pie Chart Jobs.

### DIFF
--- a/src/main/java/sirius/biz/jobs/interactive/DougnutChartJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/DougnutChartJobFactory.java
@@ -15,7 +15,7 @@ public abstract class DougnutChartJobFactory extends SingleDatasetChartJobFactor
 
     @Override
     public String getIcon() {
-        return "fa fa-pie-chart";
+        return "fas fa-chart-pie";
     }
 
     @Override

--- a/src/main/java/sirius/biz/jobs/interactive/PolarAreaChartJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/PolarAreaChartJobFactory.java
@@ -15,7 +15,7 @@ public abstract class PolarAreaChartJobFactory extends SingleDatasetChartJobFact
 
     @Override
     public String getIcon() {
-        return "fa fa-pie-chart";
+        return "fas fa-chart-pie";
     }
 
     @Override


### PR DESCRIPTION
The naming convention changed with Font Awesome 5.
In addition, the icon is declared as solid ("fas") to be inline with other interactive jobs.