### PR TITLE
Increases performance deleting temporary blobs

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -61,7 +61,7 @@ import java.util.Optional;
 @Index(name = "blob_content_updated_loop", columns = "contentUpdated")
 @Index(name = "blob_deleted_loop", columns = "deleted")
 @Index(name = "blob_parent_changed_loop", columns = "parentChanged")
-@Index(name = "blob_delete_old_temporary_loop", columns = {"spaceName", "deleted", "lastModified", "temporary"})
+@Index(name = "blob_delete_temporary_loop", columns = {"spaceName", "temporary", "deleted", "lastModified"})
 @TranslationSource(Blob.class)
 public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
 

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -76,8 +76,8 @@ import java.util.Optional;
 @Index(name = "blob_content_updated_loop", columns = "contentUpdated", columnSettings = Mango.INDEX_ASCENDING)
 @Index(name = "blob_deleted_loop", columns = "deleted", columnSettings = Mango.INDEX_ASCENDING)
 @Index(name = "blob_parent_changed_loop", columns = "parentChanged", columnSettings = Mango.INDEX_ASCENDING)
-@Index(name = "blob_delete_old_temporary_loop",
-        columns = {"spaceName", "deleted", "lastModified", "temporary"},
+@Index(name = "blob_delete_temporary_loop",
+        columns = {"spaceName", "temporary", "deleted", "lastModified"},
         columnSettings = {Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING, Mango.INDEX_ASCENDING})
 @TranslationSource(Blob.class)
 public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {


### PR DESCRIPTION
Since only a few blobs are temporary, having this columns early in the index yields a much better performance.

So this change is not breaking, the updated index has been renamed, so the framework will insert a new index. As a patch task, the previous index shall be dropped.

- Mongo: `db.mongoblob.drop("blob_delete_old_temporary_loop")`
- SQL: `DROP INDEX IF EXISTS blob_delete_old_temporary_loop ON sqlblob NOWAIT`

Fixes: [SIRI-771](https://scireum.myjetbrains.com/youtrack/issue/SIRI-771)