### PR TITLE
BREAKING: better handle blob changes

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
@@ -14,6 +14,9 @@ import sirius.kernel.di.std.AutoRegister;
  * Defines handlers to process {@link Blob blobs} which content (the underlying physical object) has been updated.
  * <p>
  * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
+ * <p>
+ * Note that this handler will be invoked for fresh created blobs which {@link BlobCreatedHandler} has been already
+ * invoked but no physical object was available at the time.
  *
  * @see ProcessBlobChangesLoop
  */

--- a/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
@@ -11,9 +11,9 @@ package sirius.biz.storage.layer2;
 import sirius.kernel.di.std.AutoRegister;
 
 /**
- * Defines handlers to process {@link Blob blobs} which content (the underlying physical object) has been updated.
+ * Defines handlers to process {@linkplain Blob blobs} which content (the underlying physical object) has been updated.
  * <p>
- * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
+ * Note: Handlers need to be {@linkplain sirius.kernel.di.std.Register registered}.
  *
  * @see ProcessBlobChangesLoop
  */

--- a/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
@@ -1,0 +1,22 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.layer2;
+
+import sirius.kernel.di.std.AutoRegister;
+
+/**
+ * Defines handlers to process {@link Blob blobs} which content (the underlying physical object) has been updated.
+ * <p>
+ * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
+ *
+ * @see ProcessBlobChangesLoop
+ */
+@AutoRegister
+public interface BlobContentUpdatedHandler extends BlobChangedHandler {
+}

--- a/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
@@ -14,9 +14,6 @@ import sirius.kernel.di.std.AutoRegister;
  * Defines handlers to process {@link Blob blobs} which content (the underlying physical object) has been updated.
  * <p>
  * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
- * <p>
- * Note that this handler will be invoked for fresh created blobs which {@link BlobCreatedHandler} has been already
- * invoked but no physical object was available at the time.
  *
  * @see ProcessBlobChangesLoop
  */

--- a/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
@@ -11,12 +11,12 @@ package sirius.biz.storage.layer2;
 import sirius.kernel.di.std.AutoRegister;
 
 /**
- * Defines handlers to process created or modified {@link sirius.biz.storage.layer2.Blob blobs}.
+ * Defines handlers to process created {@link Blob blobs}.
  * <p>
  * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
  *
  * @see ProcessBlobChangesLoop
  */
 @AutoRegister
