### PR TITLE
CodeListLookupTable: Returns emtpy stream instead of throwing an exception.

### DIFF
--- a/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
@@ -156,7 +156,7 @@ class CodeListLookupTable extends LookupTable {
     protected Stream<LookupTableEntry> performQuery(String language, String lookupPath, String lookupValue) {
         // This would need a complex caching strategy as always fetching the DB would be too expensive.
         // Could be implemented when needed.
-        throw new UnsupportedOperationException();
+        return Stream.empty();
     }
 
     @Override


### PR DESCRIPTION
This matches the behavior of other not yet implemented methods of this class.

Fixes: OX-9525