### PR TITLE
Adds PackageData.ADDITIONAL_PERMISSIONS as extra filter in the tenants view.

### DIFF
--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantController.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantController.java
@@ -25,6 +25,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.web.controller.Controller;
 import sirius.web.http.WebContext;
+import sirius.web.security.Permissions;
 
 import java.util.Optional;
 
@@ -64,12 +65,15 @@ public class MongoTenantController extends TenantController<String, MongoTenant,
 
         MongoPerformanceData.addFilterFacet(pageHelper);
 
+        pageHelper.applyExtenders("/tenants/*");
+
         pageHelper.addTermAggregation(MongoTenant.TENANT_DATA.inner(TenantData.PACKAGE_DATA.inner(PackageData.PACKAGE_STRING)),
                                       name -> packages.getPackageName(TenantController.PACKAGE_SCOPE_TENANT, name));
         pageHelper.addTermAggregation(MongoTenant.TENANT_DATA.inner(TenantData.PACKAGE_DATA.inner(PackageData.UPGRADES)),
                                       name -> packages.getUpgradeName(TenantController.PACKAGE_SCOPE_TENANT, name));
+        pageHelper.addTermAggregation(MongoTenant.TENANT_DATA.inner(TenantData.PACKAGE_DATA.inner(PackageData.ADDITIONAL_PERMISSIONS)),
+                                      Permissions::getTranslatedPermission);
 
-        pageHelper.applyExtenders("/tenants/*");
 
         return pageHelper;
     }

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -685,6 +685,7 @@ OpenSearchController.label = Systemweite Suche
 OverrideMode.ALWAYS = Immer
 OverrideMode.NEVER = Nie
 OverrideMode.ON_CHANGE = Bei Änderung
+PackageData.additionalPermissions = Zusätzliche Berechtigungen
 PackageData.packageString = Leistungspaket
 PackageData.upgrades = Upgrades
 Packages.packages = Pakete


### PR DESCRIPTION
Also moves all package specific filters to the end as the might grow quite large.

Fixes: SIRI-828