### PR TITLE
Fixes the export feature of the DataExplorer: now values are being exported properly

### DIFF
--- a/src/main/java/sirius/biz/analytics/explorer/ChartFactory.java
+++ b/src/main/java/sirius/biz/analytics/explorer/ChartFactory.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.analytics.explorer;
 
+import sirius.biz.analytics.metrics.Dataset;
 import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.AutoRegister;
 import sirius.kernel.di.std.Named;
@@ -312,8 +313,8 @@ public abstract class ChartFactory<O> implements Named, Priorized {
      * @return one or more time series to be exported
      * @throws Exception in case of any error when computing the chart data
      */
-    protected abstract List<TimeSeriesData> computeExportableTimeSeries(O object,
-                                                                        TimeSeries timeSeries,
-                                                                        ComparisonPeriod comparisonPeriod)
+    protected abstract List<Dataset> computeExportableTimeSeries(O object,
+                                                                 TimeSeries timeSeries,
+                                                                 ComparisonPeriod comparisonPeriod)
             throws Exception;
 }

--- a/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
+++ b/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
@@ -205,8 +205,7 @@ public class DataExplorerController extends BizController {
                                     .computeExportableTimeSeries(providerAndObject.getSecond(),
                                                                  timeSeries,
                                                                  comparisonPeriod)
-                                    .stream()
-                                    .map(timeSeriesData -> timeSeriesData.toDataset(timeSeries));
+                                    .stream();
         } catch (Exception error) {
             Exceptions.handle()
                       .to(Log.BACKGROUND)

--- a/src/main/java/sirius/biz/analytics/explorer/TimeSeriesChartFactory.java
+++ b/src/main/java/sirius/biz/analytics/explorer/TimeSeriesChartFactory.java
@@ -168,26 +168,23 @@ public abstract class TimeSeriesChartFactory<O> extends ChartFactory<O> {
         String label = getChartLabel(object);
         String subLabel = getChartSubLabel(object);
 
+        List<TimeSeriesData> data = new ArrayList<>();
+        timeSeries.withDataConsumer(data::add);
+
         TimeSeries comparisonTimeSeries = timeSeries.comparisonSeries(comparisonPeriod);
-
-        List<Dataset> result = new ArrayList<>();
-
-        // Enhance labels with the chart label and sub label so that the column names are more descriptive...
-        timeSeries.withDataConsumer(timeSeriesData -> {
-            if (Strings.isFilled(subLabel)) {
-                timeSeriesData.setLabel(label + " (" + subLabel + ") - " + timeSeriesData.getLabel());
-            } else {
-                timeSeriesData.setLabel(label + " - " + timeSeriesData.getLabel());
-            }
-            if (timeSeriesData.isComparisonTimeSeries()) {
-                result.add(timeSeriesData.toDataset(comparisonTimeSeries));
-            } else {
-                result.add(timeSeriesData.toDataset(timeSeries));
-            }
-        });
-
         executeComputers(object, comparisonPeriod, timeSeries, comparisonTimeSeries);
 
-        return result;
+        return data.stream().map(timeseriesData -> {
+            if (Strings.isFilled(subLabel)) {
+                timeseriesData.setLabel(label + " (" + subLabel + ") - " + timeseriesData.getLabel());
+            } else {
+                timeseriesData.setLabel(label + " - " + timeseriesData.getLabel());
+            }
+            if (timeseriesData.isComparisonTimeSeries()) {
+                return timeseriesData.toDataset(comparisonTimeSeries);
+            } else {
+                return timeseriesData.toDataset(timeSeries);
+            }
+        }).toList();
     }
 }

--- a/src/main/java/sirius/biz/analytics/explorer/TimeSeriesChartFactory.java
+++ b/src/main/java/sirius/biz/analytics/explorer/TimeSeriesChartFactory.java
@@ -111,9 +111,9 @@ public abstract class TimeSeriesChartFactory<O> extends ChartFactory<O> {
     }
 
     private void executeComputers(O object,
-                           ComparisonPeriod comparisonPeriod,
-                           TimeSeries timeSeries,
-                           TimeSeries comparisonTimeSeries) throws Exception {
+                                  ComparisonPeriod comparisonPeriod,
+                                  TimeSeries timeSeries,
+                                  TimeSeries comparisonTimeSeries) throws Exception {
         // Run all "main" computers...
         computers(object, comparisonPeriod != ComparisonPeriod.NONE, false, computer -> {
             computer.compute(object, timeSeries);
@@ -163,8 +163,8 @@ public abstract class TimeSeriesChartFactory<O> extends ChartFactory<O> {
 
     @Override
     protected List<Dataset> computeExportableTimeSeries(O object,
-                                                               TimeSeries timeSeries,
-                                                               ComparisonPeriod comparisonPeriod) throws Exception {
+                                                        TimeSeries timeSeries,
+                                                        ComparisonPeriod comparisonPeriod) throws Exception {
         String label = getChartLabel(object);
         String subLabel = getChartSubLabel(object);
 

--- a/src/main/java/sirius/biz/analytics/explorer/TimeSeriesChartFactory.java
+++ b/src/main/java/sirius/biz/analytics/explorer/TimeSeriesChartFactory.java
@@ -162,13 +162,15 @@ public abstract class TimeSeriesChartFactory<O> extends ChartFactory<O> {
     }
 
     @Override
-    protected List<TimeSeriesData> computeExportableTimeSeries(O object,
+    protected List<Dataset> computeExportableTimeSeries(O object,
                                                                TimeSeries timeSeries,
                                                                ComparisonPeriod comparisonPeriod) throws Exception {
         String label = getChartLabel(object);
         String subLabel = getChartSubLabel(object);
 
-        List<TimeSeriesData> result = new ArrayList<>();
+        TimeSeries comparisonTimeSeries = timeSeries.comparisonSeries(comparisonPeriod);
+
+        List<Dataset> result = new ArrayList<>();
 
         // Enhance labels with the chart label and sub label so that the column names are more descriptive...
         timeSeries.withDataConsumer(timeSeriesData -> {
@@ -177,10 +179,13 @@ public abstract class TimeSeriesChartFactory<O> extends ChartFactory<O> {
             } else {
                 timeSeriesData.setLabel(label + " - " + timeSeriesData.getLabel());
             }
-            result.add(timeSeriesData);
+            if (timeSeriesData.isComparisonTimeSeries()) {
+                result.add(timeSeriesData.toDataset(comparisonTimeSeries));
+            } else {
+                result.add(timeSeriesData.toDataset(timeSeries));
+            }
         });
 
-        TimeSeries comparisonTimeSeries = timeSeries.comparisonSeries(comparisonPeriod);
         executeComputers(object, comparisonPeriod, timeSeries, comparisonTimeSeries);
 
         return result;


### PR DESCRIPTION
- Fixes comparison period not showing up.
- Also fixes current period values always zero.

This was caused due to two problems.
- 1st: The TimeSeries.comparisonSeries method has to be called after the dataConsumer has been registered!
- 2nd: The executeComputers method has to be called before converting a TimeSeriesData into a Dataset, since the TimeSeriesData is not set until the computers have been executed. Thus, when calling toDataset to early only zero values will be copied into the Dataset.

Fixes: SIRI-788