### PR TITLE
Allows error messages to wrap in details view

### DIFF
--- a/src/main/resources/default/templates/biz/protocol/error.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/error.html.pasta
@@ -19,7 +19,7 @@
     <div class="card mb-4">
         <div class="card-body">
             <h5 class="card-title">@i18n("StoredIncident.message")</h5>
-            <pre class="mt-4 mb-0">@incident.getMessage()</pre>
+            <pre class="mt-4 mb-0" style="white-space: normal">@incident.getMessage()</pre>
         </div>
     </div>
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2427877/220864732-15592667-d03d-43d9-9aa4-2cb4aaffa38a.png)

After:

![image](https://user-images.githubusercontent.com/2427877/220864812-cdf74e60-b3a7-4cd1-b9e7-79b5d1bfb4e0.png)
