### PR TITLE
Sorts data-explorer entries by chart priority.

### DIFF
--- a/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
+++ b/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
@@ -74,8 +74,8 @@ public class DataExplorerController extends BizController {
     public void explorer(WebContext webContext) {
         List<Action> actions = factories.stream()
                                         .filter(ChartFactory::isAccessibleToCurrentUser)
+                                        .sorted(Comparator.comparing(ChartFactory::getPriority))
                                         .map(this::toAction)
-                                        .sorted(Comparator.comparing(Action::getCategory))
                                         .toList();
 
         webContext.respondWith().template("/templates/biz/tycho/analytics/data-explorer.html.pasta", actions);


### PR DESCRIPTION
Sorting by category name was suboptimal and the category itself has no priority.

Fixes: [OX-9825](https://scireum.myjetbrains.com/youtrack/issue/OX-9825)