### PR TITLE
Don't override security config arrays from other conf files

### DIFF
--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1336,14 +1336,13 @@ security {
     }
 
     # Defines all roles known by the system. This can be redefined by the application.
-    roles = [ "system-administrator", "user-administrator", "administrator", "jobs-manager", "jobs-execution", "file-manager" ]
+    roles = ${?security.roles} [ "system-administrator", "user-administrator", "administrator", "jobs-manager", "jobs-execution", "file-manager" ]
 
     # Defines all sub scopes known by the system. This can be redefined by the application.
-    subScopes = [ "ui", "api", "vfs", "empty" ]
+    subScopes = ${?security.subScopes} [ "ui", "api", "vfs", "empty" ]
 
     # Defines all tenant permissions (aka features). This also can be redefined by the application.
-    tenantPermissions = [
-    ]
+    tenantPermissions = ${?security.tenantPermissions} [ ]
 
     profiles {
 

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1336,13 +1336,14 @@ security {
     }
 
     # Defines all roles known by the system. This can be redefined by the application.
-    roles = ${?security.roles} [ "system-administrator", "user-administrator", "administrator", "jobs-manager", "jobs-execution", "file-manager" ]
+    roles = ${?security.roles} ["system-administrator", "user-administrator", "administrator", "jobs-manager", "jobs-execution", "file-manager"]
 
     # Defines all sub scopes known by the system. This can be redefined by the application.
-    subScopes = ${?security.subScopes} [ "ui", "api", "vfs", "empty" ]
+    subScopes = ${?security.subScopes} ["ui", "api", "vfs", "empty"]
 
     # Defines all tenant permissions (aka features). This also can be redefined by the application.
-    tenantPermissions = ${?security.tenantPermissions} [ ]
+    # Init to an empty array, in case it is not redefined somewhere else
+    tenantPermissions = ${?security.tenantPermissions} []
 
     profiles {
 


### PR DESCRIPTION
When merging multiple config files, HOCON does merge objects, but not arrays. When you specify an array for e.g. security.roles in another component-<sth>.conf file, it is randomly chosen which one is loaded first. So: If a value was already loaded, we should merge it, instead of overriding it.