### PR TITLE
Fixes permission for 'system-wide user interaction chart'

### DIFF
--- a/src/main/java/sirius/biz/tenants/metrics/NumberOfUserInteractionsChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/NumberOfUserInteractionsChart.java
@@ -44,7 +44,7 @@ public class NumberOfUserInteractionsChart extends TimeSeriesChartFactory<Object
     @Override
     public boolean isAccessibleToCurrentUser() {
         UserInfo currentUser = UserContext.getCurrentUser();
-        return currentUser.hasPermission(UserAccountController.getUserManagementPermission());
+        return super.isAccessibleToCurrentUser() && currentUser.hasPermission(UserAccountController.getUserManagementPermission());
     }
 
     @Nullable


### PR DESCRIPTION
Fixes: [OX-9339](https://scireum.myjetbrains.com/youtrack/issue/OX-9339/DataExplorer-Verf%C3%BCgbare-Charts-unklar)