### PR TITLE
some cosmetics in log & footer for tycho

### DIFF
--- a/src/main/resources/default/extensions/tycho-page-menu/footer.html.pasta
+++ b/src/main/resources/default/extensions/tycho-page-menu/footer.html.pasta
@@ -12,7 +12,7 @@
             </i:invoke>
         </t:permission>
         <t:permission permission="flag-logged-in">
-            <span class="d-none d-xl-inline-block text-muted small mr-2 pr-2 br-gray">
+            <span class="d-none d-xl-inline-block text-muted small ml-2 pl-2 bl-gray">
                <b>@currentUserName()</b>
                <i:if test="isFilled(user().getTenantName())">(@user().getTenantName())</i:if>
             </span>

--- a/src/main/resources/default/templates/biz/protocol/audit_logs.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/audit_logs.html.pasta
@@ -51,7 +51,7 @@
                                         </div>
                                         <div class="col-md-4 text-small text-muted">@message.getIp()</div>
                                     </div>
-                                    <pre class="pt-2 mb-0" style="white-space: break-spaces">@i18n(message.getMessage())</pre>
+                                    <pre class="pt-2 mb-0" style="white-space: break-spaces; overflow-wrap: anywhere;">@i18n(message.getMessage())</pre>
                                 </td>
                             </tr>
                         </i:for>

--- a/src/main/resources/default/templates/biz/protocol/entity_protocol.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/entity_protocol.html.pasta
@@ -52,7 +52,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12 pt-2">
-                                            <pre class="mb-0" style="white-space: break-spaces">@message.getChanges()</pre>
+                                            <pre class="mb-0" style="white-space: break-spaces; overflow-wrap: anywhere;">@message.getChanges()</pre>
                                         </div>
                                     </div>
                                 </td>

--- a/src/main/resources/default/templates/biz/protocol/errors.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/errors.html.pasta
@@ -62,8 +62,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12 error-code">
-                                            <pre class="mb-0 pt-2"
-                                                 style="white-space: break-spaces;">@i.getMessage()</pre>
+                                            <pre class="mb-0 pt-2" style="white-space: break-spaces; overflow-wrap: anywhere;">@i.getMessage()</pre>
                                         </div>
                                     </div>
                                 </td>

--- a/src/main/resources/default/templates/biz/protocol/logs.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/logs.html.pasta
@@ -45,7 +45,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12 pt-2">
-                                            <pre class="mb-0" style="white-space: break-spaces">@message.getMessage()</pre>
+                                            <pre class="mb-0" style="white-space: break-spaces; overflow-wrap: anywhere;">@message.getMessage()</pre>
                                         </div>
                                     </div>
                                 </td>

--- a/src/main/resources/default/templates/biz/protocol/mails.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/mails.html.pasta
@@ -48,7 +48,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12 pt-2">
-                                            <pre class="mb-0" style="white-space: break-spaces">@mail.getSubject()</pre>
+                                            <pre class="mb-0" style="white-space: break-spaces; overflow-wrap: anywhere;">@mail.getSubject()</pre>
                                         </div>
                                     </div>
                                 </td>

--- a/src/main/resources/default/templates/biz/protocol/protocol.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/protocol.html.pasta
@@ -67,7 +67,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12 pt-2">
-                                            <pre class="mb-0" style="white-space: break-spaces;">@message.getChanges()</pre>
+                                            <pre class="mb-0" style="white-space: break-spaces; overflow-wrap: anywhere;">@message.getChanges()</pre>
                                         </div>
                                     </div>
                                 </td>

--- a/src/main/resources/default/templates/biz/tycho/page-footer-help.html.pasta
+++ b/src/main/resources/default/templates/biz/tycho/page-footer-help.html.pasta
@@ -2,7 +2,7 @@
 <i:local name="navbox" value="renderToString('navbox')"/>
 
 <i:if test="isFilled(contents) || isFilled(navbox)">
-     <span class="text-muted small mr-2 pr-2 br-gray dropup" id="tycho-page-help-dropdown">
+     <span class="text-muted small dropup" id="tycho-page-help-dropdown">
         <a class="btn btn-primary"
            data-toggle="dropdown"
            style="padding: 0.20rem .5rem;font-size: 0.75rem;line-height: 1.25;border-radius: .2rem;"


### PR DESCRIPTION
before:
<img width="1316" alt="Bildschirmfoto 2022-10-24 um 12 10 14" src="https://user-images.githubusercontent.com/55080004/197502998-6710023d-187d-4141-94c9-38226d14af6f.png">

after: 
<img width="1080" alt="Bildschirmfoto 2022-10-24 um 12 05 34" src="https://user-images.githubusercontent.com/55080004/197502247-09d41bf6-af55-47ad-b47c-11bc01321ece.png">

long exception-paths break now to not have a scollbar without header. The Footer is consistent for all widths without the small border before

relates to https://github.com/scireum/sirius-web/pull/1118