### PR TITLE
Analytics: Scheduler Bug Fixes

### DIFF
--- a/src/main/java/sirius/biz/analytics/checks/ChangeCheck.java
+++ b/src/main/java/sirius/biz/analytics/checks/ChangeCheck.java
@@ -30,7 +30,7 @@ import java.time.LocalDate;
 public abstract class ChangeCheck<E extends BaseEntity<?> & Traced> implements AnalyticalTask<E> {
 
     @Override
-    public void compute(LocalDate date, E entity) {
+    public void compute(LocalDate date, E entity, boolean bestEffort) {
         execute(entity);
     }
 

--- a/src/main/java/sirius/biz/analytics/checks/DailyCheck.java
+++ b/src/main/java/sirius/biz/analytics/checks/DailyCheck.java
@@ -29,7 +29,7 @@ import java.time.LocalDate;
 public abstract class DailyCheck<E extends BaseEntity<?>> implements AnalyticalTask<E> {
 
     @Override
-    public void compute(LocalDate date, E entity) {
+    public void compute(LocalDate date, E entity, boolean bestEffort) {
         execute(entity);
     }
 

--- a/src/main/java/sirius/biz/analytics/metrics/DailyMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/DailyMetricComputer.java
@@ -45,7 +45,7 @@ public abstract class DailyMetricComputer<E extends BaseEntity<?>> implements An
     }
 
     @Override
-    public final void compute(LocalDate date, E entity) throws Exception {
+    public final void compute(LocalDate date, E entity, boolean bestEffort) throws Exception {
         compute(date,
                 date.atStartOfDay(),
                 date.plusDays(1).atStartOfDay().minusSeconds(1),

--- a/src/main/java/sirius/biz/analytics/metrics/MonthlyLargeMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MonthlyLargeMetricComputer.java
@@ -47,7 +47,7 @@ public abstract class MonthlyLargeMetricComputer<E extends BaseEntity<?>> implem
     }
 
     @Override
-    public final void compute(LocalDate date, E entity) throws Exception {
+    public final void compute(LocalDate date, E entity, boolean bestEffort) throws Exception {
         compute(date,
                 date.withDayOfMonth(1).atStartOfDay(),
                 date.withDayOfMonth(date.lengthOfMonth()).plusDays(1).atStartOfDay().minusSeconds(1),

--- a/src/main/java/sirius/biz/analytics/metrics/MonthlyMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MonthlyMetricComputer.java
@@ -57,7 +57,7 @@ public abstract class MonthlyMetricComputer<E extends BaseEntity<?>> implements 
     }
 
     @Override
-    public final void compute(LocalDate date, E entity) throws Exception {
+    public final void compute(LocalDate date, E entity, boolean bestEffort) throws Exception {
         compute(date,
                 date.withDayOfMonth(1).atStartOfDay(),
                 date.withDayOfMonth(date.lengthOfMonth()).plusDays(1).atStartOfDay().minusSeconds(1), isPastDate(date),

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticalTask.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticalTask.java
@@ -62,10 +62,14 @@ public interface AnalyticalTask<E extends BaseEntity<?>> {
 
     /**
      * Executes the analytical task for the given entity and reference date.
+     * <p>
+     * The {@code bestEffort} flag indicates if best effort scheduling is used. The flag can be ignored, but
+     * implementations can choose to modify their behavior based on it.
      *
-     * @param date   the data for which the task is to be executed
-     * @param entity the entity for which this task is to be executed
+     * @param date       the data for which the task is to be executed
+     * @param entity     the entity for which this task is to be executed
+     * @param bestEffort a flag indicating if best effort scheduling is used
      * @throws Exception in case of an error during the computation
      */
-    void compute(LocalDate date, E entity) throws Exception;
+    void compute(LocalDate date, E entity, boolean bestEffort) throws Exception;
 }

--- a/src/main/java/sirius/biz/analytics/scheduler/BaseAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/BaseAnalyticalTaskScheduler.java
@@ -171,7 +171,7 @@ abstract class BaseAnalyticalTaskScheduler<B extends BaseEntity<?>> implements A
     private void executeTaskForEntity(B entity, Class<?> type, LocalDate date, AnalyticalTask<?> task) {
         Watch watch = Watch.start();
         try {
-            ((AnalyticalTask<B>) task).compute(date, entity);
+            ((AnalyticalTask<B>) task).compute(date, entity, useBestEffortScheduling());
         } catch (Exception ex) {
             Exceptions.handle()
                       .to(AnalyticalEngine.LOG)


### PR DESCRIPTION
> [SIRI-795](https://scireum.myjetbrains.com/youtrack/issue/SIRI-795) — Replaces #1680.

Revises analytics scheduling to compute time ranges correctly and at one place.

_Note:_ The value of the additional boolean flag that makes this PR breaking can be ignored by implementations of `AnalyticalTask` in order to maintain the previous behaviour.