### PR TITLE
Changes the order in which passwords and API-Tokens are checked

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -647,12 +647,6 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         }
 
         LoginData loginData = account.getUserAccountData().getLogin();
-        if (acceptApiTokens && checkApiToken(loginData, password)) {
-            completeAuditLogForUser(auditLog.neutral("AuditLog.apiTokenLogin"), account);
-            recordLogin(result, false);
-            return result;
-        }
-
         LoginData.PasswordVerificationResult pwResult = loginData.checkPassword(user, password);
         if (pwResult != LoginData.PasswordVerificationResult.INVALID) {
             completeAuditLogForUser(auditLog.neutral("AuditLog.passwordLogin"), account);
@@ -664,6 +658,12 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
                 return rehashingResult.get();
             }
 
+            recordLogin(result, false);
+            return result;
+        }
+
+        if (acceptApiTokens && checkApiToken(loginData, password)) {
+            completeAuditLogForUser(auditLog.neutral("AuditLog.apiTokenLogin"), account);
             recordLogin(result, false);
             return result;
         }


### PR DESCRIPTION
We prefer checking the password, as we're trying to migrate away from API tokens. Therefore we monitor the logs for "AuditLog.apiTokenLogin" and place these API tokens as properly encrypted and protected password.

Once a system no longer receives these messages, we can disable the support for api tokens entirely.