### PR TITLE
copy salutation for resolving correct user-icon on tenant-switching

### DIFF
--- a/src/main/java/sirius/biz/model/AddressData.java
+++ b/src/main/java/sirius/biz/model/AddressData.java
@@ -192,8 +192,8 @@ public class AddressData extends Composite {
 
     @Override
     public String toString() {
-        return Formatter.create("[${steet} ][${zip} ]${city}")
-                        .set("steet", street)
+        return Formatter.create("[${street} ][${zip} ]${city}")
+                        .set("street", street)
                         .set("zip", zip)
                         .set("city", city)
                         .smartFormat();

--- a/src/main/java/sirius/biz/model/InternationalAddressData.java
+++ b/src/main/java/sirius/biz/model/InternationalAddressData.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
 import java.util.regex.PatternSyntaxException;
 
 /**
- * Provides a {@link AddressData street address} along with a country code to be emdedded in entities or mixins.
+ * Provides a {@link AddressData street address} along with a country code to be embedded in entities or mixins.
  * <p>
  * Note that just like {@link AddressData} this doesn't perform any validations or verifications unless explicitly
  * told to do so.

--- a/src/main/java/sirius/biz/model/LoginData.java
+++ b/src/main/java/sirius/biz/model/LoginData.java
@@ -35,7 +35,7 @@ import java.util.List;
  * Stores a username and encrypted password along with some trace data to support logins which can be embedded into
  * other entities or mixins.
  * <p>
- * Note that no uniqueness constraint is placed on the username as the context of unqiueness has to be decided by the
+ * Note that no uniqueness constraint is placed on the username as the context of uniqueness has to be decided by the
  * outside class.
  * <p>
  * An example of an actual user is {@link sirius.biz.tenants.UserAccount}.
@@ -100,8 +100,8 @@ public class LoginData extends Composite {
     /**
      * Contains a generated string which is put into each client session of the user.
      * <p>
-     * Once the user deciedes to change the password or to log out on all devices,
-     * the fingerprint is updated and all sessions containing the old finderprint
+     * Once the user decides to change the password or to log out on all devices,
+     * the fingerprint is updated and all sessions containing the old fingerprint
      * are considered invalid.
      */
     public static final Mapping FINGERPRINT = Mapping.named("fingerprint");
@@ -122,7 +122,7 @@ public class LoginData extends Composite {
     private String generatedPassword;
 
     /**
-     * Provides an API TOKEN which is crypthgraphically created and can be used as password for technical integrations
+     * Provides an API TOKEN which is cryptographically created and can be used as password for technical integrations
      */
     public static final Mapping API_TOKEN = Mapping.named("apiToken");
     @Trim
@@ -158,7 +158,7 @@ public class LoginData extends Composite {
     /**
      * Records the timestamp of the last login via an external system.
      * <p>
-     * When using external identity poviders, like SAML, we want to keep track when the last login via this happened
+     * When using external identity providers, like SAML, we want to keep track when the last login via this happened
      * as we probably want to enforce regular validations (logins).
      */
     public static final Mapping LAST_EXTERNAL_LOGIN = Mapping.named("lastExternalLogin");
@@ -257,7 +257,7 @@ public class LoginData extends Composite {
     }
 
     /**
-     * Verifys the given password if it meets the length requirement and is equal to its confirmation.
+     * Verifies the given password if it meets the length requirement and is equal to its confirmation.
      *
      * @param password          the password to check for
      * @param confirmation      the confirmation password to check for
@@ -333,7 +333,7 @@ public class LoginData extends Composite {
      * <p>
      * Note that this value is transient and therefore not saved to the database.
      *
-     * @return the currently applied password in cleatext
+     * @return the currently applied password in cleartext
      */
     public String getCleartextPassword() {
         return cleartextPassword;

--- a/src/main/java/sirius/biz/model/PersonData.java
+++ b/src/main/java/sirius/biz/model/PersonData.java
@@ -191,7 +191,7 @@ public class PersonData extends Composite {
     }
 
     /**
-     * Generates a string representation of the full name, tranlated corresponding to the given language code.
+     * Generates a string representation of the full name, translated corresponding to the given language code.
      *
      * @param langCode the language code to translate to
      * @return the full name (if filled)
@@ -233,7 +233,7 @@ public class PersonData extends Composite {
     }
 
     /**
-     * Returns the value (translated name) of the saluation.
+     * Returns the value (translated name) of the salutation.
      *
      * @return the value for <tt>salutation</tt> from the <tt>salutations</tt> code list
      */

--- a/src/main/java/sirius/biz/model/QueryController.java
+++ b/src/main/java/sirius/biz/model/QueryController.java
@@ -31,7 +31,6 @@ import sirius.kernel.commons.Value;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Register;
-import sirius.kernel.nls.NLS;
 import sirius.web.controller.AutocompleteHelper;
 import sirius.web.controller.Message;
 import sirius.web.controller.Routed;

--- a/src/main/java/sirius/biz/tenants/AdditionalRolesProvider.java
+++ b/src/main/java/sirius/biz/tenants/AdditionalRolesProvider.java
@@ -16,10 +16,10 @@ import java.util.function.Consumer;
 public interface AdditionalRolesProvider {
 
     /**
-     * Adds additonal roles to the given roleConsumer, based on the given {@link UserAccount}.
+     * Adds additional roles to the given roleConsumer, based on the given {@link UserAccount}.
      *
      * @param user         the {@link UserAccount} for which the roles should be calculated
-     * @param roleConsumer the consumer for the additonal roles
+     * @param roleConsumer the consumer for the additional roles
      */
     void addAdditionalRoles(UserAccount<?, ?> user, Consumer<String> roleConsumer);
 

--- a/src/main/java/sirius/biz/tenants/ProfileController.java
+++ b/src/main/java/sirius/biz/tenants/ProfileController.java
@@ -48,7 +48,7 @@ public class ProfileController<I extends Serializable, T extends BaseEntity<I> &
     private UserAccountController<?, ?, ?> userAccountController;
 
     /**
-     * Shows a page where an account can change the user informations, e.g. mail, name, ...
+     * Shows a page where an account can change the user information, e.g. mail, name, ...
      *
      * @param ctx the current request
      */

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -384,6 +384,10 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
                         .addAll(currentUser.getUserAccountData().getPermissions().getPermissions().modify());
             modifiedUser.getUserAccountData()
                         .getPerson()
+                        .getSalutation()
+                        .setValue(currentUser.getUserAccountData().getPerson().getSalutation().getValue());
+            modifiedUser.getUserAccountData()
+                        .getPerson()
                         .setFirstname(currentUser.getUserAccountData().getPerson().getFirstname());
             modifiedUser.getUserAccountData()
                         .getPerson()

--- a/src/main/java/sirius/biz/tenants/UserAccountSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountSearchProvider.java
@@ -73,7 +73,7 @@ public abstract class UserAccountSearchProvider<I extends Serializable, T extend
             // If we're NOT part of the system tenant, we only may search within our own tenant...
             userAccountQuery.eq(SQLUserAccount.TENANT, currentTenant);
         } else if (!currentUser.hasPermission(UserAccountController.getUserManagementPermission())) {
-            // If we're the system tenant but have no user mangement permission there, we may not see
+            // If we're the system tenant but have no user management permission there, we may not see
             // and edit or select our own users...
             userAccountQuery.ne(SQLUserAccount.TENANT, currentTenant);
         }


### PR DESCRIPTION
On switched tenant we lost the personalized icon man/woman and fallback to skip. So we copy the salutation to keep the icon.
<img width="284" alt="Bildschirm­foto 2023-04-24 um 11 57 36" src="https://user-images.githubusercontent.com/55080004/233964117-e9c5fb4d-f25a-42c7-af8b-3ddd7d0c24e4.png">
- fixes: SIRI-796