### PR TITLE
Changes the way global "batches" are executed.

### DIFF
--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsSchedulerExecutor.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsSchedulerExecutor.java
@@ -58,6 +58,11 @@ public abstract class AnalyticsSchedulerExecutor implements DistributedTaskExecu
 
         if (batchBuffer.get() != null) {
             scheduleBatch(scheduler, date, level, true, batchBuffer.get());
+        } else {
+            // We did not generate any batches. Therefore, we need to emit an empty placeholder batch so that
+            // the AnalyticsBatchExecutor sees the "SCHEDULE_NEXT_LEVEL" flag. This completely empty batch will be
+            // filtered out later...
+            scheduleBatch(scheduler, date, level, true, new JSONObject());
         }
     }
 

--- a/src/main/java/sirius/biz/analytics/scheduler/BaseAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/BaseAnalyticalTaskScheduler.java
@@ -28,6 +28,16 @@ import java.util.function.Consumer;
  */
 abstract class BaseAnalyticalTaskScheduler<B extends BaseEntity<?>> implements AnalyticsScheduler {
 
+    /**
+     * Marks a generated placeholder batches for global tasks.
+     * <p>
+     * Global tasks (to be executed once and not per entity) as commonly created against
+     * {@link sirius.db.mongo.MongoEntity} or {@link sirius.db.jdbc.SQLEntity} respectively. These neither can nor need
+     * to create any batches of entities. Rather, an empty batch is created which has this marker enabled. This is
+     * picked up be the appropriate batch executor and a single run is performed.
+     */
+    protected static final String CONTEXT_MARKER_GLOBAL_ENTITY = "markerGlobalEntity";
+
     @Part
     protected GlobalContext context;
 

--- a/src/main/java/sirius/biz/analytics/scheduler/MongoAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/MongoAnalyticalTaskScheduler.java
@@ -39,9 +39,12 @@ public abstract class MongoAnalyticalTaskScheduler extends BaseAnalyticalTaskSch
     @Override
     protected void scheduleBatches(Class<? extends MongoEntity> type, Consumer<JSONObject> batchConsumer) {
         try {
-            if (Modifier.isAbstract(type.getModifiers()) || mixing.findDescriptor(type).isEmpty()) {
-                batchConsumer.accept(new JSONObject());
-            } else {
+            if (Modifier.isAbstract(type.getModifiers())) {
+                // We use MongoEntity.class as place-holder to run global metric computers.
+                // In this case we execute a simple run for "null"...
+                batchConsumer.accept(new JSONObject().fluentPut(BaseAnalyticalTaskScheduler.CONTEXT_MARKER_GLOBAL_ENTITY,
+                                                                true));
+            } else if (mixing.findDescriptor(type).isPresent()) {
                 batchEmitter.computeBatches(type, this::extendBatchQuery, getBatchSize(), batch -> {
                     batchConsumer.accept(batch);
                     return true;
@@ -80,9 +83,13 @@ public abstract class MongoAnalyticalTaskScheduler extends BaseAnalyticalTaskSch
 
     @Override
     public void executeBatch(JSONObject batchDescription, LocalDate date, int level) {
-        if (!batchDescription.containsKey(BaseEntityBatchEmitter.TYPE)) {
+        if (batchDescription.containsKey(BaseAnalyticalTaskScheduler.CONTEXT_MARKER_GLOBAL_ENTITY)) {
+            // A global run was detected, execute with "null" and MongoEntity as type...
             executeEntity(null, MongoEntity.class, date, level);
-        } else {
+        } else if (batchDescription.containsKey(BaseEntityBatchEmitter.TYPE)) {
+            // Note that we check for the presence of the TYPE, as (in case of some schedulers) we emit
+            // an empty batch, just to ensure that executors with the higher levels are executed, even if
+            // there are no tasks on the current level (see AnalyticalBatchExecutor.executeWork...)
             batchEmitter.evaluateBatch(batchDescription,
                                        this::extendBatchQuery,
                                        e -> executeEntity(e, e.getClass(), date, level));

--- a/src/main/java/sirius/biz/analytics/scheduler/SQLAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/SQLAnalyticalTaskScheduler.java
@@ -84,7 +84,7 @@ public abstract class SQLAnalyticalTaskScheduler extends BaseAnalyticalTaskSched
     @Override
     public void executeBatch(JSONObject batchDescription, LocalDate date, int level) {
         if (batchDescription.containsKey(BaseAnalyticalTaskScheduler.CONTEXT_MARKER_GLOBAL_ENTITY)) {
-            // A global run was detected, execute with "null" and MongoEntity as type...
+            // A global run was detected, execute with "null" and SQLEntity as type...
             executeEntity(null, SQLEntity.class, date, level);
         } else if (batchDescription.containsKey(BaseEntityBatchEmitter.TYPE)) {
             // Note that we check for the presence of the TYPE, as (in case of some schedulers) we emit

--- a/src/main/java/sirius/biz/analytics/scheduler/SQLAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/SQLAnalyticalTaskScheduler.java
@@ -40,7 +40,7 @@ public abstract class SQLAnalyticalTaskScheduler extends BaseAnalyticalTaskSched
     protected void scheduleBatches(Class<? extends SQLEntity> type, Consumer<JSONObject> batchConsumer) {
         try {
             if (Modifier.isAbstract(type.getModifiers())) {
-                // We use MongoEntity.class as place-holder to run global metric computers.
+                // We use SQLEntity.class as place-holder to run global metric computers.
                 // In this case we execute a simple run for "null"...
                 batchConsumer.accept(new JSONObject().fluentPut(BaseAnalyticalTaskScheduler.CONTEXT_MARKER_GLOBAL_ENTITY,
                                                                 true));


### PR DESCRIPTION
For global metric tasks, we used abstract classes like MongoEntity or SQLEntity and created a "fake" batch which was empty otherwise. Additionally, in some cases - namely 1) in case of an exception and 2) in case of no entities present at all - no batch was generated at all.

However, having multiple levels we actually rely on at least one batch being present, so that we can add the LAST_BATCH marker and thus scheduler the next
level. So, for global runs, we now no longer use an completely empty batch description, but one with a special flag being set. Additionally, in the cases named above, we emit a completely empty batch - which is used to forward the LAST_BATCH marker but is then safely discarded.