### PR TITLE
Remembers user-preferences even when having switched to another tenant.

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -367,31 +367,12 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         try {
             U currentUser = originalUser.getUserObject(getUserClass());
             U modifiedUser = getUserClass().getDeclaredConstructor().newInstance();
+
             modifiedUser.setId(currentUser.getId());
-            modifiedUser.getUserAccountData()
-                        .getLanguage()
-                        .setValue(currentUser.getUserAccountData().getLanguage().getValue());
-            modifiedUser.getUserAccountData()
-                        .getLogin()
-                        .setUsername(currentUser.getUserAccountData().getLogin().getUsername());
-            modifiedUser.getUserAccountData().setEmail(currentUser.getUserAccountData().getEmail());
-            modifiedUser.getUserAccountData()
-                        .getPermissions()
-                        .setConfigString(currentUser.getUserAccountData().getPermissions().getConfigString());
-            modifiedUser.getUserAccountData()
-                        .getPermissions()
-                        .getPermissions()
-                        .addAll(currentUser.getUserAccountData().getPermissions().getPermissions().modify());
-            modifiedUser.getUserAccountData()
-                        .getPerson()
-                        .getSalutation()
-                        .setValue(currentUser.getUserAccountData().getPerson().getSalutation().getValue());
-            modifiedUser.getUserAccountData()
-                        .getPerson()
-                        .setFirstname(currentUser.getUserAccountData().getPerson().getFirstname());
-            modifiedUser.getUserAccountData()
-                        .getPerson()
-                        .setLastname(currentUser.getUserAccountData().getPerson().getLastname());
+            currentUser.getDescriptor().getProperties().forEach(property -> {
+                property.setValue(modifiedUser, property.getValue(currentUser));
+            });
+
             return modifiedUser;
         } catch (Exception e) {
             throw Exceptions.handle(Log.APPLICATION, e);

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccount.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccount.java
@@ -33,6 +33,7 @@ import sirius.web.controller.Message;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -104,6 +105,10 @@ public class SQLUserAccount extends SQLTenantAware implements UserAccount<Long, 
     @Override
     public void updatePreference(String key, Object value) {
         try {
+            if (Objects.equals(value, getUserAccountData().fetchUserPreferences().get(key))) {
+                return;
+            }
+
             Map<String, Object> newPreferences = new HashMap<>(getUserAccountData().fetchUserPreferences());
             String updatedPreferencesAsString = computeUpdatedPreferences(newPreferences, key, value);
             oma.updateStatement(SQLUserAccount.class)

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
@@ -38,6 +38,7 @@ import sirius.web.controller.Message;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -150,6 +151,10 @@ public class MongoUserAccount extends MongoTenantAware implements UserAccount<St
     @Override
     public void updatePreference(String key, Object value) {
         try {
+            if (Objects.equals(value, getUserAccountData().fetchUserPreferences().get(key))) {
+                return;
+            }
+
             Map<String, Object> newPreferences = new HashMap<>(getUserAccountData().fetchUserPreferences());
             String updatedPreferencesAsString = computeUpdatedPreferences(newPreferences, key, value);
             mongo.update()


### PR DESCRIPTION
We only copied the UserAccount entities when the current user became / spied on another user. We now use the framework to ensure that all fields are copied properly.