### PR TITLE
Removes the re-throwing of the exception within the invokeConversionPipelineAsync method since it is not needed anymore

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1696,16 +1696,6 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             markConversionFailure(variant, conversionProcess);
             eventRecorder.record(new BlobConversionEvent().withConversionProcess(conversionProcess)
                                                           .withConversionError(conversionException));
-
-            throw Exceptions.handle()
-                            .error(conversionException)
-                            .to(StorageUtils.LOG)
-                            .withSystemErrorMessage("Layer 2/Conversion: Failed to create %s (%s) of %s (%s): %s (%s)",
-                                                    variant.getVariantName(),
-                                                    variant.getIdAsString(),
-                                                    blob.getBlobKey(),
-                                                    blob.getFilename())
-                            .handle();
         });
         return future;
     }


### PR DESCRIPTION
Why? - The conversion is now usually performed in a standby-process which logs any occurring errors.

Fixes: [SIRI-743](https://scireum.myjetbrains.com/youtrack/issue/SIRI-743/Promise-failHandler-Umbauen-so-dass-man-das-logging-ins-Fehlerprotokoll-auch-ausschalten-kann)