-public interface BlobCreatedRenamedHandler extends BlobChangedHandler {
+public interface BlobCreatedHandler extends BlobChangedHandler {
 }

--- a/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
@@ -14,6 +14,9 @@ import sirius.kernel.di.std.AutoRegister;
  * Defines handlers to process created {@link Blob blobs}.
  * <p>
  * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
+ * <p>
+ * Have in mind that blobs being processed by this handler might not have yet a physical object, since blob creation
+ * and actual upload of its binary contents happens in separate events.
  *
  * @see ProcessBlobChangesLoop
  */

--- a/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
@@ -14,9 +14,6 @@ import sirius.kernel.di.std.AutoRegister;
  * Defines handlers to process created {@link Blob blobs}.
  * <p>
  * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
- * <p>
- * Have in mind that blobs being processed by this handler might not have yet a physical object, since blob creation
- * and actual upload of its binary contents happens in separate events.
  *
  * @see ProcessBlobChangesLoop
  */

--- a/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
@@ -11,9 +11,9 @@ package sirius.biz.storage.layer2;
 import sirius.kernel.di.std.AutoRegister;
 
 /**
- * Defines handlers to process created {@link Blob blobs}.
+ * Defines handlers to process created {@linkplain Blob blobs}.
  * <p>
- * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
+ * Note: Handlers need to be {@linkplain sirius.kernel.di.std.Register registered}.
  *
  * @see ProcessBlobChangesLoop
  */

--- a/src/main/java/sirius/biz/storage/layer2/BlobRenamedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRenamedHandler.java
@@ -11,9 +11,9 @@ package sirius.biz.storage.layer2;
 import sirius.kernel.di.std.AutoRegister;
 
 /**
- * Defines handlers to process renamed {@link Blob blobs}.
+ * Defines handlers to process renamed {@linkplain Blob blobs}.
  * <p>
- * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
+ * Note: Handlers need to be {@linkplain sirius.kernel.di.std.Register registered}.
  *
  * @see ProcessBlobChangesLoop
  */

--- a/src/main/java/sirius/biz/storage/layer2/BlobRenamedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRenamedHandler.java
@@ -1,0 +1,22 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.layer2;
+
+import sirius.kernel.di.std.AutoRegister;
+
+/**
+ * Defines handlers to process renamed {@link Blob blobs}.
+ * <p>
+ * Note: Handlers need to be {@link sirius.kernel.di.std.Register registered}.
+ *
+ * @see ProcessBlobChangesLoop
+ */
+@AutoRegister
+public interface BlobRenamedHandler extends BlobChangedHandler {
+}

--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -31,8 +31,14 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
 
     private static final double FREQUENCY_EVERY_FIFTEEN_SECONDS = 1 / 15d;
 
-    @PriorityParts(BlobCreatedRenamedHandler.class)
-    private List<BlobCreatedRenamedHandler> createdOrRenamedHandlers;
+    @PriorityParts(BlobCreatedHandler.class)
+    private List<BlobCreatedHandler> createdHandlers;
+
+    @PriorityParts(BlobRenamedHandler.class)
+    private List<BlobRenamedHandler> renamedHandlers;
+
+    @PriorityParts(BlobContentUpdatedHandler.class)
+    private List<BlobContentUpdatedHandler> contentUpdatedHandlers;
 
     @PriorityParts(BlobParentChangedHandler.class)
     private List<BlobParentChangedHandler> parentChangedHandlers;
@@ -59,29 +65,37 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
         AtomicInteger deletedDirectories = new AtomicInteger();
         AtomicInteger renamedDirectories = new AtomicInteger();
         AtomicInteger deletedBlobs = new AtomicInteger();
-        AtomicInteger createdRenamedBlobs = new AtomicInteger();
+        AtomicInteger createdBlobs = new AtomicInteger();
+        AtomicInteger renamedBlobs = new AtomicInteger();
+        AtomicInteger contentUpdatedBlobs = new AtomicInteger();
         AtomicInteger parentChangedBlobs = new AtomicInteger();
 
         deleteDirectories(deletedDirectories::incrementAndGet);
         processRenamedDirectories(renamedDirectories::incrementAndGet);
         deleteBlobs(deletedBlobs::incrementAndGet);
         processParentChangedBlobs(parentChangedBlobs::incrementAndGet);
-        processCreatedOrRenamedBlobs(createdRenamedBlobs::incrementAndGet);
+        processCreatedBlobs(createdBlobs::incrementAndGet);
+        processRenamedBlobs(renamedBlobs::incrementAndGet);
+        processContentUpdatedBlobs(contentUpdatedBlobs::incrementAndGet);
 
         if (deletedDirectories.get()
             + renamedDirectories.get()
             + deletedBlobs.get()
-            + createdRenamedBlobs.get()
+            + createdBlobs.get()
+            + renamedBlobs.get()
+            + contentUpdatedBlobs.get()
             + parentChangedBlobs.get() == 0) {
             return null;
         }
 
         return Strings.apply(
-                "Directories: deleted (%s), renamed (%s). Blobs: deleted (%s), created/renamed (%s), moved (%s)",
+                "Directories: deleted (%s), renamed (%s). Blobs: deleted (%s), created (%s), renamed (%s), content updated (%s), moved (%s)",
                 deletedDirectories.get(),
                 renamedDirectories.get(),
                 deletedBlobs.get(),
-                createdRenamedBlobs.get(),
+                createdBlobs.get(),
+                renamedBlobs.get(),
+                contentUpdatedBlobs.get(),
                 parentChangedBlobs.get());
     }
 
@@ -91,8 +105,38 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
         }
     }
 
