### PR TITLE
Only links to job in process when job can be started via UI

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
@@ -164,8 +164,11 @@ public abstract class BatchProcessJobFactory extends BasicJobFactory {
      * @param processId the id of the process which has been created
      */
     protected void addLinkToJob(String processId) {
-        processes.addLink(processId,
-                          new ProcessLink().withLabel("$BatchProcessJobFactory.jobLink").withUri("/job/" + getName()));
+        if (canStartInteractive()) {
+            processes.addLink(processId,
+                              new ProcessLink().withLabel("$BatchProcessJobFactory.jobLink")
+                                               .withUri("/job/" + getName()));
+        }
     }
 
     private void createAndScheduleDistributedTask(String processId) {


### PR DESCRIPTION
In cases where the job is not interactive startable we don't want to guide the user towards the form UI of the job.

Fixes: [SIRI-667](https://scireum.myjetbrains.com/youtrack/issue/SIRI-667)