### PR TITLE
Returns null for empty StringParameter

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/StringParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/StringParameter.java
@@ -48,6 +48,12 @@ public class StringParameter extends TextParameter<String, StringParameter> {
         if (input.getRawString() == null) {
             return defaultValue;
         }
+
+        // Always return null when no default value was used and the input is empty or null.
+        if (input.isEmptyString()) {
+            return null;
+        }
+
         return input.getString();
     }
 


### PR DESCRIPTION
This basically restores the previous behavior. If no default was returned, and the parameter is empty (either not in context or provided blank) we want to return a null string. Reason for that is that the output is often used in DB queries where null is expected instead of an empty string.

Fixes: [SIRI-713](https://scireum.myjetbrains.com/youtrack/issue/SIRI-713)