### PR TITLE
Adds suggested dependency to suppress a warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
             <version>1.12.272</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>


### PR DESCRIPTION
`WARNING [com.amazonaws.util.Base64 - com.amazonaws.log.CommonsLog] JAXB is unavailable. Will fallback to SDK implementation which may be less performant.If you are using Java 9+, you will need to include javax.xml.bind:jaxb-api as a dependency.`

Fixes: [OX-9206](https://scireum.myjetbrains.com/youtrack/issue/OX-9206)