### PR TITLE
Marks a config value as nullable

### DIFF
--- a/src/main/java/sirius/biz/tenants/BaseTenantAutoSetup.java
+++ b/src/main/java/sirius/biz/tenants/BaseTenantAutoSetup.java
@@ -16,6 +16,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.di.std.Priorized;
 
+import javax.annotation.Nullable;
 import java.util.function.Consumer;
 
 /**
@@ -31,6 +32,7 @@ public abstract class BaseTenantAutoSetup implements AutoSetupRule {
     protected PartCollection<TenantAutoSetupExtender> extenders;
 
     @ConfigValue("security.system-saml.externalLoginIntervalDays")
+    @Nullable
     private Integer externalLoginIntervalDays;
     @ConfigValue("security.system-saml.requestIssuerName")
     private String samlRequestIssuerName;


### PR DESCRIPTION
Avoiding this startup warning:

`[2023-05-31T15:15:10.726] WARNING [di - ConfigValueAnnotationProcessor.java:43] Cannot fill security.system-saml.externalLoginIntervalDays of sirius.biz.tenants.BaseTenantAutoSetup with the config value 'externalLoginIntervalDays'. Add a Nullable annotation if this is expected, in order to suppress this warning.`

