### PR TITLE
Improve dropzone progress bar

### DIFF
--- a/src/main/resources/default/assets/scripts/vfs-dropzone-and-modals.js
+++ b/src/main/resources/default/assets/scripts/vfs-dropzone-and-modals.js
@@ -377,12 +377,6 @@ function createInplaceDropzone(basePath, localId, _input, allowedExtensions, dic
                 document.addEventListener('dragover', function (event) {
                     event.preventDefault();
                 });
-                document.addEventListener('dragend', function (event) {
-                    hideIndicators();
-                }, false);
-                document.addEventListener('drop', function (event) {
-                    hideIndicators();
-                }, false);
                 document.addEventListener('dragleave', function (event) {
                     if (sirius.isDragleaveEventLeavingWindow(event)) {
                         hideIndicators();
@@ -400,7 +394,10 @@ function createInplaceDropzone(basePath, localId, _input, allowedExtensions, dic
                 _dropzoneIndicator.addEventListener('drop', function (event) {
                     event.preventDefault();
                 });
-                dropzone.on('drop', function () {
+                dropzone.on('sending', function () {
+                    hideIndicators();
+                });
+                dropzone.on('reset', function () {
                     hideIndicators();
                 });
             }


### PR DESCRIPTION
- on "drop" and "dragend", the progress-div is not yet initialized, so we hide it before the upload even starts
- on "sending" the progress div IS initialized, so we use this event instead
- on "reset" we probably need to hide the dropzone altogether.