### PR TITLE
Adds Model.language in parallel to Model.lang

### DIFF
--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -579,6 +579,7 @@ Model.id = ID
 Model.incident = Fehler
 Model.invalidEmail = Ungültige E-Mail-Adresse.
 Model.lang = Sprache
+Model.language = Sprache
 Model.links = Links
 Model.login = Anmeldung
 Model.login.emailRequired = Bitte geben Sie eine E-Mail-Adresse an

--- a/src/main/resources/default/templates/biz/tenants/profile.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/profile.html.pasta
@@ -79,7 +79,7 @@
                                  labelKey="PersonData.lastname"/>
                 </div>
                 <div class="row">
-                    <w:singleSelect name="userAccountData_language" labelKey="Model.lang" required="true">
+                    <w:singleSelect name="userAccountData_language" labelKey="Model.language" required="true">
                         <i:for var="language" items="controller.getAvailableLanguages()" type="Tuple">
                             <option value="@language.getFirst()"
                                     @selected="language.getFirst() == userAccount.getUserAccountData().getLanguage().getValue()">

--- a/src/main/resources/default/templates/biz/tenants/tenant-details-fields.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenant-details-fields.html.pasta
@@ -10,7 +10,7 @@
 <div class="row">
     <w:textfield name="tenantData_accountNumber" value="@tenant.getTenantData().getAccountNumber()"
                  labelKey="TenantData.accountNumber"/>
-    <w:singleSelect name="tenantData_language" labelKey="Model.lang" required="true">
+    <w:singleSelect name="tenantData_language" labelKey="Model.language" required="true">
         <i:for var="language" items="controller.getAvailableLanguages()" type="Tuple">
             <option value="@language.getFirst()"
                     @selected="language.getFirst() == tenant.getTenantData().getLanguage().getValue()">

--- a/src/main/resources/default/templates/biz/tenants/tenant-details.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenant-details.html.pasta
@@ -12,7 +12,7 @@
         <div class="row">
             <w:textfield name="tenantData_accountNumber" value="@tenant.getTenantData().getAccountNumber()"
                          labelKey="TenantData.accountNumber"/>
-            <w:singleSelect name="tenantData_language" labelKey="Model.lang" required="true">
+            <w:singleSelect name="tenantData_language" labelKey="Model.language" required="true">
                 <i:for var="language" items="controller.getAvailableLanguages()" type="Tuple">
                     <option value="@language.getFirst()"
                             @selected="language.getFirst() == tenant.getTenantData().getLanguage().getValue()">

--- a/src/main/resources/default/templates/biz/tenants/user-account-details-fields.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account-details-fields.html.pasta
@@ -23,7 +23,7 @@
 <div class="row">
     <w:textfield name="userAccountData_person_lastname" value="@account.getUserAccountData().getPerson().getLastname()"
                  labelKey="PersonData.lastname"/>
-    <w:singleSelect name="userAccountData_language" labelKey="Model.lang" required="true">
+    <w:singleSelect name="userAccountData_language" labelKey="Model.language" required="true">
         <i:for var="language" items="controller.getAvailableLanguages()" type="Tuple">
             <option value="@language.getFirst()"
                     @selected="language.getFirst() == account.getUserAccountData().getLanguage().getValue()">


### PR DESCRIPTION
A previous rename from `lang` to `language` did not consider the Model.lang key, so all renamed fields without explicitly translation are left without label.

This adds a second key, maintaining compatibility to entities in product with no field renamed.