### PR TITLE
Uses appropriate filename in cifs fast move

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
@@ -164,7 +164,7 @@ public class CIFSUplink extends ConfigBasedUplink {
 
     private boolean fastMoveHandler(VirtualFile file, VirtualFile newParent) {
         try {
-            file.as(SmbFile.class).renameTo(new SmbFile(newParent.as(SmbFile.class), name));
+            file.as(SmbFile.class).renameTo(new SmbFile(newParent.as(SmbFile.class), file.name()));
             return true;
         } catch (Exception e) {
             throw Exceptions.handle()


### PR DESCRIPTION
- move changes directory, name stays the same
- name must not be set to root directory name

Fixes: SIRI-805