### PR TITLE
Fix BlobRef inside composites

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobHardRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobHardRefProperty.java
@@ -73,7 +73,7 @@ public class BlobHardRefProperty extends BlobRefProperty {
 
     @Override
     protected void onBeforeSaveChecks(Object entity) {
-        BlobHardRef ref = getRef(entity);
+        BlobHardRef ref = getRef(this.accessPath.apply(entity));
         if (isChanged(entity) && ref.isFilled() && !ref.getBlob().isTemporary()) {
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
@@ -88,7 +88,7 @@ public class BlobHardRefProperty extends BlobRefProperty {
 
     @Override
     protected void onAfterSave(Object entity) {
-        BlobHardRef ref = getRef(entity);
+        BlobHardRef ref = getRef(this.accessPath.apply(entity));
         if (isChanged(entity)) {
             BlobStorageSpace storageSpace = ref.getStorageSpace();
             String uniqueName = ((BaseEntity<?>) entity).getUniqueName();
@@ -102,7 +102,7 @@ public class BlobHardRefProperty extends BlobRefProperty {
 
     @Override
     protected void onAfterDelete(Object entity) {
-        BlobHardRef ref = getRef(entity);
+        BlobHardRef ref = getRef(this.accessPath.apply(entity));
         if (ref.isFilled()) {
             ref.getBlob()
                .getStorageSpace()

--- a/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
@@ -59,7 +59,7 @@ abstract class BlobRefProperty extends Property implements SQLPropertyInfo, ESPr
      */
     public BlobHardRef getRef(Object entity) {
         try {
-            return (BlobHardRef) super.getValueFromField(this.accessPath.apply(entity));
+            return (BlobHardRef) super.getValueFromField(entity);
         } catch (Exception e) {
             throw Exceptions.handle()
                             .to(OMA.LOG)
@@ -94,7 +94,8 @@ abstract class BlobRefProperty extends Property implements SQLPropertyInfo, ESPr
 
     @Override
     public void setValue(Object entity, Object object) {
-        this.setValueToField(object, entity);
+        Object target = accessPath.apply(entity);
+        setValueToField(object, target);
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
@@ -92,12 +92,6 @@ abstract class BlobRefProperty extends Property implements SQLPropertyInfo, ESPr
         return object.get();
     }
 
-    @Override
-    public void setValue(Object entity, Object object) {
-        Object target = accessPath.apply(entity);
-        setValueToField(object, target);
-    }
-
     /**
      * Sets the given value on the target entity as either a blob or a key depending on the value.
      *

--- a/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
@@ -65,7 +65,7 @@ abstract class BlobRefProperty extends Property implements SQLPropertyInfo, ESPr
                             .to(OMA.LOG)
                             .error(e)
                             .withSystemErrorMessage(
-                                    "Unable to obtain a reference object from entity ref field ('%s' in '%s'): %s (%s)",
+                                    "Unable to obtain the BlobHardRef object from blob ref field ('%s' in '%s'): %s (%s)",
                                     getName(),
                                     descriptor.getType().getName())
                             .handle();

--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
@@ -95,7 +95,7 @@ public class BlobSoftRefProperty extends BlobRefProperty {
         }
     }
 
-    private BlobSoftRef getBlobSoftRef() {
+    private BlobSoftRef getReferenceBlobSoftRef() {
         if (blobSoftRef == null) {
             try {
                 blobSoftRef = (BlobSoftRef) field.get(accessPath.apply(descriptor.getReferenceInstance()));
@@ -104,7 +104,7 @@ public class BlobSoftRefProperty extends BlobRefProperty {
                                 .to(Mixing.LOG)
                                 .error(e)
                                 .withSystemErrorMessage(
-                                        "Unable to obtain a BlobSoftRef object from entity ref field ('%s' in '%s'): %s (%s)",
+                                        "Unable to obtain a reference object from blob ref field ('%s' in '%s'): %s (%s)",
                                         getName(),
                                         descriptor.getType().getName())
                                 .handle();
@@ -119,7 +119,7 @@ public class BlobSoftRefProperty extends BlobRefProperty {
         super.link();
 
         try {
-            BaseEntityRef.OnDelete deleteHandler = getBlobSoftRef().getDeleteHandler();
+            BaseEntityRef.OnDelete deleteHandler = getReferenceBlobSoftRef().getDeleteHandler();
 
             if (deleteHandler == BaseEntityRef.OnDelete.CASCADE) {
                 forEachBlobType(entityDescriptor -> entityDescriptor.addCascadeDeleteHandler(this::onDeleteCascade));

--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
@@ -194,9 +194,9 @@ public class BlobSoftRefProperty extends BlobRefProperty {
 
     @Override
     protected void determineLengths() {
-        BlobSoftRef templateReference = (BlobSoftRef) getRef(descriptor.getReferenceInstance());
-        this.length =
-                templateReference.isSupportsURL() ? URL_COMPATIBLE_LENGTH : BlobHardRefProperty.DEFAULT_KEY_LENGTH;
+        this.length = getReferenceBlobSoftRef().isSupportsURL() ?
+                      URL_COMPATIBLE_LENGTH :
+                      BlobHardRefProperty.DEFAULT_KEY_LENGTH;
     }
 
     @Override
@@ -205,7 +205,7 @@ public class BlobSoftRefProperty extends BlobRefProperty {
             return;
         }
 
-        BlobSoftRef ref = (BlobSoftRef) getRef(entity);
+        BlobSoftRef ref = (BlobSoftRef) getRef(this.accessPath.apply(entity));
         if (ref.isEmpty() || ref.isURL()) {
             return;
         }


### PR DESCRIPTION
The target object is already resolved in `Property#getValue`. `Property#getValue` then calls `Property#getValueFromField`. `BlobRefProperty#getValueFromField` is overridden to return the blob key instead of the `BlobHardRef` object via `BlobRefProperty#getRef`. There, we tried to resolve the target object again, which fails when used inside composites. This removes the duplicate resolve. As `BlobRefProperty#getRef` is used in other places which don't have the target object yet, we moved the resolve there.

Fixes: [SIRI-829](https://scireum.myjetbrains.com/youtrack/issue/SIRI-829)