### PR TITLE
Removes jemalloc as main allocator in Jupiter

### DIFF
--- a/src/main/java/sirius/biz/jupiter/Jupiter.java
+++ b/src/main/java/sirius/biz/jupiter/Jupiter.java
@@ -180,11 +180,6 @@ public class Jupiter implements MetricProvider {
     @Override
     public void gather(MetricsCollector metricsCollector) {
         if (getDefault().isConfigured()) {
-            metricsCollector.metric("jupiter_memory",
-                                    "jupiter-memory",
-                                    "Jupiter-Memory",
-                                    Metric.bytesToMebibytes(getDefault().getAllocatedMemory()),
-                                    Metric.UNIT_MIB);
             metricsCollector.metric("jupiter_fallback",
                                     "jupiter-fallback",
                                     "Jupiter Fallback",

--- a/src/main/java/sirius/biz/jupiter/JupiterConnector.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnector.java
@@ -35,7 +35,6 @@ import java.util.function.Supplier;
  */
 public class JupiterConnector {
 
-    private static final JupiterCommand CMD_SYS_MEM = new JupiterCommand("SYS.MEM");
     private static final JupiterCommand CMD_SET_CONFIG = new JupiterCommand("SYS.SET_CONFIG");
 
     /**
@@ -250,25 +249,6 @@ public class JupiterConnector {
 
     protected boolean isFallbackActive() {
         return fallbackActiveUntil > System.currentTimeMillis();
-    }
-
-    /**
-     * Determines the allocated memory of the connected Jupiter instance
-     *
-     * @return the allocated memory in bytes
-     */
-    protected long getAllocatedMemory() {
-        try {
-            return queryDirect(() -> "SYS.MEM", client -> {
-                client.sendCommand(CMD_SYS_MEM, "raw");
-                return client.getIntegerMultiBulkReply().get(0);
-            });
-        } catch (Exception e) {
-            // As the monitoring command was introduced later, we simply return 0 if an error occurs
-            // (which most probably indicates that the Jupiter version is too old).
-            Exceptions.ignore(e);
-            return 0;
-        }
     }
 
     @Override


### PR DESCRIPTION
We used this to properly track the ram usage. However, it turned out, that the reported ram usage is incomplete (e.g. as C libraries still malloc).

See:
* https://github.com/scireum/jupiter/pull/16