### PR TITLE
VFS: Uses the correct timezone for outputting blob modified dates

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -455,7 +455,7 @@ public class L3Uplink implements VFSRoot {
 
     private long lastModifiedSupplier(VirtualFile file) {
         return file.tryAs(Blob.class)
-                   .map(blob -> blob.getLastModified().toInstant(ZoneOffset.UTC).toEpochMilli())
+                   .map(blob -> blob.getLastModified().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
                    .orElse(0L);
     }
 


### PR DESCRIPTION
We changed the display/fetch logic in the VFS controller to use the default zone, so we have to use the default zone here too. Otherwise these can be different resulting in time offsets when displaying the dates (e.g. uploaded 5 mins ago -> displayed as uploaded in 55 mins)

<img width="966" alt="image" src="https://user-images.githubusercontent.com/2427877/218401544-70ec36e7-25cc-47c2-b0ed-b647977aeab8.png">
