### PR TITLE
Displays job icons correctly in wondergem

### DIFF
--- a/src/main/java/sirius/biz/jobs/JobFactory.java
+++ b/src/main/java/sirius/biz/jobs/JobFactory.java
@@ -51,6 +51,15 @@ public interface JobFactory extends Named, Priorized {
     String getIcon();
 
     /**
+     * Returns the icon to used when displaying this job in wondergem templates.
+     *
+     * @return the icon of this job
+     */
+    default String getLegacyIcon() {
+        return getIcon();
+    }
+
+    /**
      * Returns a short description of this job.
      * <p>
      * This is shown in lists and should therefore be quite concise.

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJobFactory.java
@@ -36,4 +36,9 @@ public abstract class LineBasedExportJobFactory extends FileExportJobFactory {
     public String getIcon() {
         return "far fa-file-excel";
     }
+
+    @Override
+    public String getLegacyIcon() {
+        return "fa-file-excel-o";
+    }
 }

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportJobFactory.java
@@ -38,6 +38,11 @@ public abstract class LineBasedImportJobFactory extends FileImportJobFactory {
     }
 
     @Override
+    public String getLegacyIcon() {
+        return "fa-file-excel-o";
+    }
+
+    @Override
     protected void collectParameters(Consumer<Parameter<?>> parameterCollector) {
         super.collectParameters(parameterCollector);
         parameterCollector.accept(LineBasedImportJob.IMPORT_ALL_SHEETS_PARAMETER);

--- a/src/main/resources/default/taglib/w/jobs.html.pasta
+++ b/src/main/resources/default/taglib/w/jobs.html.pasta
@@ -10,7 +10,7 @@
                 <i:local name="link" value="linkAndJob.getFirst().as(String.class)"/>
                 <i:local name="job" value="linkAndJob.getSecond().as(sirius.biz.jobs.JobFactory.class)"/>
 
-                <w:navboxLink icon="@job.getIcon()" label="@job.getLabel()" url="@link"/>
+                <w:navboxLink icon="@job.getLegacyIcon()" label="@job.getLabel()" url="@link"/>
             </i:for>
         </w:navbox>
     </i:if>


### PR DESCRIPTION
We still use the w:jobs templates which links pages to capable jobs, and there the icons have gone mad, especially when they no longer match the naming, eg: fa-file -> fa fa-file works, but fa-file-excel-o is no longer found.

Note that we cannot mark this method as deprecated as biz would refuse to compile and will remove this with a future ticket.

Fixes: [OX-9090](https://scireum.myjetbrains.com/youtrack/issue/OX-9090)