### PR TITLE
adjust css for menu size on small widths

### DIFF
--- a/src/main/resources/default/assets/styles/menu.scss
+++ b/src/main/resources/default/assets/styles/menu.scss
@@ -16,14 +16,31 @@ li.right-menu-icon {
 
 }
 
-@media (max-width: 768px) {
+@media (max-width: 991px) {
   // Make fa icons the same size as our provided pngs in the collapsed (hamburger) menu...
-  .right-menu-icon svg{
-    width: 1.5rem !important;
+  li.right-menu-icon {
+    padding-left: 0;
+    border-right: none !important;
+
+    svg {
+      width: 1.5rem !important;
+    }
+  }
+  // Do not oversize the user icon in the collapsed (hamburger) menu...
+  li.right-large-menu-icon {
+    img {
+      height: 1.5rem;
+    }
   }
 }
 
-@media (min-width: 768px) {
+@media (min-width: 992px) {
+  // Make fa icons the same size as our provided pngs in the expanded (normal) menu...
+  li.right-menu-icon {
+    >a {
+      line-height: 2;
+    }
+  }
   // Make the user icon a bit more prominent in the expanded (normal) menu...
   li.right-large-menu-icon {
     a {
@@ -49,7 +66,7 @@ li.right-menu-icon {
   }
 
   input::placeholder {
-    color: rgba(0,0,0, 0.5);
+    color: rgba(0, 0, 0, 0.5);
     font-weight: lighter;
   }
 }


### PR DESCRIPTION
increased the fa search-icon size in the header on big widths and decreased the icon size of skip and the system-view on small widths. also removed destroying left padding and border on small width and move the breakpoint (see screenshot)
before:
<img width="1662" alt="Bildschirm­foto 2023-03-02 um 07 41 56" src="https://user-images.githubusercontent.com/55080004/222351146-839fa92a-9337-4dd5-a876-97b80b3f22b9.png">

after:
<img width="1643" alt="Bildschirm­foto 2023-03-02 um 07 39 56" src="https://user-images.githubusercontent.com/55080004/222350747-5c387dce-5be4-41ba-8aa6-70934dd1b73e.png">
