### PR TITLE
Preserves the intentional use of whitespace for formatting in tagliatelle errors

### DIFF
--- a/src/main/resources/default/templates/biz/protocol/error.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/error.html.pasta
@@ -19,7 +19,7 @@
     <div class="card mb-4">
         <div class="card-body">
             <h5 class="card-title">@i18n("StoredIncident.message")</h5>
-            <pre class="mt-4 mb-0" style="white-space: normal">@incident.getMessage()</pre>
+            <pre class="mt-4 mb-0" style="white-space: pre-wrap">@incident.getMessage()</pre>
         </div>
     </div>
 

--- a/src/main/resources/default/templates/biz/protocol/error.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/error.html.pasta
@@ -19,7 +19,7 @@
     <div class="card mb-4">
         <div class="card-body">
             <h5 class="card-title">@i18n("StoredIncident.message")</h5>
-            <pre class="mt-4 mb-0" style="white-space: pre-wrap">@incident.getMessage()</pre>
+            <pre class="mt-4 mb-0 whitespace-pre-wrap">@incident.getMessage()</pre>
         </div>
     </div>
 


### PR DESCRIPTION
The previous attempt to optimize the error message layout (see commit 4068508a5111d0ecbe2f714f7c7cfe015554be05) was flawed, as it destroyed the helpful formatting of Tagliatelle error messages. We now go for a pre-wrap formatting which combines the best of both worlds.

Before:

![image](https://user-images.githubusercontent.com/2427877/220869726-9a09361a-0045-4179-b130-f0d08f038049.png)

After:

![image](https://user-images.githubusercontent.com/2427877/220869787-9ec94752-d5f8-4263-8c81-5983aad74644.png)

![image](https://user-images.githubusercontent.com/2427877/220869854-a45f4fe6-a36e-4f51-922d-ae48bbff0b85.png)

