### PR TITLE
Restores fileparameter creating file logic

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/FileParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/FileParameter.java
@@ -168,7 +168,7 @@ public class FileParameter extends ParameterBuilder<VirtualFile, FileParameter> 
         }
 
         return Optional.ofNullable(vfs.resolve(input.asString()))
-                       .filter(VirtualFile::exists)
+                       .filter(file -> allowDirectories && allowFiles && file.parent().exists() || file.exists())
                        .filter(file -> allowDirectories || file.isFile())
                        .filter(file -> allowFiles || file.isDirectory());
     }


### PR DESCRIPTION
- was broken in refactoring
- now, with a fileparameter accepting files and directories, it will be enough to have an existing parent directory, and the file will be created if missing
- see former implementation here: https://github.com/scireum/sirius-biz/blob/13b2fea363a58d9aa395748b4a00eae3886ceed6/src/main/java/sirius/biz/storage/layer3/FileOrDirectoryParameter.java

Fixes: https://scireum.myjetbrains.com/youtrack/issue/SE-12064