### PR TITLE
Initializes limits in standby processes

### DIFF
--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -210,11 +210,10 @@ class ProcessEnvironment implements ProcessContext {
         if (Strings.isFilled(logEntry.getMessageType()) && logEntry.getMaxMessagesToLog() > 0) {
             AtomicInteger messagesSoFar =
                     messageCountsPerType.computeIfAbsent(logEntry.getMessageType(), this::countMessagesForType);
+            limitsPerType.putIfAbsent(logEntry.getMessageType(), logEntry.getMaxMessagesToLog());
             if (messagesSoFar.incrementAndGet() > logEntry.getMaxMessagesToLog()) {
                 return;
             }
-
-            limitsPerType.put(logEntry.getMessageType(), logEntry.getMaxMessagesToLog());
         }
 
         processes.log(processId, logEntry);


### PR DESCRIPTION
- their, the message count from previous executions in the same process might already exist
- but still we need to know the limit to generate the limit reached message at the end
