### PR TITLE
BREAKING: Improves the download with filename functionality by splitting the filename from the download in order to allow inline downloads

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
@@ -435,7 +435,7 @@ public class BlobDispatcher implements WebDispatcher {
                                                                  boolean largeFileExpected) {
         URLBuilder urlBuilder = new URLBuilder(storageSpace, blobKey);
         if (download) {
-            urlBuilder.asDownload(filename);
+            urlBuilder.withFileName(filename).asDownload();
         }
         if (Strings.isFilled(variant)) {
             urlBuilder.withVariant(variant);

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -575,7 +575,8 @@ public class L3Uplink implements VFSRoot {
         file.as(Blob.class)
             .url()
             .enableLargeFileDetection()
-            .asDownload(file.name())
+            .withFileName(file.name())
+            .asDownload()
             .buildURL()
             .ifPresentOrElse(blobDeliveryUrl -> response.redirectTemporarily(blobDeliveryUrl),
                              () -> response.error(HttpResponseStatus.NOT_FOUND));

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -174,6 +174,17 @@ public class URLBuilder {
     }
 
     /**
+     * Specifies the name of the file.
+     *
+     * @param path the filename to send to the browser
+     * @return the builder itself for fluent method calls
+     */
+    public URLBuilder withFileName(String path) {
+        this.filename = Files.getFilenameAndExtension(path);
+        return this;
+    }
+
+    /**
      * Make the URL a download url using the given filename.
      *
      * @param path the filename to send to the browser

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -189,6 +189,7 @@ public class URLBuilder {
      *
      * @param path the filename to send to the browser
      * @return the builder itself for fluent method calls
+     * @deprecated use {@link #withFileName(String)} in combination with {@link #asDownload()} instead.
      */
     @Deprecated(forRemoval = true)
     public URLBuilder asDownload(String path) {

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -179,6 +179,7 @@ public class URLBuilder {
      * @param path the filename to send to the browser
      * @return the builder itself for fluent method calls
      */
+    @Deprecated(forRemoval = true)
     public URLBuilder asDownload(String path) {
         this.filename = Files.getFilenameAndExtension(path);
         this.forceDownload = true;


### PR DESCRIPTION
# Migration Guide
Replace `.asDownload(String)` calls by `.withFileName(String).asDownload()`

Fixes: [SIRI-749](https://scireum.myjetbrains.com/youtrack/issue/SIRI-749/URLBuilder-Inline-Download-handling-ermoglichen)