### PR TITLE
Rejects deletions early when deleting complex-delete entities

### DIFF
--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -435,6 +435,7 @@ public class BizController extends BasicController {
                     assertTenant(tenantAware);
                 }
                 if (entity.getDescriptor().isComplexDelete() && processes != null) {
+                    entity.getDescriptor().getMapper().assertDeletable(entity);
                     deleteComplexEntity(entity);
                 } else {
                     entity.getDescriptor().getMapper().delete(entity);


### PR DESCRIPTION
S2 has entities which are both referenced via CASCADE and REJECT delete modes. If we delete one of these entities using `deleteEntity`, this would spawn a new process, which would immediately fail. This PR invokes the REJECT delete handlers before spawning the process.

Requires: https://github.com/scireum/sirius-db/pull/557
Fixes: [SE-12557](https://scireum.myjetbrains.com/youtrack/issue/SE-12557)