### PR TITLE
Provides images in tenants an user accounts lists

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -62,7 +62,7 @@ public class TenantData extends Composite implements Journaled {
     public static final String STORAGE_SPACE = "tenants";
 
     /**
-     * Contains the fallback URI used by {@link #fetchSmallUrl()} and {@link #fetchMediumUrl()}.
+     * Contains the fallback URI used by {@link #fetchSmallUrl()}, {@link #fetchMediumUrl()}, and {@link #fetchLargeUrl()}.
      */
     public static final String IMAGE_FALLBACK_URI = "/assets/images/tenant_image_fallback.png";
 

--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -76,6 +76,11 @@ public class TenantData extends Composite implements Journaled {
      */
     public static final String IMAGE_VARIANT_MEDIUM = "tenant-medium";
 
+    /**
+     * Contains the name of the variant used to fetch the large image.
+     */
+    public static final String IMAGE_VARIANT_LARGE = "tenant-large";
+
     @Transient
     private final BaseEntity<?> tenantObject;
 
@@ -611,7 +616,7 @@ public class TenantData extends Composite implements Journaled {
     /**
      * Builds a URL to the small image.
      *
-     * @return a URLBuilder which is used to fetch the small image of this user
+     * @return a URLBuilder which is used to fetch the small image of this tenant
      */
     public URLBuilder fetchSmallUrl() {
         return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_SMALL);
@@ -620,9 +625,18 @@ public class TenantData extends Composite implements Journaled {
     /**
      * Builds a URL to the medium image.
      *
-     * @return a URLBuilder which is used to fetch the medium image of this user
+     * @return a URLBuilder which is used to fetch the medium image of this tenant
      */
     public URLBuilder fetchMediumUrl() {
         return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_MEDIUM);
+    }
+
+    /**
+     * Builds a URL to the large image.
+     *
+     * @return a URLBuilder which is used to fetch the large image of this tenant
+     */
+    public URLBuilder fetchLargeUrl() {
+        return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_LARGE);
     }
 }

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -125,7 +125,9 @@ public abstract class UserAccountController<I extends Serializable, T extends Ba
                 getUsersAsPage(webContext).addBooleanFacet(UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.LOGIN)
                                                                                         .inner(LoginData.ACCOUNT_LOCKED)
                                                                                         .toString(),
-                                                           NLS.get("LoginData.accountLocked")).withTotalCount().asPage();
+                                                           NLS.get("LoginData.accountLocked"))
+                                          .withTotalCount()
+                                          .asPage();
 
         webContext.respondWith().template("/templates/biz/tenants/user-accounts.html.pasta", accounts, getUserClass());
     }
@@ -201,7 +203,7 @@ public abstract class UserAccountController<I extends Serializable, T extends Ba
 
                                                             List<String> accessiblePermissions = getRoles();
                                                             packages.loadAccessiblePermissions(webContext.getParameters(
-                                                                    "roles"),
+                                                                                                       "roles"),
                                                                                                accessiblePermissions::contains,
                                                                                                userAccount.getUserAccountData()
                                                                                                           .getPermissions()
@@ -600,7 +602,14 @@ public abstract class UserAccountController<I extends Serializable, T extends Ba
     @LoginRequired
     @Permission(TenantUserManager.PERMISSION_SELECT_USER_ACCOUNT)
     public void selectUserAccounts(WebContext webContext) {
-        Page<U> selectableUsers = getSelectableUsersAsPage().withContext(webContext).asPage();
+        Page<U> selectableUsers = getSelectableUsersAsPage().withContext(webContext)
+                                                            .addBooleanFacet(UserAccount.USER_ACCOUNT_DATA.inner(
+                                                                                                UserAccountData.LOGIN)
+                                                                                                          .inner(LoginData.ACCOUNT_LOCKED)
+                                                                                                          .toString(),
+                                                                             NLS.get("LoginData.accountLocked"))
+                                                            .withTotalCount()
+                                                            .asPage();
         fillTenantsFromCache(selectableUsers);
 
         webContext.respondWith()

--- a/src/main/java/sirius/biz/tenants/UserAccountData.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountData.java
@@ -74,6 +74,11 @@ public class UserAccountData extends Composite implements MessageProvider {
      */
     public static final String IMAGE_VARIANT_MEDIUM = "user-medium";
 
+    /**
+     * Contains the name of the variant used to fetch the large image.
+     */
+    public static final String IMAGE_VARIANT_LARGE = "user-large";
+
     @Transient
     private final BaseEntity<?> userObject;
 
@@ -463,5 +468,14 @@ public class UserAccountData extends Composite implements MessageProvider {
      */
     public URLBuilder fetchMediumUrl() {
         return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_MEDIUM);
+    }
+
+    /**
+     * Builds a URL to the large image.
+     *
+     * @return a URLBuilder which is used to fetch the large image of this user
+     */
+    public URLBuilder fetchLargeUrl() {
+        return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_LARGE);
     }
 }

