### PR TITLE
Permits to start conversions from a local file

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1486,7 +1486,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     }
 
     /**
-     * Actually attempts to either lookup or create the requested variant.
+     * Actually attempts to either look up or create the requested variant.
      *
      * @param blob        the blob for which the variant is to be resolved
      * @param variantName the variant of the blob to find
@@ -1545,7 +1545,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         }
 
         if (conversionEnabled && !retryLimitReached(variant)) {
-            // A variant exists and we should re-try to create it...
+            // A variant exists, and we should re-try to create it...
             if (markConversionAttempt(variant)) {
                 // We successfully marked this as "in conversion" -> fork a conversion task in parallel
                 invokeConversionPipelineAsync(blob, variant);

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1647,8 +1647,10 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * @return a future holding the conversion process
      */
     private Future invokeConversionPipelineAsync(B blob, FileHandle inputFile, V variant) {
-        ConversionProcess conversionProcess =
-                new ConversionProcess(blob, variant.getVariantName()).withInputFile(inputFile.getFile());
+        ConversionProcess conversionProcess = new ConversionProcess(blob, variant.getVariantName());
+        if (inputFile != null) {
+            conversionProcess.withInputFile(inputFile.getFile());
+        }
 
         Future future = conversionEngine.performConversion(conversionProcess);
         future.onSuccess(ignored -> {

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1641,13 +1641,14 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     /**
      * Spawns a thread which will actually invoke the appropriate conversion pipeline.
      *
-     * @param blob    the blob for which the variant is to be created
-     * @param variant the variant to generate
+     * @param blob      the blob for which the variant is to be created
+     * @param inputFile the file handle holding the file to use as input for the conversion
+     * @param variant   the variant to generate
      * @return a future holding the conversion process
      */
-    private Future invokeConversionPipelineAsync(B blob, File inputFile, V variant) {
+    private Future invokeConversionPipelineAsync(B blob, FileHandle inputFile, V variant) {
         ConversionProcess conversionProcess =
-                new ConversionProcess(blob, variant.getVariantName()).withInputFile(inputFile);
+                new ConversionProcess(blob, variant.getVariantName()).withInputFile(inputFile.getFile());
 
         Future future = conversionEngine.performConversion(conversionProcess);
         future.onSuccess(ignored -> {
@@ -1739,12 +1740,12 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * Tries to create the requested variant if the variant does not exist already.
      *
      * @param blob        the blob for which the variant is to be created
-     * @param inputFile   the input file to use for the conversion
+     * @param inputFile   the file handle holding the file to use as input for the conversion
      * @param variantName the variant to generate
      * @param retries     the number of retries left
      * @return a future holding the conversion process
      */
-    private Future tryCreateVariant(B blob, File inputFile, String variantName, int retries) {
+    private Future tryCreateVariant(B blob, FileHandle inputFile, String variantName, int retries) {
         if (retries == 0) {
             Future future = new Future();
             future.fail(new IllegalStateException(Strings.apply(
@@ -1802,11 +1803,11 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * Tries to create the requested variant if the variant does not exist already.
      *
      * @param blob        the blob for which the variant is to be created
-     * @param inputFile   the input file to use for the conversion
+     * @param inputFile   the file handle holding the file to use as input for the conversion
      * @param variantName the variant to generate
      * @return a future holding the conversion process
      */
-    public Future tryCreateVariant(B blob, File inputFile, String variantName) {
+    public Future tryCreateVariant(B blob, FileHandle inputFile, String variantName) {
         return tryCreateVariant(blob, inputFile, variantName, NUMBER_OF_ATTEMPTS_FOR_OPTIMISTIC_LOCKS);
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/Blob.java
+++ b/src/main/java/sirius/biz/storage/layer2/Blob.java
@@ -40,7 +40,7 @@ public interface Blob {
     /**
      * Returns the name of the {@link #getStorageSpace() storage space}.
      *
-     * @return the name of the stroage space in which this directory resides.
+     * @return the name of the storage space in which this directory resides.
      */
     String getSpaceName();
 
@@ -123,7 +123,7 @@ public interface Blob {
     LocalDateTime getLastTouched();
 
     /**
-     * Provides a on-disk copy of the data associated with this blob
+     * Provides an on-disk copy of the data associated with this blob
      *
      * @return a handle to the data of this blob
      */
@@ -187,7 +187,7 @@ public interface Blob {
      * Provides new content for this blob.
      * <p>
      * Also note that if a file is used to provide the new contents of this blob, use
-     * {@link #updateContent(String, File)} as this is likely way more efficient.
+     * {@link #updateContent(String, File)} as this way is likely more efficient.
      * <p>
      * Note that this blob object itself will also be updated with the appropriate metadata
      * (filename, size, lastModified).
@@ -200,7 +200,7 @@ public interface Blob {
     void updateContent(@Nullable String filename, InputStream data, long contentLength);
 
     /**
-     * Creates a output stream which can be used to update the contents of this blob.
+     * Creates an output stream which can be used to update the contents of this blob.
      * <p>
      * The data written into the output stream will be buffered locally and used to update the contents once the
      * stream is closed. Use {@link #updateContent(String, File)} if a file is used to update the contents or
@@ -215,7 +215,7 @@ public interface Blob {
     OutputStream createOutputStream(@Nullable String filename);
 
     /**
-     * Creates a output stream which can be used to update the contents of this blob.
+     * Creates an output stream which can be used to update the contents of this blob.
      * <p>
      * Stores the contents once the stream is closed just like {@link #createOutputStream(String)} but permits to add a callback
      * which is invoked once the blob has been updated.

--- a/src/main/java/sirius/biz/storage/layer2/Blob.java
+++ b/src/main/java/sirius/biz/storage/layer2/Blob.java
@@ -138,6 +138,15 @@ public interface Blob {
     Future tryCreateVariant(String variantName);
 
     /**
+     * Tries to create the desired variant using the given input file, which bypasses the download from the blob.
+     *
+     * @param variantName the name of the desired variant
+     * @param inputFile   the file to use as input for the conversion
+     * @return a future holding the conversion process
+     */
+    Future tryCreateVariant(File inputFile, String variantName);
+
+    /**
      * Determines if this blob is still marked as temporary.
      *
      * @return <tt>true</tt> if the blob is temporary, <tt>false</tt> otherwise

--- a/src/main/java/sirius/biz/storage/layer2/Blob.java
+++ b/src/main/java/sirius/biz/storage/layer2/Blob.java
@@ -141,10 +141,10 @@ public interface Blob {
      * Tries to create the desired variant using the given input file, which bypasses the download from the blob.
      *
      * @param variantName the name of the desired variant
-     * @param inputFile   the file to use as input for the conversion
+     * @param inputFile   the file handle holding the file to use as input for the conversion
      * @return a future holding the conversion process
      */
-    Future tryCreateVariant(File inputFile, String variantName);
+    Future tryCreateVariant(FileHandle inputFile, String variantName);
 
     /**
      * Determines if this blob is still marked as temporary.

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -319,6 +319,11 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
     }
 
     @Override
+    public Future tryCreateVariant(File inputFile, String variantName) {
+        return getStorageSpace().tryCreateVariant(this, inputFile, variantName);
+    }
+
+    @Override
     public void delete() {
         getStorageSpace().delete(this);
     }

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -319,7 +319,7 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
     }
 
     @Override
-    public Future tryCreateVariant(File inputFile, String variantName) {
+    public Future tryCreateVariant(FileHandle inputFile, String variantName) {
         return getStorageSpace().tryCreateVariant(this, inputFile, variantName);
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -244,7 +244,7 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
         updateFilenameFields();
 
         if (deleted) {
-            // The blob has been deleted. Reset all other flags since its now pointless to trigger any BlobChangedHandler.
+            // The blob has been deleted. Reset all other flags since it's now pointless to trigger any BlobChangedHandler.
             created = false;
             renamed = false;
             contentUpdated = false;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -326,6 +326,11 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
     }
 
     @Override
+    public Future tryCreateVariant(File inputFile, String variantName) {
+        return getStorageSpace().tryCreateVariant(this, inputFile, variantName);
+    }
+
+    @Override
     public void delete() {
         getStorageSpace().delete(this);
     }

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -251,7 +251,7 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
         updateFilenameFields();
 
         if (deleted) {
-            // The blob has been deleted. Reset all other flags since its now pointless to trigger any BlobChangedHandler.
+            // The blob has been deleted. Reset all other flags since it's now pointless to trigger any BlobChangedHandler.
             created = false;
             renamed = false;
             contentUpdated = false;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -326,7 +326,7 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
     }
 
     @Override
-    public Future tryCreateVariant(File inputFile, String variantName) {
+    public Future tryCreateVariant(FileHandle inputFile, String variantName) {
         return getStorageSpace().tryCreateVariant(this, inputFile, variantName);
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
@@ -124,7 +124,7 @@ public class ConversionProcess {
     /**
      * Provides the file to use as input for the conversion.
      * <p>
-     * This is useful when the file already exist in the file system, skipping a new download from storage.
+     * This is useful when the file already exists in the file system, skipping a new download from storage.
      *
      * @param fileToConvert the file to use as input
      * @return the object itself for fluent method calls
@@ -138,8 +138,8 @@ public class ConversionProcess {
     /**
      * Returns a file handle to an input file for conversion.
      * <p>
-     * This can either be a permanent file handle over a previously supplied file or a temporary one over a fresh
-     * downloaded file from the {@linkplain #blobToConvert blob}.
+     * This can either be a permanent file handle pointing to a previously supplied file, or a temporary one
+     * pointing to a file freshly downloaded from the {@linkplain #blobToConvert blob}.
      *
      * @return a {@link FileHandle} to the file to use for conversion
      * @throws Exception if a file cannot be obtained

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
@@ -16,7 +16,7 @@ import sirius.kernel.commons.Watch;
 /**
  * Covers the task of performing a conversion of a given {@link Blob} into a {@link BlobVariant} of the desired type.
  * <p>
- * This class is sort of a data transfer type as it wraps both, the input parameters as well as the output/result and
+ * This class is sort of a data transfer type as it wraps both, the input parameters and the output/result and
  * some performance metrics.
  */
 public class ConversionProcess {

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
@@ -114,9 +114,11 @@ public class ConversionProcess {
      * Used by the {@link Converter} to supply the actual result of the conversion.
      *
      * @param fileHandle the file to use as variant
+     * @return the object itself for fluent method calls
      */
-    public void withConversionResult(FileHandle fileHandle) {
+    public ConversionProcess withConversionResult(FileHandle fileHandle) {
         this.fileHandle = fileHandle;
+        return this;
     }
 
     /**


### PR DESCRIPTION
This is very useful in jobs already holding a physical file which can be used as source to generate several variants, without having to download the original file each time for every conversion.

Fixes: [SIRI-768](https://scireum.myjetbrains.com/youtrack/issue/SIRI-768)