### PR TITLE
Minor improvements for charts

### DIFF
--- a/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
+++ b/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
@@ -31,6 +31,7 @@ import sirius.web.services.JSONStructuredOutput;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -71,8 +72,11 @@ public class DataExplorerController extends BizController {
     @Routed("/data-explorer")
     @LoginRequired
     public void explorer(WebContext webContext) {
-        List<Action> actions =
-                factories.stream().filter(ChartFactory::isAccessibleToCurrentUser).map(this::toAction).toList();
+        List<Action> actions = factories.stream()
+                                        .filter(ChartFactory::isAccessibleToCurrentUser)
+                                        .map(this::toAction)
+                                        .sorted(Comparator.comparing(Action::getCategory))
+                                        .toList();
 
         webContext.respondWith().template("/templates/biz/tycho/analytics/data-explorer.html.pasta", actions);
     }

--- a/src/main/java/sirius/biz/analytics/explorer/MetricTimeSeriesComputer.java
+++ b/src/main/java/sirius/biz/analytics/explorer/MetricTimeSeriesComputer.java
@@ -34,6 +34,7 @@ public class MetricTimeSeriesComputer<E> implements TimeSeriesComputer<E> {
 
     private final String monthlyMetricName;
     private String dailyMetricName;
+    private String label;
     private Function<E, Object> projector;
 
     /**
@@ -57,6 +58,17 @@ public class MetricTimeSeriesComputer<E> implements TimeSeriesComputer<E> {
     }
 
     /**
+     * Specifies the label under which this time series is displayed in charts.
+     *
+     * @param label the label to be displayed
+     * @return the computer itself for fluent method calls
+     */
+    public MetricTimeSeriesComputer<E> withLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
      * Provides a projector to control what gets actually put into the <tt>of</tt> of {@link MetricQuery}.
      *
      * @param projector the projector which maps the selected chart entity to the actual value to query
@@ -70,7 +82,9 @@ public class MetricTimeSeriesComputer<E> implements TimeSeriesComputer<E> {
     @Override
     public void compute(E object, TimeSeries timeseries) throws Exception {
         TimeSeries effectiveTimeSeries = Strings.isFilled(dailyMetricName) ? timeseries : timeseries.toMonthlySeries();
-        TimeSeriesData data = effectiveTimeSeries.createDefaultData();
+        TimeSeriesData data = Strings.isFilled(label) ?
+                              effectiveTimeSeries.createData(label) :
+                              effectiveTimeSeries.createDefaultData();
         MetricQuery metricQuery = customizeQuery(project(object),
                                                  timeseries.getGranularity() == Granularity.DAY && Strings.isFilled(
                                                          dailyMetricName) ?


### PR DESCRIPTION

- Outputs available charts sorted by category, so they don't change positions when reloading the list
- Allows to distinguish multiple `MetricTimeSeriesComputer` with different labels in the same chart (similar to having `EventTimeSeriesComputer`s with aggregations)


![Bildschirm­foto 2023-03-21 um 18 01 41](https://user-images.githubusercontent.com/42942954/226686772-a9310a9b-a54c-4d41-8e9c-8755466063e3.png)



