### PR TITLE
Brings job-documentation to Tycho

### DIFF
--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -127,7 +127,7 @@ public abstract class BasicJobFactory implements JobFactory {
      * @param collector the collector used to supply additional info sections for a job
      */
     protected void collectJobInfos(JobInfoCollector collector) {
-        collector.addWell(getDetailDescription());
+        collector.addCard(getDetailDescription());
     }
 
     @Override

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityExportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityExportJobFactory.java
@@ -137,7 +137,7 @@ public abstract class EntityExportJobFactory<E extends BaseEntity<?>, Q extends 
     @Override
     protected void collectJobInfos(JobInfoCollector collector) {
         super.collectJobInfos(collector);
-        collector.addTranslatedWell("EntityExportJobFactory.templateModes");
+        collector.addTranslatedCard("EntityExportJobFactory.templateModes");
         getDictionary().emitJobInfos(collector);
     }
 }

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -103,7 +103,7 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
     @Override
     protected void collectJobInfos(JobInfoCollector collector) {
         super.collectJobInfos(collector);
-        collector.addTranslatedWell("EntityImportJobFactory.automaticMappings");
+        collector.addTranslatedCard("EntityImportJobFactory.automaticMappings");
         getDictionary().emitJobInfos(collector);
     }
 

--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
@@ -122,7 +122,7 @@ public abstract class RelationalEntityImportJobFactory<E extends BaseEntity<?> &
     @Override
     protected void collectJobInfos(JobInfoCollector collector) {
         super.collectJobInfos(collector);
-        collector.addTranslatedWell("EntityImportJobFactory.automaticMappings");
+        collector.addTranslatedCard("EntityImportJobFactory.automaticMappings");
         getDictionary().emitJobInfos(collector);
     }
 

--- a/src/main/java/sirius/biz/jobs/infos/CardInfo.java
+++ b/src/main/java/sirius/biz/jobs/infos/CardInfo.java
@@ -9,21 +9,21 @@
 package sirius.biz.jobs.infos;
 
 /**
- * Renders a text block wrapped in a well.
+ * Renders a text block wrapped in a card.
  */
