### PR TITLE
Makes roles checkbox labels clickable

### DIFF
--- a/src/main/resources/default/templates/biz/tenants/user-account-details-fields.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account-details-fields.html.pasta
@@ -72,9 +72,9 @@
                 <label>
                     <input class="form-check-input" type="checkbox" name="roles" value="@role"
                            @checked="account.getUserAccountData().getPermissions().getPermissions().contains(role)"/>
-                    <label class="form-check-label">
+                    <span class="form-check-label">
                         @controller.getRoleName(role)
-                    </label>
+                    </span>
                     <small class="form-text text-muted">@controller.getRoleDescription(role)</small>
                 </label>
             </div>


### PR DESCRIPTION
By replacing the inner `label` tag with a `span` tag, similar to the setup used in `t:checkbox`.

Fixes: [OX-8902](https://scireum.myjetbrains.com/youtrack/issue/OX-8902)