### PR TITLE
Corrects variable type of line chart datasets

### DIFF
--- a/src/main/resources/default/templates/biz/jobs/linechart.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/linechart.html.pasta
@@ -17,8 +17,9 @@
     <script type="text/javascript">
             sirius.ready(function () {
                 const datasets = [];
+                let dataset;
                 @for(sirius.biz.analytics.charts.Dataset dataset : datasets) {
-                    const dataset = { label: '@dataset.getLabel()',
+                    dataset = { label: '@dataset.getLabel()',
                         data: [ @raw { @dataset.renderData() } ],
                         axis: @raw { @dataset.renderAxisName() }};
                     @if (dataset.isGray()) {


### PR DESCRIPTION
These are overwritten when multiple datasets are present. Which is not possible with a const variable for obvious reasons.

Fixes: [SIRI-668](https://scireum.myjetbrains.com/youtrack/issue/SIRI-668)