### PR TITLE
Impedes updating contents of read-only files

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -798,7 +798,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
      * created
      */
     public Optional<OutputStream> tryCreateOutputStream() {
-        if (!canCreateOutputStream()) {
+        if (!canCreateOutputStream() || readOnly()) {
             return Optional.empty();
         }
 
@@ -875,6 +875,10 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
      * @return <tt>true</tt> if a stream can be consumed, <tt>false</tt> otherwise
      */
     public boolean canConsumeStream() {
+        if (readOnly()) {
+            return false;
+        }
+
         if (internalCanConsumeStream()) {
             return true;
         }
@@ -967,6 +971,10 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
      * @return <tt>true</tt> if a file can be consumed, <tt>false</tt> otherwise
      */
     public boolean canConsumeFile() {
+        if (readOnly()) {
+            return false;
+        }
+
         if (internalCanConsumeFile()) {
             return true;
         }


### PR DESCRIPTION
Example from the UI, but validation occurs anywhere we attempt to get into the file's output stream.

<img width="1963" alt="image" src="https://github.com/scireum/sirius-biz/assets/54799255/29f7d935-8133-451b-b16f-7f5d2d977a8f">

Fixes: [SIRI-805](https://scireum.myjetbrains.com/youtrack/issue/SIRI-805)