### PR TITLE
Adds separate metric for number of delayed replication tasks

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskStorage.java
@@ -70,6 +70,13 @@ public interface ReplicationTaskStorage {
     int countTotalNumberOfTasks();
 
     /**
+     * Computes the number of delayed / parked replication tasks.
+     *
+     * @return the number of delayed / parked replication tasks
+     */
+    int countNumberOfDelayedTasks();
+
+    /**
      * Computes the number of executable replication tasks.
      *
      * @return the number of executable replication tasks

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
@@ -119,6 +119,14 @@ public class SQLReplicationTaskStorage
     }
 
     @Override
+    public int countNumberOfDelayedTasks() {
+        return (int) oma.select(SQLReplicationTask.class)
+                        .eq(SQLReplicationTask.FAILED, false)
+                        .where(OMA.FILTERS.gte(SQLReplicationTask.EARLIEST_EXECUTION, LocalDateTime.now()))
+                        .count();
+    }
+
+    @Override
     public int countNumberOfExecutableTasks() {
         return (int) oma.select(SQLReplicationTask.class)
                         .eq(SQLReplicationTask.FAILED, false)

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
@@ -125,6 +125,14 @@ public class MongoReplicationTaskStorage
     }
 
     @Override
+    public int countNumberOfDelayedTasks() {
+        return (int) mango.select(MongoReplicationTask.class)
+                          .eq(MongoReplicationTask.FAILED, false)
+                          .where(QueryBuilder.FILTERS.gte(MongoReplicationTask.EARLIEST_EXECUTION, LocalDateTime.now()))
+                          .count();
+    }
+
+    @Override
     public int countNumberOfExecutableTasks() {
         return (int) mango.select(MongoReplicationTask.class)
                           .eq(MongoReplicationTask.FAILED, false)

--- a/src/main/java/sirius/biz/storage/util/StorageMetrics.java
+++ b/src/main/java/sirius/biz/storage/util/StorageMetrics.java
@@ -101,6 +101,9 @@ public class StorageMetrics extends CachingLoadInfoProvider implements MetricPro
             consumer.accept(new LoadInfo("storage-total-replication-tasks",
                                          "Total Replication Tasks",
                                          replicationTaskStorage.countTotalNumberOfTasks()));
+            consumer.accept(new LoadInfo("storage-delayed-replication-tasks",
+                                         "Delayed / Parked Replication Tasks",
+                                         replicationTaskStorage.countNumberOfDelayedTasks()));
             consumer.accept(new LoadInfo("storage-executable-replication-tasks",
                                          "Executable Replication Tasks",
                                          replicationTaskStorage.countNumberOfExecutableTasks()));


### PR DESCRIPTION
This metric is not really necessary as those are already represented by the difference between the total number of tasks and the number of executable tasks. But it helps to further explain that a high number of total tasks may be expected as delete tasks are delayed for a set number of days. These are not actual replications (like backing up an uploaded file) but rather deletions of the backed up file after a file is deleted in the main storage space.

Fixes: SIRI-672