-    protected void invokeCreatedOrRenamedHandlers(Blob blob) {
-        createdOrRenamedHandlers.forEach(handler -> {
+    protected void invokeCreatedHandlers(Blob blob) {
+        createdHandlers.forEach(handler -> {
+            try {
+                handler.execute(blob);
+            } catch (Exception e) {
+                buildStorageException(e).withSystemErrorMessage(
+                        "Layer 2: %s failed to process the new blob %s (%s) in %s: (%s)",
+                        handler.getClass().getSimpleName(),
+                        blob.getBlobKey(),
+                        blob.getFilename(),
+                        blob.getSpaceName()).handle();
+            }
+        });
+    }
+
+    protected void invokeRenamedHandlers(Blob blob) {
+        renamedHandlers.forEach(handler -> {
+            try {
+                handler.execute(blob);
+            } catch (Exception e) {
+                buildStorageException(e).withSystemErrorMessage(
+                        "Layer 2: %s failed to process the renamed blob %s (%s) in %s: (%s)",
+                        handler.getClass().getSimpleName(),
+                        blob.getBlobKey(),
+                        blob.getFilename(),
+                        blob.getSpaceName()).handle();
+            }
+        });
+    }
+
+    protected void invokeContentUpdatedHandlers(Blob blob) {
+        contentUpdatedHandlers.forEach(handler -> {
             try {
                 handler.execute(blob);
             } catch (Exception e) {
@@ -165,13 +209,31 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
     protected abstract void deleteDirectories(Runnable counter);
 
     /**
-     * Queries and processes {@link Blob blobs} marked as created or had the file name renamed.
+     * Queries and processes {@link Blob blobs} marked as created.
      * <p>
-     * The processing is performed by the registered {@link BlobCreatedRenamedHandler handlers}
+     * The processing is performed by the registered {@link BlobCreatedHandler handlers}
      *
      * @param counter a {@link Runnable} to be called for each {@link Blob blob} processed
      */
-    protected abstract void processCreatedOrRenamedBlobs(Runnable counter);
+    protected abstract void processCreatedBlobs(Runnable counter);
+
+    /**
+     * Queries and processes {@link Blob blobs} marked as renamed.
+     * <p>
+     * The processing is performed by the registered {@link BlobRenamedHandler handlers}
+     *
+     * @param counter a {@link Runnable} to be called for each {@link Blob blob} processed
+     */
+    protected abstract void processRenamedBlobs(Runnable counter);
+
+    /**
+     * Queries and processes {@link Blob blobs} which physical object has been replaced.
+     * <p>
+     * The processing is performed by the registered {@link BlobContentUpdatedHandler handlers}
+     *
+     * @param counter a {@link Runnable} to be called for each {@link Blob blob} processed
+     */
+    protected abstract void processContentUpdatedBlobs(Runnable counter);
 
     /**
      * Marks children items of a given {@link Directory directory} as deleted.

--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -106,57 +106,31 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
     }
 
     protected void invokeCreatedHandlers(Blob blob) {
-        createdHandlers.forEach(handler -> {
-            try {
-                handler.execute(blob);
-            } catch (Exception e) {
-                buildStorageException(e).withSystemErrorMessage(
-                        "Layer 2: %s failed to process the new blob %s (%s) in %s: (%s)",
-                        handler.getClass().getSimpleName(),
-                        blob.getBlobKey(),
-                        blob.getFilename(),
-                        blob.getSpaceName()).handle();
-            }
-        });
+        invokeBlobChangedHandlers(blob, createdHandlers, "new");
     }
 
     protected void invokeRenamedHandlers(Blob blob) {
-        renamedHandlers.forEach(handler -> {
-            try {
-                handler.execute(blob);
-            } catch (Exception e) {
-                buildStorageException(e).withSystemErrorMessage(
-                        "Layer 2: %s failed to process the renamed blob %s (%s) in %s: (%s)",
-                        handler.getClass().getSimpleName(),
-                        blob.getBlobKey(),
-                        blob.getFilename(),
-                        blob.getSpaceName()).handle();
-            }
-        });
+        invokeBlobChangedHandlers(blob, renamedHandlers, "renamed");
     }
 
     protected void invokeContentUpdatedHandlers(Blob blob) {
-        contentUpdatedHandlers.forEach(handler -> {
-            try {
-                handler.execute(blob);
-            } catch (Exception e) {
-                buildStorageException(e).withSystemErrorMessage(
-                        "Layer 2: %s failed to process the changed blob %s (%s) in %s: (%s)",
-                        handler.getClass().getSimpleName(),
-                        blob.getBlobKey(),
-                        blob.getFilename(),
-                        blob.getSpaceName()).handle();
-            }
-        });
+        invokeBlobChangedHandlers(blob, contentUpdatedHandlers, "changed");
     }
 
     protected void invokeParentChangedHandlers(Blob blob) {
-        parentChangedHandlers.forEach(handler -> {
+        invokeBlobChangedHandlers(blob, parentChangedHandlers, "parent change for");
+    }
+
+    private <H extends BlobChangedHandler> void invokeBlobChangedHandlers(Blob blob,
+                                                                          List<H> handlers,
+                                                                          String changeType) {
+        handlers.forEach(handler -> {
             try {
                 handler.execute(blob);
             } catch (Exception e) {
                 buildStorageException(e).withSystemErrorMessage(
-                        "Layer 2: %s failed to process parent change for blob %s (%s) in %s: (%s)",
+                        "Layer 2: %s failed to process %s blob %s (%s) in %s: (%s)",
+                        changeType,
                         handler.getClass().getSimpleName(),
                         blob.getBlobKey(),
                         blob.getFilename(),

--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -183,29 +183,29 @@ public abstract class ProcessBlobChangesLoop extends BackgroundLoop {
     protected abstract void deleteDirectories(Runnable counter);
 
     /**
-     * Queries and processes {@link Blob blobs} marked as created.
+     * Queries and processes {@linkplain Blob blobs} marked as created.
      * <p>
-     * The processing is performed by the registered {@link BlobCreatedHandler handlers}
+     * The processing is performed by the registered {@linkplain BlobCreatedHandler handlers}
      *
-     * @param counter a {@link Runnable} to be called for each {@link Blob blob} processed
+     * @param counter a {@link Runnable} to be called for each {@linkplain Blob blob} processed
      */
     protected abstract void processCreatedBlobs(Runnable counter);
 
     /**
-     * Queries and processes {@link Blob blobs} marked as renamed.
+     * Queries and processes {@linkplain Blob blobs} marked as renamed.
      * <p>
-     * The processing is performed by the registered {@link BlobRenamedHandler handlers}
+     * The processing is performed by the registered {@linkplain BlobRenamedHandler handlers}
      *
-     * @param counter a {@link Runnable} to be called for each {@link Blob blob} processed
+     * @param counter a {@link Runnable} to be called for each {@linkplain Blob blob} processed
      */
     protected abstract void processRenamedBlobs(Runnable counter);
 
     /**
-     * Queries and processes {@link Blob blobs} which physical object has been replaced.
+     * Queries and processes {@linkplain Blob blobs} which physical object has been replaced.
      * <p>
-     * The processing is performed by the registered {@link BlobContentUpdatedHandler handlers}
+     * The processing is performed by the registered {@linkplain BlobContentUpdatedHandler handlers}
      *
-     * @param counter a {@link Runnable} to be called for each {@link Blob blob} processed
+     * @param counter a {@link Runnable} to be called for each {@linkplain Blob blob} processed
      */
     protected abstract void processContentUpdatedBlobs(Runnable counter);
 

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -244,25 +244,30 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 
         updateFilenameFields();
 
-        if (isNew()) {
-            created = true;
-        } else {
-            if (isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION)) {
-                renamed = true;
-            }
-            if (isChanged(PHYSICAL_OBJECT_KEY)) {
-                contentUpdated = true;
-            }
-            if (isChanged(PARENT)) {
-                parentChanged = true;
-            }
-        }
-
         if (deleted) {
+            // The blob has been deleted. Reset all other flags since its now pointless to trigger any BlobChangedHandler.
             created = false;
             renamed = false;
             contentUpdated = false;
             parentChanged = false;
+            return;
+        }
+
+        if (isNew() || isCreated()) {
+            // New Blob entities have no physical object and won't be used by any loops until a blob is uploaded.
+            // Blobs still marked as created have not yet been processed by the BlobCreatedHandler, therefore
+            // it is pointless to set any other flag.
+            return;
+        }
+
+        if (isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION)) {
+            renamed = true;
+        }
+        if (isChanged(PHYSICAL_OBJECT_KEY)) {
+            contentUpdated = true;
+        }
+        if (isChanged(PARENT)) {
+            parentChanged = true;
         }
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -11,7 +11,6 @@ package sirius.biz.storage.layer2.jdbc;
 import sirius.biz.storage.layer2.BasicBlobStorageSpace;
 import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.layer2.Directory;
-import sirius.biz.storage.layer2.mongo.MongoBlob;
 import sirius.biz.storage.layer2.variants.BlobVariant;
 import sirius.biz.storage.layer2.variants.ConversionProcess;
 import sirius.biz.storage.util.StorageUtils;
@@ -543,9 +542,9 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
 
             String previousPhysicalObjectKey = blob.getPhysicalObjectKey();
             if (Strings.isFilled(previousPhysicalObjectKey)) {
-                updateStatement.set(MongoBlob.CONTENT_UPDATED, true);
+                updateStatement.set(SQLBlob.CONTENT_UPDATED, true);
             } else {
-                updateStatement.set(MongoBlob.CREATED, true);
+                updateStatement.set(SQLBlob.CREATED, true);
             }
 
             int numUpdated = updateStatement.where(SQLBlob.ID, blob.getId())

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -540,6 +540,10 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                                .set(SQLBlob.FILE_EXTENSION, Files.getFileExtension(filename.toLowerCase()));
             }
 
+            if (!blob.isNew()) {
+                updateStatement.set(SQLBlob.CONTENT_UPDATED, true);
+            }
+
             int numUpdated = updateStatement.where(SQLBlob.ID, blob.getId())
                                             .where(SQLBlob.PHYSICAL_OBJECT_KEY, blob.getPhysicalObjectKey())
                                             .executeUpdate();

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -52,26 +52,6 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
     }
 
     @Override
-    protected void processCreatedOrRenamedBlobs(Runnable counter) {
-        oma.select(SQLBlob.class).eq(SQLBlob.CREATED_OR_RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeCreatedOrRenamedHandlers(blob);
-            try {
-                oma.updateStatement(SQLBlob.class)
-                   .set(SQLBlob.CREATED_OR_RENAMED, false)
-                   .where(SQLBlob.ID, blob.getId())
-                   .executeUpdate();
-            } catch (SQLException e) {
-                buildStorageException(e).withSystemErrorMessage(
-                        "Layer 2: Failed to reset blob %s (%s) in %s as not changed: (%s)",
-                        blob.getBlobKey(),
-                        blob.getFilename(),
-                        blob.getSpaceName()).handle();
-            }
-            counter.run();
-        });
-    }
-
-    @Override
     protected void processCreatedBlobs(Runnable counter) {
         oma.select(SQLBlob.class).eq(SQLBlob.CREATED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             invokeCreatedHandlers(blob);

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -47,10 +47,10 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
             try {
                 propagateDelete(dir);
                 oma.delete(dir);
+                counter.run();
             } catch (Exception e) {
                 handleDirectoryDeletionException(dir, e);
             }
-            counter.run();
         });
     }
 
@@ -113,10 +113,10 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
                    .set(SQLDirectory.RENAMED, false)
                    .where(SQLDirectory.ID, dir.getId())
                    .executeUpdate();
+                counter.run();
             } catch (Exception e) {
                 handleDirectoryDeletionException(dir, e);
             }
