### PR TITLE
Metrics: Queries the correct class for mongo user metrics

### DIFF
--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantGlobalMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantGlobalMetricComputer.java
@@ -54,14 +54,14 @@ public class MongoTenantGlobalMetricComputer extends MongoMonthlyGlobalMetricCom
                                                      .count());
         metrics.updateGlobalMonthlyMetric(GlobalTenantMetricComputer.METRIC_NUM_USERS,
                                           date,
-                                          (int) mango.selectFromSecondary(MongoTenant.class)
+                                          (int) mango.selectFromSecondary(MongoUserAccount.class)
                                                      .eq(MongoUserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.LOGIN)
                                                                                            .inner(LoginData.ACCOUNT_LOCKED),
                                                          false)
                                                      .count());
         metrics.updateGlobalMonthlyMetric(GlobalTenantMetricComputer.METRIC_NUM_ACTIVE_USERS,
                                           date,
-                                          (int) mango.selectFromSecondary(MongoTenant.class)
+                                          (int) mango.selectFromSecondary(MongoUserAccount.class)
                                                      .eq(MongoUserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.LOGIN)
                                                                                            .inner(LoginData.ACCOUNT_LOCKED),
                                                          false)


### PR DESCRIPTION
This explains why the chart is completely empty :)

![image](https://user-images.githubusercontent.com/2427877/219490175-40e19b6c-152b-4b13-b2b6-9fa6b1849a83.png)

Fixes: [SIRI-657](https://scireum.myjetbrains.com/youtrack/issue/SIRI-657)