### PR TITLE
ClickHouse: Properly formats SQL Arrays in SQL Query Tool

### DIFF
--- a/src/main/java/sirius/biz/jdbc/DatabaseController.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseController.java
@@ -38,6 +38,7 @@ import sirius.web.services.InternalService;
 import sirius.web.services.JSONStructuredOutput;
 
 import javax.annotation.Nullable;
+import java.sql.Array;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
@@ -238,6 +239,14 @@ public class DatabaseController extends BasicController {
 
         if (value.getClass().isArray()) {
             return Arrays.stream((Object[]) value).map(NLS::toUserString).collect(Collectors.joining(", "));
+        }
+
+        if (value instanceof Array sqlArrayValue) {
+            try {
+                return Arrays.stream((Object[]) sqlArrayValue.getArray()).map(NLS::toUserString).collect(Collectors.joining(", "));
+            } catch (SQLException e) {
+                Exceptions.ignore(e);
+            }
         }
 
         return NLS.toUserString(value);


### PR DESCRIPTION
SQL Arrays don't recognize as real native Arrays in Java so we have to handle them separately. This will print out array fields in ClickHouse Events properly.

### Before

![image](https://user-images.githubusercontent.com/2427877/191926656-8e0eb4ca-2ec9-458f-9415-f2856946d861.png)


### After

![image](https://user-images.githubusercontent.com/2427877/191926111-74d5e67c-ad82-44b1-857a-50ea2994f248.png)


Fixes: SIRI-637