-            counter.run();
         });
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -73,42 +73,50 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processRenamedBlobs(Runnable counter) {
-        oma.select(SQLBlob.class).eq(SQLBlob.RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeRenamedHandlers(blob);
-            try {
-                oma.updateStatement(SQLBlob.class)
-                   .set(SQLBlob.RENAMED, false)
-                   .where(SQLBlob.ID, blob.getId())
-                   .executeUpdate();
-            } catch (SQLException e) {
-                buildStorageException(e).withSystemErrorMessage(
-                        "Layer 2: Failed to reset blob %s (%s) in %s as not renamed: (%s)",
-                        blob.getBlobKey(),
-                        blob.getFilename(),
-                        blob.getSpaceName()).handle();
-            }
-            counter.run();
-        });
+        oma.select(SQLBlob.class)
+           .eq(SQLBlob.RENAMED, true)
+           .eq(SQLBlob.CREATED, false)
+           .limit(CURSOR_LIMIT)
+           .iterateAll(blob -> {
+               invokeRenamedHandlers(blob);
+               try {
+                   oma.updateStatement(SQLBlob.class)
+                      .set(SQLBlob.RENAMED, false)
+                      .where(SQLBlob.ID, blob.getId())
+                      .executeUpdate();
+               } catch (SQLException e) {
+                   buildStorageException(e).withSystemErrorMessage(
+                           "Layer 2: Failed to reset blob %s (%s) in %s as not renamed: (%s)",
+                           blob.getBlobKey(),
+                           blob.getFilename(),
+                           blob.getSpaceName()).handle();
+               }
+               counter.run();
+           });
     }
 
     @Override
     protected void processContentUpdatedBlobs(Runnable counter) {
-        oma.select(SQLBlob.class).eq(SQLBlob.CONTENT_UPDATED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeContentUpdatedHandlers(blob);
-            try {
-                oma.updateStatement(SQLBlob.class)
-                   .set(SQLBlob.CONTENT_UPDATED, false)
-                   .where(SQLBlob.ID, blob.getId())
-                   .executeUpdate();
-            } catch (SQLException e) {
-                buildStorageException(e).withSystemErrorMessage(
-                        "Layer 2: Failed to reset blob %s (%s) in %s as content not changed: (%s)",
-                        blob.getBlobKey(),
-                        blob.getFilename(),
-                        blob.getSpaceName()).handle();
-            }
-            counter.run();
-        });
+        oma.select(SQLBlob.class)
+           .eq(SQLBlob.CONTENT_UPDATED, true)
+           .eq(SQLBlob.CREATED, false)
+           .limit(CURSOR_LIMIT)
+           .iterateAll(blob -> {
+               invokeContentUpdatedHandlers(blob);
+               try {
+                   oma.updateStatement(SQLBlob.class)
+                      .set(SQLBlob.CONTENT_UPDATED, false)
+                      .where(SQLBlob.ID, blob.getId())
+                      .executeUpdate();
+               } catch (SQLException e) {
+                   buildStorageException(e).withSystemErrorMessage(
+                           "Layer 2: Failed to reset blob %s (%s) in %s as content not changed: (%s)",
+                           blob.getBlobKey(),
+                           blob.getFilename(),
+                           blob.getSpaceName()).handle();
+               }
+               counter.run();
+           });
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -92,6 +92,26 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
     }
 
     @Override
