### PR TITLE
Handles uploading input streams with no contents

### DIFF
--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -731,9 +731,7 @@ public class ObjectStore {
                                                                                    multipartUpload.getUploadId(),
                                                                                    eTags));
         } catch (Exception e) {
-            getClient().abortMultipartUpload(new AbortMultipartUploadRequest(bucket.getName(),
-                                                                             objectId,
-                                                                             multipartUpload.getUploadId()));
+            abortMultipartUpload(bucket, objectId, multipartUpload);
             if (e instanceof InterruptedIOException || e.getCause() instanceof InterruptedIOException) {
                 throw Exceptions.createHandled()
                                 .error(e)
@@ -750,6 +748,14 @@ public class ObjectStore {
                                                     bucket.getName())
                             .handle();
         }
+    }
+
+    private void abortMultipartUpload(BucketName bucket,
+                                      String objectId,
+                                      InitiateMultipartUploadResult multipartUpload) {
+        getClient().abortMultipartUpload(new AbortMultipartUploadRequest(bucket.getName(),
+                                                                         objectId,
+                                                                         multipartUpload.getUploadId()));
     }
 
     @Nonnull


### PR DESCRIPTION
It is possible to load 0-byte files, but not using a multipart upload, which cannot be completed if no eTags were generated for each chunk loaded.

Fixes: [SIRI-651](https://scireum.myjetbrains.com/youtrack/issue/SIRI-651)