### PR TITLE
Permits to load groups of CSV files in stages

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -167,7 +167,7 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
 
             for (ImportFile importFile : importFiles) {
                 if (!TaskContext.get().isActive()) {
-                    break;
+                    return;
                 }
                 Optional<ExtractedFile> extractedFile = fetchEntry(importFile.filename);
                 if (extractedFile.isPresent()) {


### PR DESCRIPTION
This is _cloning_ the existing approach used by the XMLImportJob.

By default, `collectImportFiles()` functions as before and provides a list of files to collect.

If desired though, several stages can be defined, each loading a different set of files. For example: a header file is processed first and based on its contents, a different set will be processed later.

Fixes: [OX-9070](https://scireum.myjetbrains.com/youtrack/issue/OX-9070)