### PR TITLE
Calls super method to run required framework code

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/FileImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/FileImportJob.java
@@ -241,6 +241,7 @@ public abstract class FileImportJob extends ImportJob {
                .filter(VirtualFile::exists)
                .filter(VirtualFile::readOnly)
                .ifPresent(virtualFile -> virtualFile.updateReadOnlyFlag(false));
+        super.close();
     }
 
     /**


### PR DESCRIPTION
Without this fix, the importer would not get closed and subsequently the handler would not get closed and so e.g. batch queries would not get commited. 