### PR TITLE
Permits Jupiter to sync against multiple S3 repositories (buckets)

### DIFF
--- a/src/main/java/sirius/biz/jupiter/JupiterConfigUpdater.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConfigUpdater.java
@@ -22,9 +22,9 @@ public interface JupiterConfigUpdater {
     /**
      * Invoked to contribute to the config in <tt>config</tt> for the given instance.
      *
-     * @param instance     the name of the instance which is to be configured
+     * @param connector    the instance which is to be configured
      * @param systemConfig the extension / settings block for this instance in the system config
      * @param config       the config to contribute to
      */
-    void emitConfig(String instance, Extension systemConfig, Map<String, Object> config);
+    void emitConfig(JupiterConnector connector, Extension systemConfig, Map<String, Object> config);
 }

--- a/src/main/java/sirius/biz/jupiter/JupiterConnector.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnector.java
@@ -12,12 +12,14 @@ import redis.clients.jedis.Connection;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import sirius.db.redis.RedisDB;
+import sirius.kernel.Sirius;
 import sirius.kernel.async.Operation;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Microtiming;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -78,6 +80,15 @@ public class JupiterConnector {
      */
     public boolean isConfigured() {
         return redis.isConfigured();
+    }
+
+    /**
+     * Returns the list of namespaces which are enabled for this connector.
+     *
+     * @return the list of enabled namespaces
+     */
+    public List<String> fetchEnabledNamespaces() {
+        return Sirius.getSettings().getExtension("jupiter.settings", getName()).getStringList("repository.namespaces");
     }
 
     /**

--- a/src/main/java/sirius/biz/jupiter/JupiterSync.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSync.java
@@ -47,6 +47,7 @@ import java.io.OutputStream;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,19 +96,6 @@ public class JupiterSync implements Startable, EndOfDayTask {
 
     @ConfigValue("jupiter.syncRepository")
     private List<String> syncRepository;
-
-    @ConfigValue("jupiter.repository.uplink.store")
-    private String uplinkStore;
-
-    @ConfigValue("jupiter.repository.uplink.bucket")
-    private String uplinkBucket;
-
-    @ConfigValue("jupiter.repository.uplink.test-bucket")
-    @Nullable
-    private String uplinkTestBucket;
-
-    @ConfigValue("jupiter.repository.uplink.ignoredPaths")
-    private List<String> uplinkIgnoredPaths;
 
     @ConfigValue("jupiter.repository.localSpaceName")
     private String localRepoSpaceName;
@@ -281,7 +269,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
             Map<String, Object> config = new HashMap<>();
             Extension systemConfig = Sirius.getSettings().getExtension("jupiter.settings", connection.getName());
             for (JupiterConfigUpdater updater : updaters) {
-                updater.emitConfig(connection.getName(), systemConfig, config);
+                updater.emitConfig(connection, systemConfig, config);
             }
 
             String configString = asYaml(config);
@@ -346,7 +334,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
             List<Runnable> updateTasks = new ArrayList<>();
 
             syncLocalRepository(processContext, connection, repositoryFiles, updateTasks::add, filesToDelete);
-            syncUplinkRepository(processContext, connection, repositoryFiles, updateTasks::add, filesToDelete);
+            syncUplinkRepositories(processContext, connection, repositoryFiles, updateTasks::add, filesToDelete);
 
             for (String file : filesToDelete) {
                 processContext.log(ProcessLog.info()
@@ -381,37 +369,67 @@ public class JupiterSync implements Startable, EndOfDayTask {
         }
     }
 
+    private void syncUplinkRepositories(ProcessContext processContext,
+                                        JupiterConnector connection,
+                                        List<RepositoryFile> repositoryFiles,
+                                        Consumer<Runnable> updateTaskConsumer,
+                                        Set<String> filesToDelete) {
+        Set<String> enabledNamespaces = new HashSet<>(connection.fetchEnabledNamespaces());
+        for (Extension uplinkStore : Sirius.getSettings().getExtensions("jupiter.repository.uplinks")) {
+            String store = uplinkStore.get("store").asString();
+            String bucket = getEffectiveUplinkBucket(uplinkStore);
+            List<String> requiredNamespace = uplinkStore.getStringList("requiredNamespaces");
+            if (!requiredNamespace.isEmpty() && requiredNamespace.stream().noneMatch(enabledNamespaces::contains)) {
+                processContext.debug(ProcessLog.info()
+                                               .withFormattedMessage(
+                                                       "Skipping uplink checks for %s / %s as none of the required namespaces is enabled.",
+                                                       uplinkStore.getId(),
+                                                       connection.getName()));
+            } else if (Strings.isEmpty(store) || Strings.isEmpty(bucket) || !objectStores.isConfigured(store)) {
+                processContext.debug(ProcessLog.info()
+                                               .withFormattedMessage(
+                                                       "Skipping uplink checks for %s / %s as no repository or bucket is configured.",
+                                                       uplinkStore.getId(),
+                                                       connection.getName()));
+            } else {
+                syncUplinkRepository(processContext,
+                                     connection,
+                                     repositoryFiles,
+                                     updateTaskConsumer,
+                                     filesToDelete,
+                                     uplinkStore);
+            }
+        }
+    }
+
     private void syncUplinkRepository(ProcessContext processContext,
                                       JupiterConnector connection,
                                       List<RepositoryFile> repositoryFiles,
                                       Consumer<Runnable> updateTaskConsumer,
-                                      Set<String> filesToDelete) {
-        if (Strings.isEmpty(uplinkStore) || Strings.isEmpty(getEffectiveUplinkBucket())) {
-            processContext.debug(ProcessLog.info()
-                                           .withFormattedMessage(
-                                                   "Skipping uplink checks for %s as no repository or bucket is configured.",
-                                                   connection.getName()));
-            return;
-        }
+                                      Set<String> filesToDelete,
+                                      Extension uplinkStore) {
+        String store = uplinkStore.get("store").asString();
+        String bucket = getEffectiveUplinkBucket(uplinkStore);
 
         processContext.debug(ProcessLog.info()
-                                       .withFormattedMessage("Checking uplink repository (%s in %s) for %s...",
-                                                             getEffectiveUplinkBucket(),
-                                                             uplinkStore,
+                                       .withFormattedMessage("Checking uplink repository %s (%s in %s) for %s...",
+                                                             uplinkStore.getId(),
+                                                             bucket,
+                                                             store,
                                                              connection.getName()));
 
-        ObjectStore store = objectStores.getStore(uplinkStore);
-        BucketName uplinkBucketName = store.getBucketName(getEffectiveUplinkBucket());
-        store.listObjects(uplinkBucketName, null, object -> {
-            if (object.getSize() > 0 && uplinkIgnoredPaths.stream()
-                                                          .noneMatch(ignoredPath -> object.getKey()
-                                                                                          .startsWith(ignoredPath))) {
+        ObjectStore objectStore = objectStores.getStore(store);
+        BucketName uplinkBucketName = objectStore.getBucketName(bucket);
+        objectStore.listObjects(uplinkBucketName, null, object -> {
+            if (object.getSize() > 0 && uplinkStore.getStringList("ignoredPaths")
+                                                   .stream()
+                                                   .noneMatch(ignoredPath -> object.getKey().startsWith(ignoredPath))) {
                 handleUplinkFile(processContext,
                                  connection,
                                  repositoryFiles,
                                  updateTaskConsumer,
                                  filesToDelete,
-                                 store,
+                                 objectStore,
                                  uplinkBucketName,
                                  object);
             }
@@ -420,12 +438,12 @@ public class JupiterSync implements Startable, EndOfDayTask {
         });
     }
 
-    private String getEffectiveUplinkBucket() {
-        if (!Sirius.isProd() && Strings.isFilled(uplinkTestBucket)) {
-            return uplinkTestBucket;
+    private String getEffectiveUplinkBucket(Extension uplinkStore) {
+        if (!Sirius.isProd() && Strings.isFilled(uplinkStore.getString("testBucket"))) {
+            return uplinkStore.getString("testBucket");
         }
 
-        return uplinkBucket;
+        return uplinkStore.getString("bucket");
     }
 
     @SuppressWarnings("java:S107")

--- a/src/main/java/sirius/biz/jupiter/LRUCacheConfigUpdater.java
+++ b/src/main/java/sirius/biz/jupiter/LRUCacheConfigUpdater.java
@@ -27,7 +27,7 @@ public class LRUCacheConfigUpdater implements JupiterConfigUpdater {
     private static final String KEY_CACHES = "caches";
 
     @Override
-    public void emitConfig(String instance, Extension systemConfig, Map<String, Object> config) {
+    public void emitConfig(JupiterConnector connector, Extension systemConfig, Map<String, Object> config) {
         if (!systemConfig.has(KEY_CACHES)) {
             return;
         }

--- a/src/main/java/sirius/biz/jupiter/RepositoryConfigUpdater.java
+++ b/src/main/java/sirius/biz/jupiter/RepositoryConfigUpdater.java
@@ -25,9 +25,9 @@ import java.util.Map;
 public class RepositoryConfigUpdater implements JupiterConfigUpdater {
 
     @Override
-    public void emitConfig(String instance, Extension systemConfig, Map<String, Object> config) {
+    public void emitConfig(JupiterConnector connector, Extension systemConfig, Map<String, Object> config) {
         Map<String, Object> repoConfig = new HashMap<>();
-        repoConfig.put("namespaces", systemConfig.getStringList("repository.namespaces"));
+        repoConfig.put("namespaces", connector.fetchEnabledNamespaces());
         config.put("repository", repoConfig);
     }
 }

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1734,21 +1734,29 @@ jupiter {
     syncRepository = [ "jupiter" ]
 
     repository {
-        # Contains the configuration to a S3 bucket which is synchronized to the Jupiter repository.
-        uplink {
-            # Contains the name of the s3 store which hosts the bucket.
-            store = ""
-            # Contains the name of the bucket to sync.
-            bucket = ""
-            # Contains the name of the bucket to sync when Sirius is running in DEV, STAGING or TEST mode.
-            # This can be used if the underlying datasource provides a preview location to test unreleased
-            # master data.
-            test-bucket = ""
+        # Contains the configurations to S3 buckets which are synchronized to the Jupiter repository.
+        uplinks {
+            default {
+                # Contains the name of the s3 store which hosts the bucket.
+                store = ""
 
-            # Contains a list of path prefixes which will be ignored when syncing.
-            # If the repository contains a "folder" (keys with a path prefix) named "media/.."
-            # which should not be transferred to Jupiter, this path could be listed below.
-            ignoredPaths = []
+                # Contains the name of the bucket to sync.
+                bucket = ""
+
+                # Contains the name of the bucket to sync when Sirius is running in DEV, STAGING or TEST mode.
+                # This can be used if the underlying datasource provides a preview location to test unreleased
+                # master data.
+                testBucket = ""
+
+                # Contains a list of path prefixes which will be ignored when syncing.
+                # If the repository contains a "folder" (keys with a path prefix) named "media/.."
+                # which should not be transferred to Jupiter, this path could be listed below.
+                ignoredPaths = []
+
+                # Contains a list of namespaces out of which at least one has to be active for the uplink
+                # repository to be synced. If this list is empty, no check is performed.
+                requiredNamespaces = []
+            }
         }
 
         # Contains the name of the layer 2 space which is also synchronized into the Jupiter repository.


### PR DESCRIPTION
We now utilize multiple repositories which are fed from different sources. Also, a repository can be ignored completely if none of the relevant namespaces is turned on.