-public class WellInfo extends TextInfo {
+public class CardInfo extends TextInfo {
 
     /**
      * Creates a new text block.
      *
      * @param text the text to output in a well
      */
-    public WellInfo(String text) {
+    public CardInfo(String text) {
         super(text);
     }
 
     @Override
     public String getTemplateName() {
-        return "/templates/biz/jobs/infos/well.html.pasta";
+        return "/templates/biz/jobs/infos/card.html.pasta";
     }
 }

--- a/src/main/java/sirius/biz/jobs/infos/JobInfoCollector.java
+++ b/src/main/java/sirius/biz/jobs/infos/JobInfoCollector.java
@@ -88,31 +88,31 @@ public class JobInfoCollector {
     }
 
     /**
-     * Adds a {@link WellInfo well info}.
+     * Adds a {@link CardInfo well info}.
      *
-     * @param text the text to add as well
+     * @param text the text to add as card
      * @return the collector itself for fluent method calls
      */
-    public JobInfoCollector addWell(String text) {
+    public JobInfoCollector addCard(String text) {
         if (Strings.isEmpty(text)) {
             return this;
         }
 
-        return addInfo(new WellInfo(text));
+        return addInfo(new CardInfo(text));
     }
 
     /**
-     * Adds a {@link WellInfo text info} using a translated i18n key.
+     * Adds a {@link CardInfo text info} using a translated i18n key.
      *
      * @param i18nKey the key used to lookup the translated text
      * @return the collector itself for fluent method calls
      */
-    public JobInfoCollector addTranslatedWell(String i18nKey) {
-        return addWell(NLS.get(i18nKey));
+    public JobInfoCollector addTranslatedCard(String i18nKey) {
+        return addCard(NLS.get(i18nKey));
     }
 
     /**
-     * Adds a block of unsecaped HTML.
+     * Adds a block of unescaped HTML.
      *
      * @param html the html to add
      * @return the collector itself for fluent method calls

--- a/src/main/resources/default/taglib/t/report.html.pasta
+++ b/src/main/resources/default/taglib/t/report.html.pasta
@@ -2,12 +2,12 @@
 
 <t:emptyCheck data="report.getRows()">
     <div class="card mb-4">
-        <div class="card-body">
+        <div class="card-body table-responsive">
             <table class="table">
                 <thead>
                 <tr>
                     <i:for type="String" var="column" items="report.getLabels()">
-                        <th style="text-align: center">@column</th>
+                        <th class="text-nowrap">@column</th>
                     </i:for>
                 </tr>
                 </thead>
@@ -15,7 +15,7 @@
                 <i:for type="Map" var="row" items="report.getRows()">
                     <tr>
                         <i:for type="String" var="column" items="report.getColumns()">
-                            <td class="cell">
+                            <td>
                                 <i:raw>@row.get(column).as(sirius.biz.analytics.reports.Cell.class).render()</i:raw>
                             </td>
                         </i:for>

--- a/src/main/resources/default/templates/biz/jobs/infos.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos.html.pasta
@@ -1,6 +1,6 @@
 <i:arg type="sirius.biz.jobs.JobFactory" name="job"/>
 
-<w:page title="@job.getLabel()">
+<t:page title="@job.getLabel()">
     <i:block name="breadcrumbs">
         <li>
             <a href="/jobs">@i18n("JobFactory.plural")</a>
@@ -10,13 +10,12 @@
         </li>
     </i:block>
 
-    <w:pageHeader title="@job.getLabel()"/>
-
+    <t:pageHeader title="@job.getLabel()"/>
     <i:for type="sirius.biz.jobs.infos.JobInfo" var="info" items="job.getJobInfos()">
-        <i:dynamicInvoke template="@info.getTemplateName()" job="job" info="info" />
+        <i:dynamicInvoke template="@info.getTemplateName()" job="job" info="info"/>
     </i:for>
 
-    <div class="form-actions">
-        <a href="/job/@job.getName()" class="btn">@i18n("NLS.back")</a>
+    <div class="mt-4">
+        <t:backButton/>
     </div>
-</w:page>
+</t:page>

--- a/src/main/resources/default/templates/biz/jobs/infos/card.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos/card.html.pasta
@@ -1,0 +1,6 @@
+<i:arg type="sirius.biz.jobs.infos.TextInfo" name="info"/>
+<div class="card mb-4">
+    <div class="card-body">
+        @info.getText()
+    </div>
+</div>

--- a/src/main/resources/default/templates/biz/jobs/infos/heading.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos/heading.html.pasta
@@ -1,2 +1,2 @@
 <i:arg type="sirius.biz.jobs.infos.TextInfo" name="info"/>
-<w:subHeading label="@info.getText()"/>
+<t:heading label="@info.getText()"/>

--- a/src/main/resources/default/templates/biz/jobs/infos/report.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos/report.html.pasta
@@ -1,2 +1,2 @@
 <i:arg type="sirius.biz.jobs.infos.ReportInfo" name="info"/>
-<w:report report="info.getReport()" />
+<t:report report="info.getReport()"/>

--- a/src/main/resources/default/templates/biz/jobs/infos/well.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos/well.html.pasta
@@ -1,4 +1,0 @@
-<i:arg type="sirius.biz.jobs.infos.TextInfo" name="info"/>
-<div class="well">
-    @info.getText()
-</div>


### PR DESCRIPTION
BREAKING: 

addWell & addTranslatedWell are renamed to addCard & addTranslatedCard
Wherever used something like this, rename the method from addWell to addCard

`protected void collectJobInfos(JobInfoCollector collector) {
        collector.addWell(getDetailDescription());
    }`


Example:
<img width="1700" alt="Bildschirm­foto 2023-03-27 um 11 22 44" src="https://user-images.githubusercontent.com/55080004/227899856-366965cc-32d7-4bed-9d26-23f93b333912.png">

- fixes: SIRI-774