### PR TITLE
Add getter for value of sort field

### DIFF
--- a/src/main/java/sirius/biz/mongo/SortField.java
+++ b/src/main/java/sirius/biz/mongo/SortField.java
@@ -106,4 +106,8 @@ public class SortField extends Composite {
 
         this.sortField = normalizeText(sortFieldContents.toString());
     }
+
+    private String getSortField() {
+        return sortField;
+    }
 }

--- a/src/main/java/sirius/biz/mongo/SortField.java
+++ b/src/main/java/sirius/biz/mongo/SortField.java
@@ -107,7 +107,7 @@ public class SortField extends Composite {
         this.sortField = normalizeText(sortFieldContents.toString());
     }
 
-    private String getSortField() {
+    public String getSortField() {
         return sortField;
     }
 }


### PR DESCRIPTION
This can for example be used in comparators when wanting to sort a list of entities with a SortField on their lexicographic order.

Fixes: [OX-10128](https://scireum.myjetbrains.com/youtrack/issue/OX-10128)