### PR TITLE
SIRI-678: Increases the size of the 'name' column for Facts.

### DIFF
--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/Fact.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/Fact.java
@@ -41,7 +41,7 @@ public class Fact extends SQLEntity {
      * Contains the name of the metric.
      */
     public static final Mapping NAME = Mapping.named("name");
-    @Length(50)
+    @Length(255)
     private String name;
 
     /**

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/Fact.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/Fact.java
@@ -44,7 +44,7 @@ public class Fact extends MongoEntity {
      * Contains the name of the metric.
      */
     public static final Mapping NAME = Mapping.named("name");
-    @Length(50)
+    @Length(255)
     private String name;
 
     /**


### PR DESCRIPTION
In most cases, 50 characters are enough as the field mostly contains fixed size strings for a given entity type and id. In special cases however, an entity might have multiple statistics of the same type, but for specific "sub categories". The name then consists of type + identifier of the "sub category". If the sub category doesn't have an ID and is instead only identifiable by a label or name of some sort, the total name may exceed the 50 character limit.

Performance: On a system with 136990 monthly metrics, the change of the field length took 1.265 seconds.