### PR TITLE
Fixes and improves blob cache invalidation

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -269,13 +269,11 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * Caches the {@link Blob blobs} that belong to certain paths
      */
     protected static Cache<String, Blob> blobByPathCache = CacheManager.<Blob>createCoherentCache("storage-paths")
-                                                                       .addRemover(REMOVE_BY_FILENAME,
-                                                                                   (input, entry) -> entry.getValue()
-                                                                                                     == null
-                                                                                                     || Strings.areEqual(
-                                                                                           entry.getValue()
-                                                                                                .getFilename(),
-                                                                                           input));
+                                                                       .addValueBasedRemover(REMOVE_BY_FILENAME)
+                                                                       .removeIf((input, blob) -> blob == null
+                                                                                                  || Strings.areEqual(
+                                                                               blob.getFilename(),
+                                                                               input));
 
     protected final Extension config;
     protected final String description;

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -979,6 +979,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             throw Exceptions.createHandled().withNLSKey("BasicBlobStorageSpace.cannotRenameDuplicateName").handle();
         }
 
+        blobByPathCache.removeAll(REMOVE_BY_FILENAME, blob.getFilename());
         updateBlobName(blob, newName);
 
         blobKeyToFilenameCache.remove(blob.getBlobKey());
@@ -1127,6 +1128,9 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     public void updateContent(B blob, @Nullable String filename, File file) {
         String nextPhysicalId = keyGenerator.generateId();
         try {
+            if (Strings.isFilled(filename)) {
+                blobByPathCache.removeAll(REMOVE_BY_FILENAME, blob.getFilename());
+            }
             getPhysicalSpace().upload(nextPhysicalId, file);
             blobKeyToPhysicalCache.remove(buildCacheLookupKey(blob.getBlobKey(), URLBuilder.VARIANT_RAW));
             Optional<String> previousPhysicalId = updateBlob(blob, nextPhysicalId, file.length(), filename);
@@ -1180,6 +1184,9 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     public void updateContent(B blob, String filename, InputStream data, long contentLength) {
         String nextPhysicalId = keyGenerator.generateId();
         try {
+            if (Strings.isFilled(filename)) {
+                blobByPathCache.removeAll(REMOVE_BY_FILENAME, blob.getFilename());
+            }
             getPhysicalSpace().upload(nextPhysicalId, data, contentLength);
             blobKeyToPhysicalCache.remove(buildCacheLookupKey(blob.getBlobKey(), URLBuilder.VARIANT_RAW));
             Optional<String> previousPhysicalId = updateBlob(blob, nextPhysicalId, contentLength, filename);


### PR DESCRIPTION
- in case of blob changes, we need to cleanup all relevant caches
- unfortunately, the blobByPathCache works with paths that are not available at some layer 2 methods, so we cannot determine the cache keys
- so we use removal by filename as a good compromise to remove all required, but not to much. null value entries get removed as well

Fixes: SIRI-776