--- a/src/main/java/sirius/biz/tenants/UserAccountData.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountData.java
@@ -60,7 +60,7 @@ public class UserAccountData extends Composite implements MessageProvider {
     public static final String STORAGE_SPACE = "user-accounts";
 
     /**
-     * Contains the fallback URI used by {@link #fetchSmallUrl()} and {@link #fetchMediumUrl()}.
+     * Contains the fallback URI used by {@link #fetchSmallUrl()}, {@link #fetchMediumUrl()}, and {@link #fetchLargeUrl()}.
      */
     public static final String IMAGE_FALLBACK_URI = "/assets/images/user_image_fallback.png";
 

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -992,11 +992,17 @@ storage {
 
                 tenant-small {
                     converter = "plain-png"
+                    width = 80
+                    height = 80
+                }
+
+                tenant-medium {
+                    converter = "plain-png"
                     width = 180
                     height = 180
                 }
 
-                tenant-medium {
+                tenant-large {
                     converter = "plain-png"
                     width = 350
                     height = 350
@@ -1004,11 +1010,17 @@ storage {
 
                 user-small {
                     converter = "plain-jpeg"
+                    width = 80
+                    height = 80
+                }
+
+                user-medium {
+                    converter = "plain-jpeg"
                     width = 180
                     height = 180
                 }
 
-                user-medium {
+                user-large {
                     converter = "plain-jpeg"
                     width = 350
                     height = 350

--- a/src/main/resources/default/templates/biz/tenants/profile.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/profile.html.pasta
@@ -27,7 +27,7 @@
             <t:infobox labelKey="UserAccountData.image">
                 <t:blobImageHardRefField name="userAccountData_image"
                                          objectRef="@userAccount.getUserAccountData().getImage()"
-                                         previewVariant="@sirius.biz.tenants.UserAccountData.IMAGE_VARIANT_MEDIUM"
+                                         previewVariant="@sirius.biz.tenants.UserAccountData.IMAGE_VARIANT_LARGE"
                                          defaultPreview="@sirius.biz.tenants.UserAccountData.IMAGE_FALLBACK_URI"/>
             </t:infobox>
 

--- a/src/main/resources/default/templates/biz/tenants/select-tenant.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/select-tenant.html.pasta
@@ -27,8 +27,20 @@
             <t:datacards>
                 <i:for type="sirius.biz.tenants.Tenant" var="tenant" items="tenants.getItems()">
                     <t:datacard subTitle="@tenant.getTenantData().getAccountNumber()"
+                                headerLeft="true"
+                                headerLeftAlignmentClass="align-items-stretch text-break break-word"
                                 link="@apply('/tenants/select/%s', tenant.getIdAsString())">
                         <i:block name="header">
+                            <div class="pl-2 pr-1 align-self-center">
+                                <div class="d-flex flex-column align-items-center justify-content-center"
+                                     style="width: 80px">
+                                    <img style="object-fit: cover; object-position: center;"
+                                         class="mw-100"
+                                         src="@tenant.getTenantData().fetchSmallUrl().buildImageURL()"
+                                         alt=""/>
+                                </div>
+                            </div>
+
                             <i:extensions target="select-tenant" page="tenants" tenant="tenant"
                                           point="card-header"/>
                         </i:block>

--- a/src/main/resources/default/templates/biz/tenants/select-user-account.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/select-user-account.html.pasta
@@ -26,14 +26,26 @@
                 <i:for type="sirius.biz.tenants.UserAccount" var="account" items="users.getItems()">
                     <t:datacard
                             subTitle="@account.getUserAccountData().getLogin().getUsername()"
+                            headerLeft="true"
+                            headerLeftAlignmentClass="align-items-stretch text-break break-word"
                             link="@apply('/user-accounts/select/%s', account.getIdAsString())">
+                        <i:block name="header">
+                            <div class="pl-2 pr-1 align-self-center">
+                                <div class="d-flex flex-column align-items-center justify-content-center"
+                                     style="width: 80px">
+                                    <img style="object-fit: cover; object-position: center;"
+                                         class="mw-100"
+                                         src="@account.getUserAccountData().fetchSmallUrl().buildImageURL()"
+                                         alt=""/>
+                                </div>
+                            </div>
+
+                            <i:extensions target="select-user-account" page="users" account="account"
+                                          point="card-header"/>
+                        </i:block>
                         <i:block name="title">
                             <t:langFlag lang="@account.getUserAccountData().getLanguage().getValue()"/>
                             <span>@account.getUserAccountData()</span>
-                        </i:block>
-                        <i:block name="header">
-                            <i:extensions target="select-user-account" page="users" account="account"
-                                          point="card-header"/>
                         </i:block>
 
                         <i:extensions target="select-user-account" page="users" account="account" point="card-top"/>

--- a/src/main/resources/default/templates/biz/tenants/tenant.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenant.html.pasta
@@ -41,7 +41,7 @@
             <i:if test="page == 'details'">
                 <t:infobox labelKey="TenantData.image">
                     <t:blobImageHardRefField name="tenantData_image" objectRef="@tenant.getTenantData().getImage()"
-                                             previewVariant="@sirius.biz.tenants.TenantData.IMAGE_VARIANT_MEDIUM"
+                                             previewVariant="@sirius.biz.tenants.TenantData.IMAGE_VARIANT_LARGE"
                                              defaultPreview="@sirius.biz.tenants.TenantData.IMAGE_FALLBACK_URI"/>
                 </t:infobox>
 

--- a/src/main/resources/default/templates/biz/tenants/tenant.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenant.html.pasta
@@ -24,15 +24,17 @@
             <i:block name="actions">
                 <i:extensions target="tenant" point="actions" tenant="tenant" controller="controller" page="page"/>
             </i:block>
-            <i:block name="additionalActions">
-                <t:dropdownSection>
-                    <i:extensions target="tenant"
-                                  point="additionalActions"
-                                  tenant="tenant"
-                                  controller="controller"
-                                  page="page"/>
-                </t:dropdownSection>
-            </i:block>
+            <i:if test="!tenant.isNew()">
+                <i:block name="additionalActions">
+                    <t:dropdownSection>
+                        <i:extensions target="tenant"
+                                      point="additionalActions"
+                                      tenant="tenant"
+                                      controller="controller"
+                                      page="page"/>
+                    </t:dropdownSection>
+                </i:block>
+            </i:if>
         </t:pageHeader>
     </i:block>
 

--- a/src/main/resources/default/templates/biz/tenants/tenant.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenant.html.pasta
@@ -47,7 +47,7 @@
 
                 <i:else>
                     <div class="mb-2 d-none d-lg-block">
-                        <t:blobImage skipEmpty="true" urlBuilder="tenant.getTenantData().fetchMediumUrl()"
+                        <t:blobImage skipEmpty="true" urlBuilder="tenant.getTenantData().fetchLargeUrl()"
                                      style="height: 180px"/>
                     </div>
                 </i:else>

--- a/src/main/resources/default/templates/biz/tenants/tenant.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenant.html.pasta
@@ -17,7 +17,7 @@
     </i:block>
 
     <i:block name="page-header">
-        <t:pageHeader title="@tenant.getTenantData().getName()">
+        <t:pageHeader title="@tenant.isNew() ? tenant.toString() : tenant.getTenantData().getName()">
             <t:inlineInfo labelKey="TenantData.accountNumber" value="@tenant.getTenantData().getAccountNumber()"/>
             <i:extensions target="tenant" point="head" tenant="tenant" controller="controller" page="page"/>
 

--- a/src/main/resources/default/templates/biz/tenants/tenants.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenants.html.pasta
@@ -28,8 +28,20 @@
             <t:datacards>
                 <i:for type="sirius.biz.tenants.Tenant" var="tenant" items="tenants.getItems()">
                     <t:datacard subTitle="@tenant.getTenantData().getAccountNumber()"
+                                headerLeft="true"
+                                headerLeftAlignmentClass="align-items-stretch text-break break-word"
                                 link="@apply('/tenant/%s', tenant.getIdAsString())">
                         <i:block name="header">
+                            <div class="pl-2 pr-1 align-self-center">
+                                <div class="d-flex flex-column align-items-center justify-content-center"
+                                     style="width: 80px">
+                                    <img style="object-fit: cover; object-position: center;"
+                                         class="mw-100"
+                                         src="@tenant.getTenantData().fetchSmallUrl().buildImageURL()"
+                                         alt=""/>
+                                </div>
+                            </div>
+
                             <i:extensions target="tenants" page="tenants" tenant="tenant"
                                           point="card-header"/>
                         </i:block>

--- a/src/main/resources/default/templates/biz/tenants/user-account-details-fields.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account-details-fields.html.pasta
@@ -1,0 +1,85 @@
+<i:arg type="sirius.biz.tenants.UserAccount" name="account"/>
+<i:arg type="sirius.biz.tenants.UserAccountController" name="controller"/>
+
+<div class="row">
+    <t:textfield name="userAccountData_email" value="@account.getUserAccountData().getEmail()"
+                 labelKey="Model.email"
+                 class="col-12 col-md-6 required"
+                 helpKey="UserAccount.email.help"/>
+    <t:textfield class="col-12 col-md-6" name="userAccountData_login_username"
+                 value="@account.getUserAccountData().getLogin().getUsername()"
+                 labelKey="LoginData.username"
+                 helpKey="UserAccount.username.help"/>
+</div>
+
+<div class="row">
+    <t:lookupValue class="col-12 col-md-6 col-xl-3" name="userAccountData_person_salutation"
+                   value="@account.getUserAccountData().getPerson().getSalutation()"
+                   optional="true"
+                   labelKey="PersonData.salutation"/>
+    <t:textfield class="col-12 col-md-6 col-xl-3" name="userAccountData_person_title"
+                 value="@account.getUserAccountData().getPerson().getTitle()" labelKey="PersonData.title"/>
+    <t:textfield class="col-12 col-md-6" name="userAccountData_person_firstname"
+                 value="@account.getUserAccountData().getPerson().getFirstname()"
+                 labelKey="PersonData.firstname"/>
+    <t:textfield class="col-12 col-md-6" name="userAccountData_person_lastname"
+                 value="@account.getUserAccountData().getPerson().getLastname()"
+                 labelKey="PersonData.lastname"/>
+
+    <t:singleSelect class="col-12 col-md-6" name="userAccountData_language" labelKey="Model.language">
+        <i:for var="language" items="controller.getAvailableLanguages()" type="Tuple">
+            <option value="@language.getFirst()"
+                    @selected="language.getFirst() == account.getUserAccountData().getLanguage().getValue()">
+                @language.getSecond()
+            </option>
+        </i:for>
+    </t:singleSelect>
+</div>
+
+<i:extensions target="user-account-details" point="below-details" account="account"/>
+
+<div class="row">
+    <div class="col-md-6">
+        <t:heading labelKey="Model.security"/>
+        <div class="row">
+            <t:booleanSelect class="col" name="userAccountData_login_accountLocked"
+                             value="account.getUserAccountData().getLogin().isAccountLocked()"
+                             labelKey="LoginData.accountLocked"
+                             helpKey="LoginData.accountLocked.help"/>
+        </div>
+        <i:if test="!controller.getSubScopes().isEmpty()">
+            <div class="row">
+                <t:singleSelect class="col" name="userAccountData_subScopes"
+                                labelKey="UserAccountData.subScopes"
+                                helpKey="UserAccountData.subScopes.help"
+                                optional="true">
+                    <i:for var="subScope"
+                           type="String"
+                           items="@controller.getSubScopes()">
+                        <option value="@subScope"
+                                @selected="account.getUserAccountData().getSubScopes().contains(subScope)">
+                            @controller.getSubScopeName(subScope)
+                        </option>
+                    </i:for>
+                </t:singleSelect>
+            </div>
+        </i:if>
+    </div>
+    <div class="col-md-6">
+        <t:heading labelKey="UserAccount.roles"/>
+        <i:for type="String" var="role" items="controller.getRoles()">
+            <div class="form-check">
+                <label>
+                    <input class="form-check-input" type="checkbox" name="roles" value="@role"
+                           @checked="account.getUserAccountData().getPermissions().getPermissions().contains(role)"/>
+                    <label class="form-check-label">
+                        @controller.getRoleName(role)
+                    </label>
+                    <small class="form-text text-muted">@controller.getRoleDescription(role)</small>
+                </label>
+            </div>
+        </i:for>
+    </div>
+</div>
+
+<i:extensions target="user-account-details" point="bottom" account="account"/>

--- a/src/main/resources/default/templates/biz/tenants/user-account-details.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account-details.html.pasta
@@ -3,88 +3,9 @@
 
 <i:invoke template="/templates/biz/tenants/user-account.html.pasta" account="account" page="details">
     <t:editForm url="@apply('/user-account/%s', account.getIdAsString())">
-        <div class="row">
-            <t:textfield name="userAccountData_email" value="@account.getUserAccountData().getEmail()"
-                         labelKey="Model.email"
-                         class="col-12 col-md-6 required"
-                         helpKey="UserAccount.email.help"/>
-            <t:textfield class="col-12 col-md-6" name="userAccountData_login_username"
-                         value="@account.getUserAccountData().getLogin().getUsername()"
-                         labelKey="LoginData.username"
-                         helpKey="UserAccount.username.help"/>
-        </div>
-
-        <div class="row">
-            <t:lookupValue class="col-12 col-md-6 col-xl-3" name="userAccountData_person_salutation"
-                           value="@account.getUserAccountData().getPerson().getSalutation()"
-                           optional="true"
-                           labelKey="PersonData.salutation"/>
-            <t:textfield class="col-12 col-md-6 col-xl-3" name="userAccountData_person_title"
-                         value="@account.getUserAccountData().getPerson().getTitle()" labelKey="PersonData.title"/>
-            <t:textfield class="col-12 col-md-6" name="userAccountData_person_firstname"
-                         value="@account.getUserAccountData().getPerson().getFirstname()"
-                         labelKey="PersonData.firstname"/>
-            <t:textfield class="col-12 col-md-6" name="userAccountData_person_lastname"
-                         value="@account.getUserAccountData().getPerson().getLastname()"
-                         labelKey="PersonData.lastname"/>
-
-            <t:singleSelect class="col-12 col-md-6" name="userAccountData_language" labelKey="Model.language">
-                <i:for var="language" items="controller.getAvailableLanguages()" type="Tuple">
-                    <option value="@language.getFirst()"
-                            @selected="language.getFirst() == account.getUserAccountData().getLanguage().getValue()">
-                        @language.getSecond()
-                    </option>
-                </i:for>
-            </t:singleSelect>
-        </div>
-
-        <i:extensions target="user-account-details" point="below-details" account="account"/>
-
-        <div class="row">
-            <div class="col-md-6">
-                <t:heading labelKey="Model.security"/>
-                <div class="row">
-                    <t:booleanSelect class="col" name="userAccountData_login_accountLocked"
-                                     value="account.getUserAccountData().getLogin().isAccountLocked()"
-                                     labelKey="LoginData.accountLocked"
-                                     helpKey="LoginData.accountLocked.help"/>
-                </div>
-                <i:if test="!controller.getSubScopes().isEmpty()">
-                    <div class="row">
-                        <t:singleSelect class="col" name="userAccountData_subScopes"
-                                        labelKey="UserAccountData.subScopes"
-                                        helpKey="UserAccountData.subScopes.help"
-                                        optional="true">
-                            <i:for var="subScope"
-                                   type="String"
-                                   items="@controller.getSubScopes()">
-                                <option value="@subScope"
-                                        @selected="account.getUserAccountData().getSubScopes().contains(subScope)">
-                                    @controller.getSubScopeName(subScope)
-                                </option>
-                            </i:for>
-                        </t:singleSelect>
-                    </div>
-                </i:if>
-            </div>
-            <div class="col-md-6">
-                <t:heading labelKey="UserAccount.roles"/>
-                <i:for type="String" var="role" items="controller.getRoles()">
-                    <div class="form-check">
-                        <label>
-                            <input class="form-check-input" type="checkbox" name="roles" value="@role"
-                                   @checked="account.getUserAccountData().getPermissions().getPermissions().contains(role)"/>
-                            <label class="form-check-label">
-                                @controller.getRoleName(role)
-                            </label>
-                            <small class="form-text text-muted">@controller.getRoleDescription(role)</small>
-                        </label>
-                    </div>
-                </i:for>
-            </div>
-        </div>
-
-        <i:extensions target="user-account-details" point="bottom" account="account"/>
+        <i:invoke template="/templates/biz/tenants/user-account-details-fields.html.pasta"
+                  account="account"
+                  controller="controller"/>
 
         <t:formBar backButton="false">
             <t:tracing trace="account.getTrace()" journal="account.getJournal()"/>

--- a/src/main/resources/default/templates/biz/tenants/user-account.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account.html.pasta
@@ -111,7 +111,7 @@
 
                 <i:else>
                     <div class="mb-2 d-none d-lg-block">
-                        <t:blobImage skipEmpty="true" urlBuilder="account.getUserAccountData().fetchMediumUrl()"
+                        <t:blobImage skipEmpty="true" urlBuilder="account.getUserAccountData().fetchLargeUrl()"
                                      style="height: 180px"/>
                     </div>
                 </i:else>

--- a/src/main/resources/default/templates/biz/tenants/user-account.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account.html.pasta
@@ -18,7 +18,7 @@
     </i:block>
 
     <i:block name="page-header">
-        <t:pageHeader title="@account.getUserAccountData().toString()">
+        <t:pageHeader title="@account.isNew() ? account.toString() : account.getUserAccountData().toString()">
             <i:block name="actions">
                 <i:extensions target="user-account" account="account" point="actions"/>
             </i:block>

--- a/src/main/resources/default/templates/biz/tenants/user-account.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account.html.pasta
@@ -105,7 +105,7 @@
                 <t:infobox labelKey="UserAccountData.image">
                     <t:blobImageHardRefField name="userAccountData_image"
                                              objectRef="@account.getUserAccountData().getImage()"
-                                             previewVariant="@sirius.biz.tenants.UserAccountData.IMAGE_VARIANT_MEDIUM"
+                                             previewVariant="@sirius.biz.tenants.UserAccountData.IMAGE_VARIANT_LARGE"
                                              defaultPreview="@sirius.biz.tenants.UserAccountData.IMAGE_FALLBACK_URI"/>
                 </t:infobox>
 

--- a/src/main/resources/default/templates/biz/tenants/user-account.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account.html.pasta
@@ -23,48 +23,50 @@
                 <i:extensions target="user-account" account="account" point="actions"/>
             </i:block>
 
-            <i:block name="additionalActions">
-                <t:dropdownSection>
-                    <t:dropdownItem labelKey="TenantController.select"
-                                    icon="fa fa-building"
-                                    url="@apply('/user-accounts/select/%s', account.getIdAsString())"/>
-                </t:dropdownSection>
-                <i:if test="@account.getUserAccountData().isPasswordGenerationPossible()">
+            <i:if test="!account.isNew()">
+                <i:block name="additionalActions">
                     <t:dropdownSection>
-                        <t:dropdownItem
-                                labelKey="LoginData.password.generate"
-                                icon="fa-regular fa-envelope"
-                                url="@apply('/user-account/%s/generate-password', account.getIdAsString())"/>
-                        <i:if test="@account.getUserAccountData().canSendGeneratedPassword()">
+                        <t:dropdownItem labelKey="TenantController.select"
+                                        icon="fa fa-building"
+                                        url="@apply('/user-accounts/select/%s', account.getIdAsString())"/>
+                    </t:dropdownSection>
+                    <i:if test="@account.getUserAccountData().isPasswordGenerationPossible()">
+                        <t:dropdownSection>
                             <t:dropdownItem
-                                    labelKey="LoginData.password.generateAndSend"
-                                    icon="fa-solid fa-envelope"
-                                    url="@apply('/user-account/%s/generate-and-send-password', account.getIdAsString())"/>
+                                    labelKey="LoginData.password.generate"
+                                    icon="fa-regular fa-envelope"
+                                    url="@apply('/user-account/%s/generate-password', account.getIdAsString())"/>
+                            <i:if test="@account.getUserAccountData().canSendGeneratedPassword()">
+                                <t:dropdownItem
+                                        labelKey="LoginData.password.generateAndSend"
+                                        icon="fa-solid fa-envelope"
+                                        url="@apply('/user-account/%s/generate-and-send-password', account.getIdAsString())"/>
+                            </i:if>
+                        </t:dropdownSection>
+                    </i:if>
+                    <t:dropdownSection>
+                        <i:if test="account.getUserAccountData().getLogin().isAccountLocked()">
+                            <t:dropdownItem
+                                    labelKey="LoginData.unlock"
+                                    icon="fa-solid fa-unlock"
+                                    url="@apply('/user-account/%s/unlock', account.getIdAsString())"/>
+                            <i:else>
+                                <t:dropdownItem
+                                        labelKey="LoginData.lock"
+                                        icon="fa-solid fa-lock"
+                                        url="@apply('/user-account/%s/lock', account.getIdAsString())"/>
+                            </i:else>
                         </i:if>
                     </t:dropdownSection>
-                </i:if>
-                <t:dropdownSection>
-                    <i:if test="account.getUserAccountData().getLogin().isAccountLocked()">
-                        <t:dropdownItem
-                                labelKey="LoginData.unlock"
-                                icon="fa-solid fa-unlock"
-                                url="@apply('/user-account/%s/unlock', account.getIdAsString())"/>
-                        <i:else>
-                            <t:dropdownItem
-                                    labelKey="LoginData.lock"
-                                    icon="fa-solid fa-lock"
-                                    url="@apply('/user-account/%s/lock', account.getIdAsString())"/>
-                        </i:else>
-                    </i:if>
-                </t:dropdownSection>
 
-                <t:dropdownSection>
-                    <i:extensions target="user-account" account="account" point="additionalActions"/>
-                </t:dropdownSection>
-                <t:dropdownSection>
-                    <t:dropdownDeleteItem url="@apply('/user-account/%s/delete', account.getIdAsString())"/>
-                </t:dropdownSection>
-            </i:block>
+                    <t:dropdownSection>
+                        <i:extensions target="user-account" account="account" point="additionalActions"/>
+                    </t:dropdownSection>
+                    <t:dropdownSection>
+                        <t:dropdownDeleteItem url="@apply('/user-account/%s/delete', account.getIdAsString())"/>
+                    </t:dropdownSection>
+                </i:block>
+            </i:if>
 
             <div class="d-flex flex-row">
                 <i:if test="account.getUserAccountData().getLogin().isAccountLocked()">

--- a/src/main/resources/default/templates/biz/tenants/user-accounts.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-accounts.html.pasta
@@ -30,13 +30,25 @@
                 <i:for type="sirius.biz.tenants.UserAccount" var="account" items="accounts.getItems()">
                     <t:datacard
                             subTitle="@account.getUserAccountData().getLogin().getUsername()"
+                            headerLeft="true"
+                            headerLeftAlignmentClass="align-items-stretch text-break break-word"
                             link="@apply('/user-account/%s', account.getIdAsString())">
+                        <i:block name="header">
+                            <div class="pl-2 pr-1 align-self-center">
+                                <div class="d-flex flex-column align-items-center justify-content-center"
+                                     style="width: 80px">
+                                    <img style="object-fit: cover; object-position: center;"
+                                         class="mw-100"
+                                         src="@account.getUserAccountData().fetchSmallUrl().buildImageURL()"
+                                         alt=""/>
+                                </div>
+                            </div>
+
+                            <i:extensions target="user-accounts" page="accounts" account="account" point="card-header"/>
+                        </i:block>
                         <i:block name="title">
                             <t:langFlag lang="@account.getUserAccountData().getLanguage().getValue()"/>
                             <span>@account.getUserAccountData()</span>
-                        </i:block>
-                        <i:block name="header">
-                            <i:extensions target="user-accounts" page="accounts" account="account" point="card-header"/>
                         </i:block>
                         <i:block name="actions">
                             <t:dropdownSection>


### PR DESCRIPTION
Tenants List:
![Bildschirmfoto 2023-06-20 um 14 07 38](https://github.com/scireum/sirius-biz/assets/42942954/c833e3e6-5bc0-43a8-ab1f-5c30f44067f4)

"Select Tenant". "Select User" and "User Accounts List" use the same layout with images.

Also extracts user account details to a separate template for reusability, as was also done with tenant details in commit [1201d1914b429743fa053000466099af03a2238d](https://github.com/scireum/sirius-biz/pull/1723/commits/1201d1914b429743fa053000466099af03a2238d).

Fixes: [OX-8902](https://scireum.myjetbrains.com/youtrack/issue/OX-8902), [SIRI-606](https://scireum.myjetbrains.com/youtrack/issue/SIRI-606)

### Breaking
Due to the changed image variant configuration, these steps need to be performed for `TenantData` and `UserAccountData` when upgrading to this version:
- replace previous calls of `fetchSmallUrl` with `fetchMediumUrl` and `fetchMediumUrl` with `fetchLargeUrl`
- replace previous usages of the constant `IMAGE_VARIANT_SMALL` with `IMAGE_VARIANT_MEDIUM` and `IMAGE_VARIANT_MEDIUM` with `IMAGE_VARIANT_LARGE`