### PR TITLE
Only attempts to perform a lookup for sane / plausible / working paths.

### DIFF
--- a/src/main/java/sirius/biz/tycho/UserAssistant.java
+++ b/src/main/java/sirius/biz/tycho/UserAssistant.java
@@ -14,6 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.web.http.WebContext;
 
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Provides a helper to fetch the {@link sirius.biz.tycho.academy.OnboardingEngine academy} track or video or
@@ -49,6 +50,7 @@ public class UserAssistant {
      * @see WebContext#setAttribute(String, Object)
      */
     public static final String WEB_CONTEXT_SETTING_KBA = "UserAssistantKba";
+    private static final Pattern VALID_PATH = Pattern.compile("[a-zA-Z0-9\\-/_]+");
 
     /**
      * Determines the {@link sirius.biz.tycho.academy.OnboardingEngine academy} track to link to.
@@ -68,6 +70,9 @@ public class UserAssistant {
     }
 
     private Optional<String> getSettingIfPresent(String type, String path) {
+        if (!VALID_PATH.matcher(path).matches()) {
+            return Optional.empty();
+        }
         String setting = "user-assistant." + type + "." + path;
 
         if (Sirius.getSettings().has(setting)) {

--- a/src/main/java/sirius/biz/tycho/UserAssistant.java
+++ b/src/main/java/sirius/biz/tycho/UserAssistant.java
@@ -50,6 +50,7 @@ public class UserAssistant {
      * @see WebContext#setAttribute(String, Object)
      */
     public static final String WEB_CONTEXT_SETTING_KBA = "UserAssistantKba";
+
     private static final Pattern VALID_PATH = Pattern.compile("[a-zA-Z0-9\\-/_]+");
 
     /**


### PR DESCRIPTION
Most notably, if an invalid query string is present which only uses & and no ? we skip these paths, as TypeSafe-Config crashes on them.