### PR TITLE
Doesn't swallow exceptions in the completion handling of watchable streams

### DIFF
--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -401,7 +401,7 @@ class ProcessEnvironment implements ProcessContext {
         zipOutputStream.putNextEntry(new ZipEntry(filename));
 
         WatchableOutputStream outputStream = new WatchableOutputStream(new UncloseableOutputStream(zipOutputStream));
-        outputStream.getCompletionFuture().onSuccess(() -> {
+        outputStream.onSuccess(() -> {
             try {
                 zipOutputStream.closeEntry();
                 zipOutputStream.close();

--- a/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplink.java
@@ -367,10 +367,8 @@ public class SFTPUplink extends ConfigBasedUplink {
             UplinkConnector<SftpClient> connector = connectorPool.obtain(sftpConfig);
             try {
                 InputStream rawStream = connector.connector().read(path);
-                WatchableInputStream watchableInputStream = new WatchableInputStream(rawStream);
-                watchableInputStream.getCompletionFuture().then(connector::safeClose);
 
-                return watchableInputStream;
+                return new WatchableInputStream(rawStream).onCompletion(connector::safeClose);
             } catch (Exception e) {
                 connector.safeClose();
                 if (attempt.shouldThrow(e)) {
@@ -395,10 +393,8 @@ public class SFTPUplink extends ConfigBasedUplink {
             UplinkConnector<SftpClient> connector = connectorPool.obtain(sftpConfig);
             try {
                 OutputStream rawStream = connector.connector().write(path);
-                WatchableOutputStream watchableOutputStream = new WatchableOutputStream(rawStream);
-                watchableOutputStream.getCompletionFuture().then(connector::safeClose);
 
-                return watchableOutputStream;
+                return new WatchableOutputStream(rawStream).onCompletion(connector::safeClose);
             } catch (Exception e) {
                 connector.safeClose();
                 if (attempt.shouldThrow(e)) {

--- a/src/main/java/sirius/biz/storage/util/StorageUtils.java
+++ b/src/main/java/sirius/biz/storage/util/StorageUtils.java
@@ -238,7 +238,7 @@ public class StorageUtils {
     public OutputStream createLocalBuffer(Consumer<File> dataConsumer) throws IOException {
         File bufferFile = File.createTempFile("local-file-buffer", null);
         WatchableOutputStream out = new WatchableOutputStream(new FileOutputStream(bufferFile));
-        out.getCompletionFuture().onFailure(error -> {
+        out.onFailure(error -> {
             Files.delete(bufferFile);
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
@@ -246,7 +246,7 @@ public class StorageUtils {
                             .withSystemErrorMessage("An error occurred while writing to a temporary buffer: %s (%s)")
                             .handle();
         });
-        out.getCompletionFuture().onSuccess(() -> {
+        out.onSuccess(() -> {
             try {
                 dataConsumer.accept(bufferFile);
             } finally {

--- a/src/main/java/sirius/biz/storage/util/WatchableInputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableInputStream.java
@@ -101,7 +101,7 @@ public class WatchableInputStream extends InputStream {
     }
 
     /**
-     * Adds a completion handler to this stream which is executed only if closing the stream is successful.
+     * Sets the completion handler to this stream which is executed only if closing the stream is successful.
      *
      * @param successHandler the handler to be executed once the stream is successfully closed
      * @return <tt>this</tt> for fluent method chaining
@@ -116,7 +116,7 @@ public class WatchableInputStream extends InputStream {
     }
 
     /**
-     * Adds a completion handler to this stream which is executed only if closing the stream fails.
+     * Sets the completion handler to this stream which is executed only if closing the stream fails.
      * <p>
      * The original exception will be thrown, if this handler doesn't throw its own exception.
      *
@@ -133,7 +133,7 @@ public class WatchableInputStream extends InputStream {
     }
 
     /**
-     * Adds a completion handler to this stream which is executed when the stream is closed.
+     * Installs a completion handler to this stream which is executed when the stream is closed.
      * <p>
      * In case of a failure, the original exception will be thrown, if this handler doesn't throw its own exception.
      *

--- a/src/main/java/sirius/biz/storage/util/WatchableInputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableInputStream.java
@@ -26,7 +26,7 @@ public class WatchableInputStream extends InputStream {
     private final InputStream delegate;
     private Runnable successHandler;
     private Consumer<Throwable> failureHandler;
-    private boolean closeHandled = false;
+    private volatile boolean closeHandled = false;
 
     /**
      * Creates a new stream which wraps and delegates all calls to the given one.

--- a/src/main/java/sirius/biz/storage/util/WatchableInputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableInputStream.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Wraps an {@link InputStream} and provides a {@link Future completion future}.
@@ -23,7 +24,9 @@ import java.util.Objects;
 public class WatchableInputStream extends InputStream {
 
     private final InputStream delegate;
-    private final Future completionFuture;
+    private Runnable successHandler;
+    private Consumer<Throwable> failureHandler;
+    private boolean closeHandled = false;
 
     /**
      * Creates a new stream which wraps and delegates all calls to the given one.
@@ -33,7 +36,6 @@ public class WatchableInputStream extends InputStream {
     public WatchableInputStream(@Nonnull InputStream delegate) {
         Objects.requireNonNull(delegate, "null was passed into a WatchableInputStream");
         this.delegate = delegate;
-        this.completionFuture = new Future();
     }
 
     @Override
@@ -80,26 +82,71 @@ public class WatchableInputStream extends InputStream {
     public void close() throws IOException {
         try {
             delegate.close();
-
-            // Filter duplicate completions...
-            if (!completionFuture.isCompleted()) {
-                completionFuture.success();
-            }
         } catch (IOException e) {
-            // Filter duplicate completions...
-            if (!completionFuture.isCompleted()) {
-                completionFuture.fail(e);
+            // Close might be invoked several times (e.g. by some ZIP implementations).
+            // Therefore, we filter this to only execute the handler once.
+            if (failureHandler != null && !closeHandled) {
+                closeHandled = true;
+                failureHandler.accept(e);
             }
+
             throw e;
+        }
+
+        // Filter duplicate executions (s.a.)...
+        if (successHandler != null && !closeHandled) {
+            closeHandled = true;
+            successHandler.run();
         }
     }
 
     /**
-     * Provides the completion future which is fullfilled once the stream is closed.
+     * Adds a completion handler to this stream which is executed only if closing the stream is successful.
      *
-     * @return the completion future of this stream
+     * @param successHandler the handler to be executed once the stream is successfully closed
+     * @return <tt>this</tt> for fluent method chaining
      */
-    public Future getCompletionFuture() {
-        return completionFuture;
+    public WatchableInputStream onSuccess(@Nonnull final Runnable successHandler) {
+        if (this.successHandler != null) {
+            throw new UnsupportedOperationException("Only one success handler can be specified");
+        }
+
+        this.successHandler = successHandler;
+        return this;
+    }
+
+    /**
+     * Adds a completion handler to this stream which is executed only if closing the stream fails.
+     * <p>
+     * The original exception will be thrown, if this handler doesn't throw its own exception.
+     *
+     * @param failureHandler the handler to be executed once closing the stream failed
+     * @return <tt>this</tt> for fluent method chaining
+     */
+    public WatchableInputStream onFailure(@Nonnull final Consumer<Throwable> failureHandler) {
+        if (this.failureHandler != null) {
+            throw new UnsupportedOperationException("Only one failure handler can be specified");
+        }
+
+        this.failureHandler = failureHandler;
+        return this;
+    }
+
+    /**
+     * Adds a completion handler to this stream which is executed when the stream is closed.
+     * <p>
+     * In case of a failure, the original exception will be thrown, if this handler doesn't throw its own exception.
+     *
+     * @param completionHandler the handler to be executed once the stream is closed
+     * @return <tt>this</tt> for fluent method chaining
+     */
+    public WatchableInputStream onCompletion(@Nonnull final Runnable completionHandler) {
+        if (this.successHandler != null || this.failureHandler != null) {
+            throw new UnsupportedOperationException("Only one completion handler can be specified");
+        }
+
+        this.successHandler = completionHandler;
+        this.failureHandler = ignored -> completionHandler.run();
+        return this;
     }
 }

--- a/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
@@ -81,7 +81,7 @@ public class WatchableOutputStream extends OutputStream {
     }
 
     /**
-     * Adds a completion handler to this stream which is executed only if closing the stream is successful.
+     * Sets the completion handler to this stream which is executed only if closing the stream is successful.
      *
      * @param successHandler the handler to be executed once the stream is successfully closed
      * @return <tt>this</tt> for fluent method chaining
@@ -96,7 +96,7 @@ public class WatchableOutputStream extends OutputStream {
     }
 
     /**
-     * Adds a completion handler to this stream which is executed only if closing the stream fails.
+     * Sets the completion handler to this stream which is executed only if closing the stream fails.
      * <p>
      * The original exception will be thrown, if this handler doesn't throw its own exception.
      *
@@ -113,7 +113,7 @@ public class WatchableOutputStream extends OutputStream {
     }
 
     /**
-     * Adds a completion handler to this stream which is executed when the stream is closed.
+     * Installs a completion handler to this stream which is executed when the stream is closed.
      * <p>
      * In case of a failure, the original exception will be thrown, if this handler doesn't throw its own exception.
      *

--- a/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
@@ -26,7 +26,7 @@ public class WatchableOutputStream extends OutputStream {
     private final OutputStream delegate;
     private Runnable successHandler;
     private Consumer<Throwable> failureHandler;
-    private boolean closeHandled = false;
+    private volatile boolean closeHandled = false;
 
     /**
      * Creates a new stream which wraps and delegates all calls to the given one.

--- a/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Wraps an {@link OutputStream} and provides a {@link Future completion future}.
@@ -23,7 +24,9 @@ import java.util.Objects;
 public class WatchableOutputStream extends OutputStream {
 
     private final OutputStream delegate;
-    private final Future completionFuture;
+    private Runnable successHandler;
+    private Consumer<Throwable> failureHandler;
+    private boolean closeHandled = false;
 
     /**
      * Creates a new stream which wraps and delegates all calls to the given one.
@@ -33,7 +36,6 @@ public class WatchableOutputStream extends OutputStream {
     public WatchableOutputStream(@Nonnull OutputStream delegate) {
         Objects.requireNonNull(delegate, "null was passed into a WatchableOutputStream");
         this.delegate = delegate;
-        this.completionFuture = new Future();
     }
 
     @Override
@@ -55,18 +57,21 @@ public class WatchableOutputStream extends OutputStream {
     public void close() throws IOException {
         try {
             delegate.close();
-
-            // Close might be invoked several times (e.g. by some ZIP implementations).
-            // Therefore, we filter this to only fulfill the future once.
-            if (!completionFuture.isCompleted()) {
-                completionFuture.success();
-            }
         } catch (IOException e) {
-            // Filter duplicate completions (s.a.)...
-            if (!completionFuture.isCompleted()) {
-                completionFuture.fail(e);
+            // Close might be invoked several times (e.g. by some ZIP implementations).
+            // Therefore, we filter this to only execute the handler once.
+            if (failureHandler != null && !closeHandled) {
+                closeHandled = true;
+                failureHandler.accept(e);
             }
+
             throw e;
+        }
+
+        // Filter duplicate executions (s.a.)...
+        if (successHandler != null && !closeHandled) {
+            closeHandled = true;
+            successHandler.run();
         }
     }
 
@@ -76,11 +81,52 @@ public class WatchableOutputStream extends OutputStream {
     }
 
     /**
-     * Provides the completion future which is fullfilled once the stream is closed.
+     * Adds a completion handler to this stream which is executed only if closing the stream is successful.
      *
-     * @return the completion future of this stream
+     * @param successHandler the handler to be executed once the stream is successfully closed
+     * @return <tt>this</tt> for fluent method chaining
      */
-    public Future getCompletionFuture() {
-        return completionFuture;
+    public WatchableOutputStream onSuccess(@Nonnull final Runnable successHandler) {
+        if (this.successHandler != null) {
+            throw new UnsupportedOperationException("Only one success handler can be specified");
+        }
+
+        this.successHandler = successHandler;
+        return this;
+    }
+
+    /**
+     * Adds a completion handler to this stream which is executed only if closing the stream fails.
+     * <p>
+     * The original exception will be thrown, if this handler doesn't throw its own exception.
+     *
+     * @param failureHandler the handler to be executed once closing the stream failed
+     * @return <tt>this</tt> for fluent method chaining
+     */
+    public WatchableOutputStream onFailure(@Nonnull final Consumer<Throwable> failureHandler) {
+        if (this.failureHandler != null) {
+            throw new UnsupportedOperationException("Only one failure handler can be specified");
+        }
+
+        this.failureHandler = failureHandler;
+        return this;
+    }
+
+    /**
+     * Adds a completion handler to this stream which is executed when the stream is closed.
+     * <p>
+     * In case of a failure, the original exception will be thrown, if this handler doesn't throw its own exception.
+     *
+     * @param completionHandler the handler to be executed once the stream is closed
+     * @return <tt>this</tt> for fluent method chaining
+     */
+    public WatchableOutputStream onCompletion(@Nonnull final Runnable completionHandler) {
+        if (this.successHandler != null || this.failureHandler != null) {
+            throw new UnsupportedOperationException("Only one completion handler can be specified");
+        }
+
+        this.successHandler = completionHandler;
+        this.failureHandler = ignored -> completionHandler.run();
+        return this;
     }
 }


### PR DESCRIPTION
Currently, WatchableInputStream and WatchableOutputStream use a future for the completion handling. The futures are fulfilled, once the stream is closed. Unfortunately, our Futures swallow exceptions that happen during completion handling.

The FTPClient that FTPUplink uses, mandates to check the reply code after data transmissions. If the code is an error code, the transmission wasn't successful. In order to have any chance of handling these transmission errors, we need to throw an exception.

This replaces each future with two simple completion handlers. This change is breaking as any exception that was only logged away before, is now propagated.

# Breaking:
Replace `stream.getCompletionFuture().onSuccess(...)` with `stream.onSuccess(...)`

Fixes: [SIRI-682](https://scireum.myjetbrains.com/youtrack/issue/SIRI-682)