### PR TITLE
Tycho: Allows to overwrite the image style of the blobImage tag

### DIFF
--- a/src/main/resources/default/taglib/t/blobImage.html.pasta
+++ b/src/main/resources/default/taglib/t/blobImage.html.pasta
@@ -1,6 +1,8 @@
 <i:arg type="sirius.biz.storage.layer2.URLBuilder" name="urlBuilder"/>
 <i:arg type="String" name="style" default=""
        description="Determines the additional styles to apply. Most probably a height should be set here."/>
+<i:arg type="String" name="imgStyle" default="max-width: 100%; max-height: 100%;"
+       description="Determines the additional style to apply to the img object."/>
 <i:arg type="String" name="class" default="" description="Contains additional classes to apply."/>
 <i:arg type="boolean" name="skipEmpty" default="false"
        description="If set to true, an empty blob will be skipped entirely, instead of rendering the fallback image."/>
@@ -15,12 +17,12 @@
          style="@style">
         <i:if test="urlBuilder.isConversionExpected()">
             <img class="lazy-image-js"
-                 style="max-width: 100%; max-height: 100%"
+                 style="@imgStyle"
                  src="@urlBuilder.getFallbackUri().orElse(sirius.biz.storage.layer2.URLBuilder.IMAGE_FALLBACK_URI)"
                  data-src="@urlBuilder.buildImageURL()"/>
             <i:else>
                 <img class="safe-image-js"
-                     style="max-width: 100%; max-height: 100%"
+                     style="@imgStyle"
                      data-fallback="@urlBuilder.getFallbackUri().orElse(sirius.biz.storage.layer2.URLBuilder.IMAGE_FALLBACK_URI)"
                      src="@urlBuilder.buildImageURL()"/>
             </i:else>


### PR DESCRIPTION
This argument determines the additional style to apply to the img object.

Fixes: [OX-9384](https://scireum.myjetbrains.com/youtrack/issue/OX-9384/Video-Modernisierung-Backend-User-Interface-Teil-1-Ubersicht)