### PR TITLE
Always makes all metric schedulers visible

### DIFF
--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLBestEffortDailyScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLBestEffortDailyScheduler.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
  * Provides the executor which is responsible for scheduling {@link MonthlyMetricComputer} instances which refer
  * to {@link sirius.db.jdbc.SQLEntity sql entities} on a daily basis using the best effort principle.
  */
-@Register(framework = SQLMetrics.FRAMEWORK_JDBC_METRICS)
+@Register
 public class SQLBestEffortDailyScheduler extends SQLAnalyticalTaskScheduler {
 
     @Override

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLGuaranteedDailyMetricScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLGuaranteedDailyMetricScheduler.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
  * Provides the executor which is responsible for scheduling {@link DailyMetricComputer} instances which refer
  * to {@link sirius.db.jdbc.SQLEntity sql entities} on a daily basis.
  */
-@Register(framework = SQLMetrics.FRAMEWORK_JDBC_METRICS)
+@Register
 public class SQLGuaranteedDailyMetricScheduler extends SQLAnalyticalTaskScheduler {
 
     @Override

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLGuaranteedMonthlyScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLGuaranteedMonthlyScheduler.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
  * Provides the executor which is responsible for scheduling {@link MonthlyMetricComputer} instances which refer
  * to {@link sirius.db.jdbc.SQLEntity sql entities} on a monthly basis.
  */
-@Register(framework = SQLMetrics.FRAMEWORK_JDBC_METRICS)
+@Register
 public class SQLGuaranteedMonthlyScheduler extends SQLAnalyticalTaskScheduler {
 
     @Override

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLMonthlyLargeMetricsScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLMonthlyLargeMetricsScheduler.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
  * Provides the executor which is responsible for scheduling {@link MonthlyLargeMetricComputer} instances which refer
  * to {@link sirius.db.jdbc.SQLEntity sql entities} on a monthly basis.
  */
-@Register(framework = SQLMetrics.FRAMEWORK_JDBC_METRICS)
+@Register
 public class SQLMonthlyLargeMetricsScheduler extends SQLAnalyticalTaskScheduler {
 
     @Override

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoBestEffortDailyScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoBestEffortDailyScheduler.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
  * Provides the executor which is responsible for scheduling {@link MonthlyMetricComputer} instances which refer
  * to {@link sirius.db.mongo.MongoEntity mongo entities} on a daily basis using the best effort principle.
  */
-@Register(framework = MongoMetrics.FRAMEWORK_MONGO_METRICS)
+@Register
 public class MongoBestEffortDailyScheduler extends MongoAnalyticalTaskScheduler {
 
     @Override

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoGuaranteedDailyMetricScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoGuaranteedDailyMetricScheduler.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
  * Provides the executor which is responsible for scheduling {@link DailyMetricComputer} instances which refer
  * to {@link sirius.db.mongo.MongoEntity mongo entities} on a daily basis.
  */
-@Register(framework = MongoMetrics.FRAMEWORK_MONGO_METRICS)
+@Register
 public class MongoGuaranteedDailyMetricScheduler extends MongoAnalyticalTaskScheduler {
 
     @Override

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoGuaranteedMonthlyScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoGuaranteedMonthlyScheduler.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
  * Provides the executor which is responsible for scheduling {@link MonthlyMetricComputer} instances which refer
  * to {@link sirius.db.mongo.MongoEntity mongo entities} on a monthly basis.
  */
-@Register(framework = MongoMetrics.FRAMEWORK_MONGO_METRICS)
+@Register
 public class MongoGuaranteedMonthlyScheduler extends MongoAnalyticalTaskScheduler {
 
     @Override

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoMonthlyLargeMetricsScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoMonthlyLargeMetricsScheduler.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
  * Provides the executor which is responsible for scheduling {@link MonthlyLargeMetricComputer} instances which refer
  * to {@link sirius.db.mongo.MongoEntity mongo entities} on a monthly basis.
  */
-@Register(framework = MongoMetrics.FRAMEWORK_MONGO_METRICS)
+@Register
 public class MongoMonthlyLargeMetricsScheduler extends MongoAnalyticalTaskScheduler {
 
     @Override


### PR DESCRIPTION
Schedulers are disabled if not needed anyway. We must not disable them generally, as e.g. the ProcessesDailyMetrics are registered as SQLDailyGlobalMetricComputer but should even work in Mongo environments as the underlying entities are stored in Elastic (which doesn't have its own computer and scheduler).