### PR TITLE
Fixes falsely altered border colors in logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>dev-33.2.1</sirius.kernel>
-        <sirius.web>dev-57.6.0</sirius.web>
+        <sirius.web>dev-57.7.0</sirius.web>
         <sirius.db>dev-45.2.1</sirius.db>
     </properties>
 

--- a/src/main/java/sirius/biz/protocol/LoggedMessage.java
+++ b/src/main/java/sirius/biz/protocol/LoggedMessage.java
@@ -72,15 +72,15 @@ public class LoggedMessage extends SearchableEntity {
      */
     public String getRowClass() {
         if ("ERROR".equals(getLevel())) {
-            return "border-sirius-red";
+            return "sci-left-border-red";
         }
         if ("WARN".equals(getLevel())) {
-            return "border-sirius-yellow";
+            return "sci-left-border-yellow";
         }
         if ("DEBUG".equals(getLevel())) {
-            return "border-sirius-gray";
+            return "sci-left-border-gray";
         }
-        return "border-sirius-blue";
+        return "sci-left-border-blue";
     }
 
     public String getMessage() {

--- a/src/main/resources/default/assets/scripts/lookup-tables.js.pasta
+++ b/src/main/resources/default/assets/scripts/lookup-tables.js.pasta
@@ -72,10 +72,10 @@ LookupTableInfo.prototype.ENTRY_TEMPLATE = '<td>' +
     '</div>' +
     '{{#description}}<div class="text-small text-muted mt-2">{{description}}</div>{{/description}}' +
     '{{#source}}' +
-    '   <div class="whitespace-pre-wrap text-monospace text-small left-border border-sirius-blue-dark pl-2 pr-2 mt-1 source-js d-none">{{source}}</div>' +
+    '   <div class="whitespace-pre-wrap text-monospace text-small sci-left-border--blue-dark pl-2 pr-2 mt-1 source-js d-none">{{source}}</div>' +
     '{{/source}}' +
     '{{#deprecated}}' +
-    '   <div class="text-small left-border border-sirius-yellow pl-2 pr-2 mt-2">@i18n("LookupTableController.deprecated")</div>' +
+    '   <div class="text-small sci-left-border-yellow border-sirius-yellow pl-2 pr-2 mt-2">@i18n("LookupTableController.deprecated")</div>' +
     '{{/deprecated}}' +
     '</td>';
 

--- a/src/main/resources/default/assets/scripts/lookup-tables.js.pasta
+++ b/src/main/resources/default/assets/scripts/lookup-tables.js.pasta
@@ -72,7 +72,7 @@ LookupTableInfo.prototype.ENTRY_TEMPLATE = '<td>' +
     '</div>' +
     '{{#description}}<div class="text-small text-muted mt-2">{{description}}</div>{{/description}}' +
     '{{#source}}' +
-    '   <div class="whitespace-pre-wrap text-monospace text-small sci-left-border--blue-dark pl-2 pr-2 mt-1 source-js d-none">{{source}}</div>' +
+    '   <div class="whitespace-pre-wrap text-monospace text-small sci-left-border-blue-dark pl-2 pr-2 mt-1 source-js d-none">{{source}}</div>' +
     '{{/source}}' +
     '{{#deprecated}}' +
     '   <div class="text-small sci-left-border-yellow border-sirius-yellow pl-2 pr-2 mt-2">@i18n("LookupTableController.deprecated")</div>' +

--- a/src/main/resources/default/templates/biz/model/schema.html.pasta
+++ b/src/main/resources/default/templates/biz/model/schema.html.pasta
@@ -42,17 +42,17 @@
             '<tbody id="schemaList">' +
             '   {{#changes}}' +
             '       <tr id="{{id}}">' +
-            '       <td class="left-border ' +
+            '       <td class="' +
             '{{#executed}}' +
             '{{#failed}}' +
-            'border-sirius-red ' +
+            'sci-left-border-red ' +
             '{{/failed}}' +
             '{{^failed}}' +
-            'border-sirius-green ' +
+            'sci-left-border-green ' +
             '{{/failed}}' +
             '{{/executed}}' +
             '{{#dataLossPossible}}' +
-            'border-sirius-yellow ' +
+            'sci-left-border-yellow ' +
             '{{/dataLossPossible}}' +
             '">' +
             '       <div class="overflow-hidden text-small text-break whitespace-pre-line">' +

--- a/src/main/resources/default/templates/biz/process/process-logs.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-logs.html.pasta
@@ -55,7 +55,7 @@
                     <tbody>
                     <i:for type="sirius.biz.process.logs.ProcessLog" var="log" items="logs.getItems()">
                         <tr>
-                            <td class="left-border border-sirius-@log.getRowColor()">
+                            <td class="sci-left-border-@log.getRowColor()">
                                 <div class="overflow-hidden text-monospace text-small text-break whitespace-pre-line">
                                     @log.getMessage()
                                 </div>

--- a/src/main/resources/default/templates/biz/process/process-output-logs.html.pasta
+++ b/src/main/resources/default/templates/biz/process/process-output-logs.html.pasta
@@ -43,7 +43,7 @@
                     <tbody>
                     <i:for type="sirius.biz.process.logs.ProcessLog" var="log" items="logs.getItems()">
                         <tr>
-                            <td class="left-border border-sirius-@log.getRowColor()">
+                            <td class="sci-left-border-@log.getRowColor()">
                                 <div class="whitespace-pre-wrap overflow-hidden text-monospace text-small">@log.getMessage()</div>
                             </td>
                             <td class="text-right">

--- a/src/main/resources/default/templates/biz/protocol/audit_logs.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/audit_logs.html.pasta
@@ -39,7 +39,7 @@
                         <tbody>
                         <i:for type="sirius.biz.protocol.AuditLogEntry" var="message" items="messages.getItems()">
                             <tr>
-                                <td class="left-border @if (message.isNegative()) { border-sirius-yellow } else { border-sirius-blue }">
+                                <td class="@if (message.isNegative()) { sci-left-border-yellow } else { sci-left-border-blue }">
                                     <div class="row">
                                         <div class="col-md-4 text-small text-muted">
                                             <div>@toUserString(message.getTimestamp())</div>

--- a/src/main/resources/default/templates/biz/protocol/logs.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/logs.html.pasta
@@ -36,7 +36,7 @@
                         <tbody>
                         <i:for type="sirius.biz.protocol.LoggedMessage" var="message" items="logs.getItems()">
                             <tr>
-                                <td class="left-border @message.getRowClass()">
+                                <td class="@message.getRowClass()">
                                     <div class="row">
                                         <div class="col-md-3 text-muted text-small">@toUserString(message.getTod())</div>
                                         <div class="col-md-3 text-muted text-small">@message.getCategory()</div>

--- a/src/main/resources/default/templates/biz/protocol/mails.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/mails.html.pasta
@@ -37,7 +37,7 @@
                         <tbody>
                         <i:for type="sirius.biz.protocol.MailProtocol" var="mail" items="mails.getItems()">
                             <tr>
-                                <td class="left-border @if (mail.isSuccess()) { border-sirius-green } else { border-sirius-red }">
+                                <td class="@if (mail.isSuccess()) { sci-left-border-green } else { sci-left-border-red }">
                                     <div class="row">
                                         <div class="col-md-3">
                                             <a href="/system/mail/@mail.getId()">@toUserString(mail.getTod())</a>


### PR DESCRIPTION
Since border-sirius colors are now `!important`, in some combinations they overwrite other borders unintentionally, e.g. in logs:
![Bildschirm­foto 2022-11-10 um 11 25 20](https://user-images.githubusercontent.com/42942954/201066542-a77faaaa-190e-4add-a94c-7913342dab9e.png)

Solves this issue by using the new left-border color styles from https://github.com/scireum/sirius-web/pull/1124:
![Bildschirm­foto 2022-11-10 um 11 24 33](https://user-images.githubusercontent.com/42942954/201066568-c0c94b82-87ca-42d4-8bce-eccdd4bcf106.png)
