### PR TITLE
Permits DataExplorer charts to take their time when computing a chart.

### DIFF
--- a/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
+++ b/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
@@ -122,6 +122,9 @@ public class DataExplorerController extends BizController {
     @InternalService
     @LoginRequired
     public Future chartApi(WebContext webContext, JSONStructuredOutput output) throws Exception {
+        // Some charts might take their time, therefore we don't want automatic timeouts here...
+        webContext.markAsLongCall();
+
         String identifier = webContext.require(PARAM_IDENTIFIER).asString();
         Tuple<ChartFactory<Object>, Object> providerAndObject = resolveProviderAndObject(identifier);
 

--- a/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
+++ b/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
@@ -168,6 +168,12 @@ public class DataExplorerController extends BizController {
         return Tuple.create(provider, object);
     }
 
+    /**
+     * Provides a route to export charts as MS Excel file.
+     *
+     * @param webContext the request to respond to
+     * @throws IOException in case of an IO error while writing the Excel response
+     */
     @Routed("/data-explorer/export")
     public void export(WebContext webContext) throws IOException {
         String range = webContext.require(PARAM_RANGE).asString();
@@ -185,8 +191,8 @@ public class DataExplorerController extends BizController {
         try (ExportXLSX export = new ExportXLSX(() -> webContext.respondWith()
                                                                 .download("data-explorer.xlsx")
                                                                 .outputStream(HttpResponseStatus.OK, null))) {
-            export.addListRow(Stream.concat(Stream.of(NLS.get("DataExplorerController.dateColumn")), timeSeriesData.stream().map(Dataset::getLabel))
-                                    .toList());
+            export.addListRow(Stream.concat(Stream.of(NLS.get("DataExplorerController.dateColumn")),
+                                            timeSeriesData.stream().map(Dataset::getLabel)).toList());
             List<String> dates = timeSeries.startDates().map(date -> timeSeries.getGranularity().format(date)).toList();
             for (int index = 0; index < dates.size(); index++) {
                 final int rowIndex = index;


### PR DESCRIPTION
The DataExplorer explicitely loads charts async and supports longer running computations. Therefore we must also disable the timeout of the WebServer.

Fixes: [OX-9875](https://scireum.myjetbrains.com/youtrack/issue/OX-9875/Data-Explorer-Chart-ladt-nicht)