### PR TITLE
Possible Fix: Freezing Log Export (SIRI-645)

### DIFF
--- a/src/main/java/sirius/biz/process/ExportLogsAsFileTaskExecutor.java
+++ b/src/main/java/sirius/biz/process/ExportLogsAsFileTaskExecutor.java
@@ -24,6 +24,7 @@ import sirius.db.es.Elastic;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
+import sirius.kernel.commons.Wait;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
@@ -84,6 +85,9 @@ public class ExportLogsAsFileTaskExecutor implements DistributedTaskExecutor {
 
     @Override
     public void executeWork(JSONObject context) throws Exception {
+        // we need to wait for elastic to propagate process state changes if running on a different machine
+        Wait.seconds(2);
+
         processes.execute(context.getString(CONTEXT_PROCESS), process -> executeInProcess(context, process));
     }
 

--- a/src/main/java/sirius/biz/process/ExportLogsAsFileTaskExecutor.java
+++ b/src/main/java/sirius/biz/process/ExportLogsAsFileTaskExecutor.java
@@ -24,7 +24,6 @@ import sirius.db.es.Elastic;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
-import sirius.kernel.commons.Wait;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
@@ -85,9 +84,6 @@ public class ExportLogsAsFileTaskExecutor implements DistributedTaskExecutor {
 
     @Override
     public void executeWork(JSONObject context) throws Exception {
-        // we need to wait for elastic to propagate process state changes if running on a different machine
-        Wait.seconds(2);
-
         processes.execute(context.getString(CONTEXT_PROCESS), process -> executeInProcess(context, process));
     }
 

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -209,6 +209,9 @@ public class Processes {
                process -> process.getState() == ProcessState.TERMINATED,
                process -> process.setState(ProcessState.RUNNING));
         log(processId, ProcessLog.info().withNLSKey("Processes.restarted").withContext("reason", reason));
+
+        // we need to wait for elastic to propagate process state changes if running on a different machine
+        Wait.seconds(2);
     }
 
     /**

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -1041,6 +1041,7 @@ VirtualFile.loadFromUrlDisabled = Datei-Download deaktiviert
 VirtualFile.loadFromUrlFailed = Datei-Download fehlgeschlagen
 VirtualFile.noDirectory = '${file}' ist kein Verzeichnis.
 VirtualFile.noFile = '${file}' ist keine Datei.
+VirtualFile.onlyOneFile = Es kann nur eine Datei gleichzeitig hochgeladen werden.
 VirtualFile.size = Größe
 VirtualFileExtractionJob.destinationParameter = Zielverzeichnis
 VirtualFileSystem.invalidPath = Der Pfad ist ungültig und kann nicht aufgelöst werden: ${path}


### PR DESCRIPTION
**Replaces #1533**

> [SIRI-645](https://scireum.myjetbrains.com/youtrack/issue/SIRI-645)

When exporting the job log, the previously `TERMINATED` process is restarted. This causes the machine serving the request to update the process state to `ACTIVE` again. This change takes some time, at most two seconds, to propagate to all connected machines. (Eventual consistency.) During that time, via Redis, execution of the export task may already be triggered on a second machine. This one checks whether the task is really marked `ACTIVE` — which may not be the case yet, leading to no further activity. The new delay is long enough to make sure that all Elastic changes have propagated before execution is even attempted.