### PR TITLE
Fixes an unhandled exception within the ConversionEngine by adding a tenant id check

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -225,12 +225,11 @@ public class ConversionEngine {
     }
 
     private void recordErrorInStandbyProcess(ConversionProcess conversionProcess, Exception exception) {
-        if (processes != null && tenants != null) {
+        String blobTenantId = conversionProcess.getBlobToConvert().getTenantId();
+        if (processes != null && tenants != null && Strings.isFilled(blobTenantId)) {
             processes.executeInStandbyProcess("conversion",
-                                              () -> NLS.get("ConversionEngine.processTitle"),
-                                              conversionProcess.getBlobToConvert().getTenantId(),
-                                              () -> tenants.fetchCachedTenantName(conversionProcess.getBlobToConvert()
-                                                                                                   .getTenantId()),
+                                              () -> NLS.get("ConversionEngine.processTitle"), blobTenantId,
+                                              () -> tenants.fetchCachedTenantName(blobTenantId),
                                               processContext -> createStandbyProcessLogEntry(conversionProcess,
                                                                                              processContext,
                                                                                              exception.getMessage()));

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -228,7 +228,8 @@ public class ConversionEngine {
         String blobTenantId = conversionProcess.getBlobToConvert().getTenantId();
         if (processes != null && tenants != null && Strings.isFilled(blobTenantId)) {
             processes.executeInStandbyProcess("conversion",
-                                              () -> NLS.get("ConversionEngine.processTitle"), blobTenantId,
+                                              () -> NLS.get("ConversionEngine.processTitle"),
+                                              blobTenantId,
                                               () -> tenants.fetchCachedTenantName(blobTenantId),
                                               processContext -> createStandbyProcessLogEntry(conversionProcess,
                                                                                              processContext,


### PR DESCRIPTION
The unhandled exception prevented the fail-code-path of the doConversion/performConversion method to be working (since result.fail was never called, and therefore no onFailure handler).

For a more detailed explanation please refere to the ticket.

Fixes: [SIRI-704](https://scireum.myjetbrains.com/youtrack/issue/SIRI-704/UrlBuilder-Failed-Img-einbauen-welches-signalisiert-das-kein-Vorschaubild-da-ist-weil-ein-Fehler-aufgetreten-ist-bzw-keins)