### PR TITLE
Prioritize the fallback value reading from disabled multi-language strings

### DIFF
--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -325,6 +325,14 @@ public class MultiLanguageString extends SafeMap<String, String> {
             throw new IllegalStateException(
                     "Can not call fetchTextOrFallback on a MultiLanguageString without fallback enabled.");
         }
+
+        if (!isEnabled()) {
+            // If the multi-language features are disabled for the field, returns the fallback value by default,
+            // falling back to the requested language as last resort. The fallback key is what gets written to the
+            // database on save for fields in this state.
+            return data().getOrDefault(FALLBACK_KEY, data().get(language));
+        }
+
         return data().getOrDefault(language, data().get(FALLBACK_KEY));
     }
 


### PR DESCRIPTION
Disabled multi-language strings (depending on conditions/permissions) saves its data to the fallback key, and reading should prioritize the same.

This can be the case if a permission gets revoked and data already exists for specific languages.

In the event of dirty data, where only a language key would exist, we fallback to the language as last resort. Note that this is actually bad data, as every multi-language field depending on permissions/conditions must be declared with fallback.

Fixes: [OX-9958](https://scireum.myjetbrains.com/youtrack/issue/OX-9958)