### PR TITLE
Fixes moving of files via SFTP

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeFileSystemAccessor.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeFileSystemAccessor.java
@@ -21,12 +21,10 @@ import java.io.IOException;
 import java.nio.channels.Channel;
 import java.nio.channels.FileLock;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
-import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -79,11 +77,5 @@ class BridgeFileSystemAccessor implements SftpFileSystemAccessor {
                                                Path dir,
                                                String handle) throws IOException {
         return new BridgeDirectoryStream(((BridgePath) dir).getVirtualFile(), (BridgeFileSystem) dir.getFileSystem());
-    }
-
-    @Override
-    public void renameFile(SftpSubsystemProxy subsystem, Path oldPath, Path newPath, Collection<CopyOption> opts)
-            throws IOException {
-        ((BridgePath) oldPath).getVirtualFile().rename(newPath.getFileName().toString());
     }
 }


### PR DESCRIPTION
PR #1554 implemented `renameFile` to fix renaming of files via SFTP. Unfortunately, that change broke moving them, as both are the same operation in POSIX. The default implementation uses `Files#move`, which triggers `BridgeFileSystemProvider#move`, so it makes sense to handle both cases there.

Some clients (mainly CLI) can move and rename at the same time, but implementing this increases the complexity quite a bit because our framework views both as separate operations. We keep it simple and only support one at a time. For most clients and use-cases this should be fine.

Fixes: [SIRI-775](https://scireum.myjetbrains.com/youtrack/issue/SIRI-775)