### PR TITLE
Computes the effective file name to convert

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
@@ -48,7 +48,7 @@ public class FSObjectStorageSpace extends ObjectStorageSpace {
     public static final String CONFIG_KEY_LAYER1_PATH = "path";
 
     /**
-     * Contains the base directory which will contain a sub directory per storage space.
+     * Contains the base directory which will contain a subdirectory per storage space.
      */
     public static final String CONFIG_KEY_LAYER1_BASE_DIR = "baseDir";
 

--- a/src/main/java/sirius/biz/storage/layer1/FileHandle.java
+++ b/src/main/java/sirius/biz/storage/layer1/FileHandle.java
@@ -65,7 +65,7 @@ public class FileHandle implements Closeable {
      * Provides access to the underlying file.
      * <p>
      * This has to be handled with absolute care as one might not know if the file is a temporary copy or if
-     * it represents the permanently stored file. Therefore modifying this file in any way is strictly prohibited.
+     * it represents the permanently stored file. Therefore, modifying this file in any way is strictly prohibited.
      *
      * @return the underlying file
      */
@@ -78,7 +78,7 @@ public class FileHandle implements Closeable {
      * <p>
      * Note that this stream must not be accessed after {@link #close()} hase been called.
      *
-     * @return an stream reading from the file
+     * @return a stream reading from the file
      * @throws FileNotFoundException in case of a non-existing file
      */
     public InputStream getInputStream() throws FileNotFoundException {

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -155,7 +155,7 @@ public abstract class ObjectStorageSpace {
     /**
      * Creates a new cipher transformer which is used to encrypt data being written.
      *
-     * @return a cipher transfomer with the appropriate encryption / cipher settings
+     * @return a cipher transformer with the appropriate encryption / cipher settings
      */
     protected ByteBlockTransformer createEncrypter() {
         return new CipherTransformer(cipherProvider.createEncryptionCipher());
@@ -183,7 +183,7 @@ public abstract class ObjectStorageSpace {
     /**
      * Creates a new inflate transformer used when reading data.
      *
-     * @return a inflate transformer to use
+     * @return an inflate transformer to use
      */
     protected ByteBlockTransformer createInflater() {
         return new InflateTransformer();
@@ -328,7 +328,7 @@ public abstract class ObjectStorageSpace {
      *
      * @param objectId the object to download
      * @return a promise which is fulfilled with the downloaded data. Note that an empty optional is used to signal
-     * that the object with the given ID doesnt exist
+     * that the object with the given ID doesn't exist
      */
     public Promise<Optional<FileHandle>> downloadAsync(String objectId) {
         Promise<Optional<FileHandle>> promise = new Promise<>();
@@ -365,7 +365,7 @@ public abstract class ObjectStorageSpace {
     }
 
     /**
-     * Downloads an provides the contents of the requested object.
+     * Downloads and provides the contents of the requested object.
      *
      * @param objectKey the id of the object
      * @return a handle to the given object or <tt>null</tt> if the object doesn't exist
@@ -378,13 +378,13 @@ public abstract class ObjectStorageSpace {
      * Downloads and provides the contents of the requested object asynchronous.
      *
      * @param objectKey the id of the object
-     * @return a a promise which is fulfilled with the handle for the given object once it is downloaded. If the object
+     * @return a promise which is fulfilled with the handle for the given object once it is downloaded. If the object
      * doesn't exist, the promise will be fulfilled with <tt>null</tt>.
      */
     protected abstract Promise<FileHandle> getDataAsync(String objectKey);
 
     /**
-     * Downloads an provides the contents of the requested object.
+     * Downloads and provides the contents of the requested object.
      *
      * @param objectKey   the id of the object
      * @param transformer the transform to apply when reading data
@@ -408,7 +408,7 @@ public abstract class ObjectStorageSpace {
      * Provides direct access to the contents of the requested object.
      *
      * @param objectId the physical storage key
-     * @return the contents a input stream
+     * @return the contents as input stream
      */
     public Optional<InputStream> getInputStream(String objectId) {
         try {
@@ -566,7 +566,7 @@ public abstract class ObjectStorageSpace {
      *
      * @param response       the response to populate
      * @param objectKey      the id of the object to deliver
-     * @param failureHandler a handler which cann be invoked if the download cannot be performed.
+     * @param failureHandler a handler which can be invoked if the download cannot be performed.
      *                       This will be supplied with the HTTP error code.
      * @throws IOException in case of an IO error
      */
@@ -639,7 +639,7 @@ public abstract class ObjectStorageSpace {
     public abstract void iterateObjects(Predicate<ObjectMetadata> objectHandler) throws IOException;
 
     /**
-     * Returns the configuration block which was used to setup this space.
+     * Returns the configuration block which was used to set up this space.
      *
      * @return the settings of this space
      */
@@ -650,7 +650,7 @@ public abstract class ObjectStorageSpace {
     /**
      * Specifies the replication space to use.
      * <p>
-     * This should be exlusively used by  the {@link ReplicationManager} to setup the replication framework.
+     * This should be exclusively used by  the {@link ReplicationManager} to set up the replication framework.
      *
      * @param replicationSpace the space to replicate all data to
      */

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
@@ -46,7 +46,7 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
     public static final String CONFIG_KEY_LAYER1_STORE = "store";
 
     /**
-     * Contains the bucket name within the S3 store to use. By default the name of the space will
+     * Contains the bucket name within the S3 store to use. By default, the name of the space will
      * be used.
      */
     private static final String CONFIG_KEY_LAYER1_BUCKET_NAME = "bucketName";
@@ -77,7 +77,7 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
 
         if (!objectStores.isConfigured(storeName)) {
             StorageUtils.LOG.WARN(
-                    "Layer 1/S3: Unknown or unconfigured object store '%s' used by space '%s'. Using system default.",
+                    "Layer 1/S3: Unknown or non-configured object store '%s' used by space '%s'. Using system default.",
                     storeName,
                     extension.getId());
             return objectStores.store();
@@ -192,8 +192,8 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
     protected Promise<FileHandle> getDataAsync(String objectId, ByteBlockTransformer transformer) {
         Promise<FileHandle> result = new Promise<>();
 
-        // We cannot use the AWS TransferManager for an async download here, as we have to apply our transfomer.
-        // Therefore we run the whole task in a separate thread...
+        // We cannot use the AWS TransferManager for an async download here, as we have to apply our transformer.
+        // Therefore, we run the whole task in a separate thread...
         tasks.executor(ObjectStore.EXECUTOR_S3).fork(() -> {
             try {
                 result.success(getData(objectId, transformer));

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
@@ -155,6 +155,18 @@ public class ConversionProcess {
         return inputFile;
     }
 
+    /**
+     * Returns the file name of the input file used for conversion.
+     *
+     * @return the file name of the supplied file or the {@link Blob#getFilename()}
+     */
+    public String getEffectiveFileName() {
+        if (fileToConvert != null) {
+            return fileToConvert.getName();
+        }
+        return getBlobToConvert().getFilename();
+    }
+
     private FileHandle obtainFileToConvert() throws FileNotFoundException {
         if (fileToConvert == null) {
             return null;

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
@@ -157,11 +157,16 @@ public class ConversionProcess {
 
     /**
      * Returns the file name of the input file used for conversion.
+     * <p>
+     * Files downloaded from external storage are temporary, with the .tmp extension. Conversions usually check if
+     * the file extension is relevant for the target format, so in this case we must fall back to the blob's file name.
+     * This will usually be the case for a recently downloaded file from a {@linkplain Blob} which will be chained
+     * into several conversions.
      *
-     * @return the file name of the supplied file or the {@link Blob#getFilename()}
+     * @return the file name of the supplied file if it's not a tmp file or the {@link Blob#getFilename()}
      */
     public String getEffectiveFileName() {
-        if (fileToConvert != null) {
+        if (fileToConvert != null && !fileToConvert.getName().endsWith(".tmp")) {
             return fileToConvert.getName();
         }
         return getBlobToConvert().getFilename();

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -106,7 +106,7 @@ public class ObjectStore {
     private static Tasks tasks;
 
     /**
-     * Provides some book keeping and monitoring for S3 up- and downloads.
+     * Provides some bookkeeping and monitoring for S3 up- and downloads.
      */
     private class MonitoringProgressListener implements S3ProgressListener {
 
@@ -398,13 +398,13 @@ public class ObjectStore {
     }
 
     /**
-     * Generates a presigned download URL for the given object.
+     * Generates a pre-signed download URL for the given object.
      * <p>
      * This can be used to {@link sirius.web.http.Response#tunnel(String)} the data to a client.
      *
      * @param bucket   the bucket in which the object resides
      * @param objectId the object to generate the url for
-     * @return a presigned download URL for the object
+     * @return a pre-signed download URL for the object
      */
     public String objectUrl(BucketName bucket, String objectId) {
         GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket.getName(), objectId);


### PR DESCRIPTION
Determines the effective file name to use for conversions.
This is necessary as the file extension is often validated as a pre-condition if a file is valid as input format. 

When `ConversionProcess.withInputFile` is used #1672, we need to know this file name instead, BUT, if the file has a `.tmp` extension we fall back to the blob's name. This very likely represents a fresh downloaded file.

**Side-Note**: the perfect solution would be to allow downloads to write a suffix to the temporary files, but that change is not so easily implemented, not without possible breaking changes.

Fixes: [OX-9819](https://scireum.myjetbrains.com/youtrack/issue/OX-9819)