### PR TITLE
Enhances the parsing of a VirtualFile's path from a given URI

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -1497,14 +1497,14 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                                  .flatMap(List::stream)
                                  .filter(path -> fileExtensionVerifier.test(Files.getFileExtension(path)))
                                  .findFirst()
-                                 .orElseGet(() -> queryStringDecoder.parameters()
-                                                                    .entrySet()
-                                                                    .stream()
-                                                                    .filter(entry -> queryParameterSelector.test(entry.getKey()))
-                                                                    .map(Map.Entry::getValue)
-                                                                    .flatMap(List::stream)
-                                                                    .findFirst()
-                                                                    .orElse(null));
+                                 .or(() -> queryStringDecoder.parameters()
+                                                             .entrySet()
+                                                             .stream()
+                                                             .filter(entry -> queryParameterSelector.test(entry.getKey()))
+                                                             .map(Map.Entry::getValue)
+                                                             .flatMap(List::stream)
+                                                             .findFirst())
+                                 .orElse(null);
     }
 
     private Tuple<VirtualFile, Boolean> resolveViaHeadRequest(URI url,

--- a/src/test/java/sirius/biz/storage/layer3/VirtualFileTest.java
+++ b/src/test/java/sirius/biz/storage/layer3/VirtualFileTest.java
@@ -1,0 +1,33 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.layer3;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VirtualFileTest {
+
+    @Test
+    void parseVirtualFilePathByQueryParameter() {
+        String searchedParameterName = "unique-id";
+        String parameterValue = "uniqueIdentifier";
+
+        URI uri = URI.create("https://something.also.not.proving.content-disposition/cdn?"
+                             + searchedParameterName
+                             + "="
+                             + parameterValue
+                             + "&another-id=not-relevant");
+        String path = VirtualFile.parsePathFromUrl(uri, ignored -> false, name -> name.equals(searchedParameterName));
+
+        assertEquals(path, parameterValue);
+    }
+}


### PR DESCRIPTION
### Description

- Extends VirtualFile's capability of parsing a path from a URL by giving the possibility to define a predicate to select a query string parameter that contains the path.

### Additional Notes

<!--
    Please fill out additional details.
-->

- This PR fixes or works on following ticket(s): [SE-12654](https://scireum.myjetbrains.com/youtrack/issue/SE-12654)

### Checklist

<!--
    Set a "x" in the boxes that apply.
    You can also fill these out after creating the PR.
    Not all of these are required, they are simply reminders.
    Please do not add, remove or alter any of the stated points.
-->

- [x] The code change has been tested and works locally
- [x] No commented-out code is introduced in this PR
- [x] No new Sonarlint issues were added (except for TODOs and Deprecations)
- [x] The code was formatted via IntelliJ and follows general best practices (see [CodeStyle / JavaDoc](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc))
- [x] Testing: junit
- [x] Documentation:  javadoc  <!-- State wether documentation (in Code, Readme, KBA) was added/updated or not. -->
