### PR TITLE
adjust styling for job-preset-list on job page

### DIFF
--- a/src/main/resources/default/templates/biz/jobs/job.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/job.html.pasta
@@ -58,17 +58,21 @@
                             <i:for type="sirius.biz.jobs.presets.JobPreset" var="preset"
                                    items="presets.fetchPresets(job)">
                                 <li class="list-group-item d-flex flex-row justify-content-between align-items-baseline">
-                                    <div><b>@preset.getJobConfigData().getLabel()</b></div>
+                                    <div class="text-truncate"><b>@preset.getJobConfigData().getLabel()</b></div>
                                     <div class="btn-group" role="group">
-                                        <a class="btn btn-outline-link"
+                                        <a class="btn btn-outline-link text-nowrap"
                                            href="javascript:loadPreset('@preset.getIdAsString()')">
                                             <i class="fa fa-check"></i>
-                                            @i18n("JobsController.usePreset")
+                                            <span class="d-sm-inline-block d-md-none d-xl-inline-block">
+                                                @i18n("JobsController.usePreset")
+                                            </span>
                                         </a>
-                                        <a class="btn btn-outline-danger pull-right"
+                                        <a class="btn btn-outline-danger pull-right text-nowrap"
                                            href="javascript:deletePreset('@preset.getIdAsString()')">
                                             <i class="fa fa-trash"></i>
-                                            @i18n("NLS.delete")
+                                            <span class="d-sm-inline-block d-md-none d-xl-inline-block">
+                                                @i18n("NLS.delete")
+                                            </span>
                                         </a>
                                     </div>
                                 </li>


### PR DESCRIPTION
long names now will be truncated with ... and buttons only displayed as icon on small screen

<img width="1145" alt="Bildschirm­foto 2023-03-28 um 13 59 39" src="https://user-images.githubusercontent.com/55080004/228229228-41f30fea-7934-403e-a9b1-8ef7256eef34.png">
<img width="784" alt="Bildschirm­foto 2023-03-28 um 13 59 51" src="https://user-images.githubusercontent.com/55080004/228229279-0e9c0220-bf20-439f-8694-84e4eedd9e2f.png">
<img width="727" alt="Bildschirm­foto 2023-03-28 um 14 00 05" src="https://user-images.githubusercontent.com/55080004/228229325-23c77943-a2ab-46ca-bf28-7f7baa3b2d1f.png">