+    protected void processRenamedBlobs(Runnable counter) {
+        oma.select(SQLBlob.class).eq(SQLBlob.RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
+            invokeRenamedHandlers(blob);
+            try {
+                oma.updateStatement(SQLBlob.class)
+                   .set(SQLBlob.RENAMED, false)
+                   .where(SQLBlob.ID, blob.getId())
+                   .executeUpdate();
+            } catch (SQLException e) {
+                buildStorageException(e).withSystemErrorMessage(
+                        "Layer 2: Failed to reset blob %s (%s) in %s as not renamed: (%s)",
+                        blob.getBlobKey(),
+                        blob.getFilename(),
+                        blob.getSpaceName()).handle();
+            }
+            counter.run();
+        });
+    }
+
+    @Override
     protected void propagateDelete(Directory dir) {
         Long directoryId = ((SQLDirectory) dir).getId();
         try {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -72,7 +72,9 @@ import java.util.Optional;
 @Index(name = "blob_reference_lookup",
         columns = {"spaceName", "deleted", "reference", "referenceDesignator"},
         columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
-@Index(name = "blob_created_renamed_loop", columns = "createdOrRenamed", columnSettings = Mango.INDEX_ASCENDING)
+@Index(name = "blob_created_loop", columns = "created", columnSettings = Mango.INDEX_ASCENDING)
+@Index(name = "blob_renamed_loop", columns = "renamed", columnSettings = Mango.INDEX_ASCENDING)
+@Index(name = "blob_content_updated_loop", columns = "contentUpdated", columnSettings = Mango.INDEX_ASCENDING)
 @Index(name = "blob_deleted_loop", columns = "deleted", columnSettings = Mango.INDEX_ASCENDING)
 @Index(name = "blob_parent_changed_loop", columns = "parentChanged", columnSettings = Mango.INDEX_ASCENDING)
 @Index(name = "blob_delete_old_temporary_loop",
@@ -211,10 +213,22 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
     private boolean deleted;
 
     /**
-     * Stores if the blob was inserted or renamed.
+     * Stores if the blob was inserted.
      */
-    public static final Mapping CREATED_OR_RENAMED = Mapping.named("createdOrRenamed");
-    private boolean createdOrRenamed;
+    public static final Mapping CREATED = Mapping.named("created");
+    private boolean created;
+
+    /**
+     * Stores if the blob was renamed.
+     */
+    public static final Mapping RENAMED = Mapping.named("renamed");
+    private boolean renamed;
+
+    /**
+     * Stores if the blob's content was updated.
+     */
+    public static final Mapping CONTENT_UPDATED = Mapping.named("contentUpdated");
+    private boolean contentUpdated;
 
     /**
      * Stores if the blob was marked as hidden.
@@ -237,16 +251,24 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
         updateFilenameFields();
 
-        if (isNew() || isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION, PHYSICAL_OBJECT_KEY)) {
-            createdOrRenamed = true;
-        }
-
-        if (!isNew() && isChanged(PARENT)) {
-            parentChanged = true;
+        if (isNew()) {
+            created = true;
+        } else {
+            if (isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION)) {
+                renamed = true;
+            }
+            if (isChanged(PHYSICAL_OBJECT_KEY)) {
+                contentUpdated = true;
+            }
+            if (isChanged(PARENT)) {
+                parentChanged = true;
+            }
         }
 
         if (deleted) {
-            createdOrRenamed = false;
+            created = false;
+            renamed = false;
+            contentUpdated = false;
             parentChanged = false;
         }
     }
@@ -477,8 +499,16 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
         return deleted;
     }
 
-    public boolean isCreatedOrRenamed() {
-        return createdOrRenamed;
+    public boolean isCreated() {
+        return created;
+    }
+
+    public boolean isRenamed() {
+        return renamed;
+    }
+
+    public boolean isContentUpdated() {
+        return contentUpdated;
     }
 
     public boolean isParentChanged() {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -251,25 +251,30 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
 
         updateFilenameFields();
 
-        if (isNew()) {
-            created = true;
-        } else {
-            if (isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION)) {
-                renamed = true;
-            }
-            if (isChanged(PHYSICAL_OBJECT_KEY)) {
-                contentUpdated = true;
-            }
-            if (isChanged(PARENT)) {
-                parentChanged = true;
-            }
-        }
-
         if (deleted) {
+            // The blob has been deleted. Reset all other flags since its now pointless to trigger any BlobChangedHandler.
             created = false;
             renamed = false;
             contentUpdated = false;
             parentChanged = false;
+            return;
+        }
+
+        if (isNew() || isCreated()) {
+            // New Blob entities have no physical object and won't be used by any loops until a blob is uploaded.
+            // Blobs still marked as created have not yet been processed by the BlobCreatedHandler, therefore
+            // it is pointless to set any other flag.
+            return;
+        }
+
+        if (isChanged(FILENAME, NORMALIZED_FILENAME, FILE_EXTENSION)) {
+            renamed = true;
+        }
+        if (isChanged(PHYSICAL_OBJECT_KEY)) {
+            contentUpdated = true;
+        }
+        if (isChanged(PARENT)) {
+            parentChanged = true;
         }
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -462,6 +462,10 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                        .set(MongoBlob.FILE_EXTENSION, Files.getFileExtension(filename.toLowerCase()));
             }
 
+            if (!blob.isNew()) {
+                updater.set(MongoBlob.CONTENT_UPDATED, true);
+            }
+
             long numUpdated = updater.where(MongoBlob.ID, blob.getId())
                                      .where(MongoBlob.PHYSICAL_OBJECT_KEY, blob.getPhysicalObjectKey())
                                      .executeForOne(MongoBlob.class)

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -462,8 +462,11 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                        .set(MongoBlob.FILE_EXTENSION, Files.getFileExtension(filename.toLowerCase()));
             }
 
-            if (!blob.isNew()) {
+            String previousPhysicalObjectKey = blob.getPhysicalObjectKey();
+            if (Strings.isFilled(previousPhysicalObjectKey)) {
                 updater.set(MongoBlob.CONTENT_UPDATED, true);
+            } else {
+                updater.set(MongoBlob.CREATED, true);
             }
 
             long numUpdated = updater.where(MongoBlob.ID, blob.getId())
@@ -472,7 +475,6 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                                      .getModifiedCount();
             if (numUpdated == 1) {
                 // Also update in-memory to avoid an additional database fetch...
-                String previousPhysicalObjectKey = blob.getPhysicalObjectKey();
                 blob.setPhysicalObjectKey(nextPhysicalId);
                 if (Strings.isFilled(filename)) {
                     blob.setFilename(filename);

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
@@ -39,8 +39,8 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
         mango.select(MongoBlob.class).eq(MongoBlob.DELETED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             try {
                 deletePhysicalObject(blob);
-                counter.run();
                 mango.delete(blob);
+                counter.run();
             } catch (Exception e) {
                 handleBlobDeletionException(blob, e);
             }
@@ -53,10 +53,10 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
             try {
                 propagateDelete(dir);
                 mango.delete(dir);
+                counter.run();
             } catch (Exception e) {
                 handleDirectoryDeletionException(dir, e);
             }
-            counter.run();
         });
     }
 
@@ -106,10 +106,10 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
                      .set(MongoDirectory.RENAMED, false)
                      .where(MongoDirectory.ID, dir.getId())
                      .executeForOne(MongoDirectory.class);
+                counter.run();
             } catch (Exception e) {
                 handleDirectoryRenameException(dir, e);
             }
-            counter.run();
         });
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
@@ -58,18 +58,6 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
     }
 
     @Override
-    protected void processCreatedOrRenamedBlobs(Runnable counter) {
-        mango.select(MongoBlob.class).eq(MongoBlob.CREATED_OR_RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeCreatedOrRenamedHandlers(blob);
-            mongo.update()
-                 .set(MongoBlob.CREATED_OR_RENAMED, false)
-                 .where(MongoBlob.ID, blob.getId())
-                 .executeForOne(MongoBlob.class);
-            counter.run();
-        });
-    }
-
-    @Override
     protected void processCreatedBlobs(Runnable counter) {
         mango.select(MongoBlob.class).eq(MongoBlob.CREATED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
             invokeCreatedHandlers(blob);

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
@@ -71,26 +71,34 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processRenamedBlobs(Runnable counter) {
-        mango.select(MongoBlob.class).eq(MongoBlob.RENAMED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeRenamedHandlers(blob);
-            mongo.update()
-                 .set(MongoBlob.RENAMED, false)
-                 .where(MongoBlob.ID, blob.getId())
-                 .executeForOne(MongoBlob.class);
-            counter.run();
-        });
+        mango.select(MongoBlob.class)
+             .eq(MongoBlob.RENAMED, true)
+             .eq(MongoBlob.CREATED, false)
+             .limit(CURSOR_LIMIT)
+             .iterateAll(blob -> {
+                 invokeRenamedHandlers(blob);
+                 mongo.update()
+                      .set(MongoBlob.RENAMED, false)
+                      .where(MongoBlob.ID, blob.getId())
+                      .executeForOne(MongoBlob.class);
+                 counter.run();
+             });
     }
 
     @Override
     protected void processContentUpdatedBlobs(Runnable counter) {
-        mango.select(MongoBlob.class).eq(MongoBlob.CONTENT_UPDATED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeContentUpdatedHandlers(blob);
-            mongo.update()
-                 .set(MongoBlob.CONTENT_UPDATED, false)
-                 .where(MongoBlob.ID, blob.getId())
-                 .executeForOne(MongoBlob.class);
-            counter.run();
-        });
+        mango.select(MongoBlob.class)
+             .eq(MongoBlob.CONTENT_UPDATED, true)
+             .eq(MongoBlob.CREATED, false)
+             .limit(CURSOR_LIMIT)
+             .iterateAll(blob -> {
+                 invokeContentUpdatedHandlers(blob);
+                 mongo.update()
+                      .set(MongoBlob.CONTENT_UPDATED, false)
+                      .where(MongoBlob.ID, blob.getId())
+                      .executeForOne(MongoBlob.class);
+                 counter.run();
+             });
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
@@ -145,13 +145,17 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processParentChangedBlobs(Runnable counter) {
-        mango.select(MongoBlob.class).eq(MongoBlob.PARENT_CHANGED, true).limit(CURSOR_LIMIT).iterateAll(blob -> {
-            invokeParentChangedHandlers(blob);
-            mongo.update()
-                 .set(MongoBlob.PARENT_CHANGED, false)
-                 .where(MongoBlob.ID, blob.getId())
-                 .executeForOne(MongoBlob.class);
-            counter.run();
-        });
+        mango.select(MongoBlob.class)
+             .eq(MongoBlob.PARENT_CHANGED, true)
+             .eq(MongoBlob.CREATED, false)
+             .limit(CURSOR_LIMIT)
+             .iterateAll(blob -> {
+                 invokeParentChangedHandlers(blob);
+                 mongo.update()
+                      .set(MongoBlob.PARENT_CHANGED, false)
+                      .where(MongoBlob.ID, blob.getId())
+                      .executeForOne(MongoBlob.class);
+                 counter.run();
+             });
     }
 }


### PR DESCRIPTION
- Deletes the `BlobCreatedOrRenamedHandler`
- Adds the `BlobCreatedHandler` -> triggered for new Blobs and only **after** a physical object has been set
- Adds the `BlobRenamedHandler` -> triggered for existing Blobs with renamed file name
- Adds the `BlobContentUpdatedHandler` -> triggered for existing Blobs which physical object has been replaced

We also make the whole logic more robust and guarantee that the `BlobCreatedHandler` runs before other handlers.

# What Products must do?
1. Implement the new Handlers if `BlobCreatedOrRenamedHandler` were previously used.
2. If necessary set one or more of the new flags (created, renamed, contentUpdated) for records with createdOrRenamed = true
3. Drop the obsolete column:
- Mongo: `db.mongoblob.updateMany({}, {$unset: {createdOrRenamed:1}})`
- SQL: `ALTER TABLE sqlblob DROP COLUMN createdOrRenamed`
4. Drop an obsolete index:
- Mongo: `db.mongoblob.dropIndex('blob_created_renamed_loop')`
- SQL: `DROP INDEX IF EXISTS blob_created_renamed_loop ON sqlblob`

> [SIRI-694](https://scireum.myjetbrains.com/youtrack/issue/SIRI-694)