### PR TITLE
Method Namespace

### DIFF
--- a/src/main/resources/default/assets/scripts/images.js
+++ b/src/main/resources/default/assets/scripts/images.js
@@ -39,7 +39,7 @@ function loadImageSafely(_img) {
     _img.onerror = function () {
         _img.dataset.src = _img.getAttribute('src');
         _img.setAttribute('src', _img.dataset.fallback);
-        sirius.loadImageLazily(_img);
+        loadImageLazily(_img);
     };
 }
 


### PR DESCRIPTION
Considering the entire file, I believe that the method invocation should not include the `sirius` namespace.