### PR TITLE
MLS Text Area: Fixes layout of language selection

### DIFF
--- a/src/main/resources/default/assets/javascript/multiLanguageField.js
+++ b/src/main/resources/default/assets/javascript/multiLanguageField.js
@@ -265,7 +265,9 @@ MultiLanguageField.prototype.shouldRenderDropdownInsteadOfTabs = function () {
 
 MultiLanguageField.prototype.renderLanguageLink = function (langCode) {
     const _anchor = document.createElement('a');
-    _anchor.classList.add('nav-link');
+    if (this.multiline) {
+        _anchor.classList.add('nav-link');
+    }
     _anchor.classList.add('mls-language-label');
     _anchor.href = '#' + this.fieldName + '-' + langCode;
     _anchor.dataset.toggle = 'tab';

--- a/src/main/resources/default/assets/scripts/multi-language-field.js
+++ b/src/main/resources/default/assets/scripts/multi-language-field.js
@@ -266,7 +266,9 @@ MultiLanguageField.prototype.shouldRenderDropdownInsteadOfTabs = function () {
 
 MultiLanguageField.prototype.renderLanguageLink = function (langCode, active) {
     const _anchor = document.createElement('a');
-    _anchor.classList.add('nav-link');
+    if (this.multiline) {
+        _anchor.classList.add('nav-link');
+    }
     _anchor.classList.add('mls-language-label');
     if (active) {
         _anchor.classList.add('active');

--- a/src/main/resources/default/assets/styles/multiLanguageField.scss
+++ b/src/main/resources/default/assets/styles/multiLanguageField.scss
@@ -65,6 +65,11 @@ input.form-control.mls-input {
     }
   }
 
+  .dropdown-menu {
+    max-height: 140px;
+    overflow: auto;
+  }
+
   .dropdown-item a {
     color: #495057;
   }

--- a/src/main/resources/default/assets/stylesheets/multiLanguageField.scss
+++ b/src/main/resources/default/assets/stylesheets/multiLanguageField.scss
@@ -94,19 +94,14 @@ input.form-control.mls-input {
     margin-left: 8px;
   }
 
-  .mls-add-language-button .dropdown-menu {
-    max-height: 140x;
+  .dropdown-menu {
+    max-height: 140px;
     overflow: auto;
   }
 
   .mls-toggle-language-button {
     a {
       color: #5e6468;
-    }
-
-    .dropdown-menu {
-      max-height: 140px;
-      overflow: auto;
     }
   }
 

--- a/src/main/resources/default/taglib/t/multiLanguageTextArea.html.pasta
+++ b/src/main/resources/default/taglib/t/multiLanguageTextArea.html.pasta
@@ -29,7 +29,7 @@
             <ul class="nav nav-tabs mls-tab-list" role="tablist">
                 <li class="nav-item dropdown mls-toggle-language-button d-none" role="presentation">
                     <a class="nav-link dropdown-toggle mls-language-label" data-toggle="dropdown" href="#">Dropdown</a>
-                    <ul class="dropdown-menu toggle-language-data"></ul>
+                    <ul class="dropdown-menu dropdown-menu-right toggle-language-data"></ul>
                 </li>
 
                 <li class="dropdown mls-add-language-button d-none" role="presentation">
@@ -37,7 +37,7 @@
                        aria-haspopup="true" aria-expanded="false" title="@i18n('MultiLanguageEditor.addLanguage')">
                         <i class="fa fa-plus"></i>
                     </a>
-                    <ul class="dropdown-menu"></ul>
+                    <ul class="dropdown-menu dropdown-menu-right"></ul>
                 </li>
             </ul>
             <i:if test="isFilled(label)">

--- a/src/main/resources/default/taglib/t/multiLanguageTextArea.html.pasta
+++ b/src/main/resources/default/taglib/t/multiLanguageTextArea.html.pasta
@@ -37,7 +37,7 @@
                        aria-haspopup="true" aria-expanded="false" title="@i18n('MultiLanguageEditor.addLanguage')">
                         <i class="fa fa-plus"></i>
                     </a>
-                    <ul class="dropdown-menu add-language-data"></ul>
+                    <ul class="dropdown-menu"></ul>
                 </li>
             </ul>
             <i:if test="isFilled(label)">

--- a/src/main/resources/default/taglib/w/multiLanguageTextArea.html.pasta
+++ b/src/main/resources/default/taglib/w/multiLanguageTextArea.html.pasta
@@ -41,7 +41,7 @@
                            aria-haspopup="true" aria-expanded="false" title="@i18n('MultiLanguageEditor.addLanguage')">
                             <i class="fa fa-plus"></i>
                         </a>
-                        <ul class="dropdown-menu add-language-data"></ul>
+                        <ul class="dropdown-menu"></ul>
                     </li>
                 </ul>
             </div>

--- a/src/main/resources/default/taglib/w/multiLanguageTextArea.html.pasta
+++ b/src/main/resources/default/taglib/w/multiLanguageTextArea.html.pasta
@@ -33,7 +33,7 @@
                 <ul class="nav nav-tabs mls-tab-list" role="tablist">
                     <li class="dropdown mls-toggle-language-button hidden" role="presentation">
                         <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="tab">Dropdown</a>
-                        <ul class="dropdown-menu toggle-language-data"></ul>
+                        <ul class="dropdown-menu dropdown-menu-right toggle-language-data"></ul>
                     </li>
 
                     <li class="dropdown mls-add-language-button hidden" role="presentation">
@@ -41,7 +41,7 @@
                            aria-haspopup="true" aria-expanded="false" title="@i18n('MultiLanguageEditor.addLanguage')">
                             <i class="fa fa-plus"></i>
                         </a>
-                        <ul class="dropdown-menu"></ul>
+                        <ul class="dropdown-menu dropdown-menu-right"></ul>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Fixes: [SIRI-696](https://scireum.myjetbrains.com/youtrack/issue/SIRI-696)

The existing styles for `max-height` and `overflow` were not properly applied.

Tycho:
<img src="https://user-images.githubusercontent.com/42942954/219094561-3515086e-7070-4267-8465-6608db180027.png" data-canonical="https://user-images.githubusercontent.com/42942954/219094561-3515086e-7070-4267-8465-6608db180027.png" width="400"/>

Wondergem:
<img src="https://user-images.githubusercontent.com/42942954/219094628-2ee4c9e0-ece7-4398-bc28-f1667fece9e7.png" data-canonical="https://user-images.githubusercontent.com/42942954/219094628-2ee4c9e0-ece7-4398-bc28-f1667fece9e7.png" width="400"/>

More compact selection in modal:
<img src="https://user-images.githubusercontent.com/42942954/219104592-fdc6d11f-227c-4af2-b758-9296e238f0f2.png" data-canonical="https://user-images.githubusercontent.com/42942954/219104592-fdc6d11f-227c-4af2-b758-9296e238f0f2.png" width="600"/>
