### PR TITLE
Invokes BlobCreatedRenamedHandler when updating the raw file

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -230,7 +230,7 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
         updateFilenameFields();
 
-        if (isNew() || isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION)) {
+        if (isNew() || isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION, PHYSICAL_OBJECT_KEY)) {
             createdOrRenamed = true;
         }
 

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -237,7 +237,7 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
         updateFilenameFields();
 
-        if (isNew() || isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION)) {
+        if (isNew() || isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION, PHYSICAL_OBJECT_KEY)) {
             createdOrRenamed = true;
         }
 


### PR DESCRIPTION
Updating the RAW file under a Blob was not causing the BlobCreatedRenamedHandler to execute, since this only triggered if the file name changed.

Loading a new file on top of an existing blob will generate a new physicalObjectKey.

Fixes: [OX-9285](https://scireum.myjetbrains.com/youtrack/issue/OX-9285)