### PR TITLE
Fixes readonly changes in uplinks

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
@@ -274,7 +274,12 @@ public class CIFSUplink extends ConfigBasedUplink {
 
     private boolean isReadOnlySupplier(VirtualFile file) {
         try {
-            return !file.as(SmbFile.class).canWrite();
+            SmbFile smbFile = file.as(SmbFile.class);
+            if (smbFile.exists()) {
+                return !smbFile.canWrite();
+            }
+            SmbFile parentFile = new SmbFile(smbFile.getParent(), smbFile.getContext());
+            return !parentFile.exists() || !parentFile.isDirectory() || !parentFile.canWrite();
         } catch (Exception e) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)

--- a/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
@@ -267,7 +267,9 @@ public class CIFSUplink extends ConfigBasedUplink {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
                             .error(e)
-                            .withSystemErrorMessage("Layer 3/CIFS: Cannot delete %s: %s (%s)", file)
+                            .withSystemErrorMessage("Layer 3/CIFS: Cannot change read-only state on %s to %s: %s (%s)",
+                                                    file,
+                                                    readOnly)
                             .handle();
         }
     }

--- a/src/main/java/sirius/biz/storage/layer3/uplink/fs/LocalDirectoryUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/fs/LocalDirectoryUplink.java
@@ -156,7 +156,12 @@ public class LocalDirectoryUplink extends ConfigBasedUplink {
     private boolean isReadOnlySupplier(VirtualFile file) {
         try {
             File unwrappedFile = file.as(File.class);
-            return !unwrappedFile.canWrite();
+            if (unwrappedFile.exists()) {
+                return !Files.isWritable(unwrappedFile.toPath());
+            } else {
+                return unwrappedFile.getParentFile() == null || !Files.isWritable(unwrappedFile.getParentFile()
+                                                                                               .toPath());
+            }
         } catch (Exception e) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
@@ -401,7 +401,7 @@ public class FTPUplink extends ConfigBasedUplink {
 
     private boolean isReadOnlySupplier(VirtualFile virtualFile) {
         for (Attempt attempt : Attempt.values()) {
-            String relativePath = file.as(RemotePath.class).getPath();
+            String relativePath = virtualFile.as(RemotePath.class).getPath();
             UplinkConnector<FTPClient> connector = connectorPool.obtain(ftpConfig);
             try {
                 FTPFile remoteFile = connector.connector().mlistFile(relativePath);
@@ -428,7 +428,7 @@ public class FTPUplink extends ConfigBasedUplink {
 
     private boolean readOnlyHandler(VirtualFile virtualFile, boolean readOnly) {
         for (Attempt attempt : Attempt.values()) {
-            String relativePath = file.as(RemotePath.class).getPath();
+            String relativePath = virtualFile.as(RemotePath.class).getPath();
             UplinkConnector<FTPClient> connector = connectorPool.obtain(ftpConfig);
             try {
                 FTPFile remoteFile = connector.connector().mlistFile(relativePath);

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
@@ -447,8 +447,9 @@ public class FTPUplink extends ConfigBasedUplink {
                                     .to(StorageUtils.LOG)
                                     .error(exception)
                                     .withSystemErrorMessage(
-                                            "Layer 3/FTP: Failed to determine if '%s' in uplink '%s' is read-only: %s (%s)",
+                                            "Layer 3/FTP: Cannot change read-only state on '%s' to '%s' in uplink '%s': %s (%s)",
                                             relativePath,
+                                            readOnly,
                                             ftpConfig)
                                     .handle();
                 }

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
@@ -405,7 +405,13 @@ public class FTPUplink extends ConfigBasedUplink {
             UplinkConnector<FTPClient> connector = connectorPool.obtain(ftpConfig);
             try {
                 FTPFile remoteFile = connector.connector().mlistFile(relativePath);
-                return !remoteFile.hasPermission(FTPFile.USER_ACCESS, FTPFile.WRITE_PERMISSION);
+                if (remoteFile != null) {
+                    return !remoteFile.hasPermission(FTPFile.USER_ACCESS, FTPFile.WRITE_PERMISSION);
+                }
+                String parentPath = virtualFile.parent().as(RemotePath.class).getPath();
+                FTPFile parentDirectory = connector.connector().mlistFile(parentPath);
+                return parentDirectory == null || !parentDirectory.hasPermission(FTPFile.USER_ACCESS,
+                                                                                 FTPFile.WRITE_PERMISSION);
             } catch (Exception exception) {
                 connector.forceClose();
                 if (attempt.shouldThrow(exception)) {


### PR DESCRIPTION
especially for non-existing files. 
Use case is e.g. a copy operation, where the destination file is often non existing