### PR TITLE
Temporarily reduce the length of logged incidences, mails, and messages

### DIFF
--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -128,8 +128,8 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
                 si.getMdc().put(t.getFirst(), t.getSecond());
             }
             si.setUser(UserContext.getCurrentUser().getProtocolUsername());
-            si.setMessage(incident.getException().getMessage());
-            si.setStack(NLS.toUserString(incident.getException()));
+            si.setMessage(Strings.limit(incident.getException().getMessage(), 30000, false)); // TODO SIRI-793: Remove this limit
+            si.setStack(Strings.limit(NLS.toUserString(incident.getException()), 30000, false)); // TODO SIRI-793: Remove this limit
             si.setCategory(incident.getCategory());
             si.setLastOccurrence(LocalDateTime.now());
 
@@ -219,8 +219,8 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
             msg.setReceiver(receiver);
             msg.setReceiverName(receiverName);
             msg.setSubject(subject);
-            msg.setTextContent(text);
-            msg.setHtmlContent(html);
+            msg.setTextContent(Strings.limit(text, 30000, false)); // TODO SIRI-793: Remove this limit
+            msg.setHtmlContent(Strings.limit(html, 30000, false)); // TODO SIRI-793: Remove this limit
             msg.setSuccess(success);
             msg.setNode(CallContext.getNodeName());
             msg.setType(type);

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -612,7 +612,8 @@ protocols {
     # low memory conditions or overload the AutoBatchLoop and ES. Note that the logging system which
     # captures stdout will still receive the full message. Still consider to limit yourself to
     # sane and digestible log messages.
-    maxLogMessageLength = 116384
+    # TODO SIRI-793: Increase this limit to 116384 again
+    maxLogMessageLength = 30000
 }
 
 # The audit log can write additional logs to the system log.


### PR DESCRIPTION
ES < 8.7.0 has a bug were it wrongfully raises an error for  fields longer than 32766 that are not indexed in lucene (see https://github.com/elastic/elasticsearch/pull/93299).

This PR introduces a temporary limit on the length of some commonly long fields of logging entities and lowers the configured default length of LoggedMessage. We use 30k instead of 32766 as ES checks the byte length and not the character count. 30k should be good enough as the number of non-ASCII characters should be quite low.

Fixes: [SIRI-786](https://scireum.myjetbrains.com/youtrack/issue/SIRI-786)