### PR TITLE
Fixes the user-account select page for SQL

### DIFF
--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -610,19 +610,11 @@ public abstract class UserAccountController<I extends Serializable, T extends Ba
                                                                              NLS.get("LoginData.accountLocked"))
                                                             .withTotalCount()
                                                             .asPage();
-        fillTenantsFromCache(selectableUsers);
 
         webContext.respondWith()
                   .template("/templates/biz/tenants/select-user-account.html.pasta",
                             selectableUsers,
                             isCurrentlySpying(webContext));
-    }
-
-    private void fillTenantsFromCache(Page<U> selectableUsers) {
-        selectableUsers.getItems()
-                       .forEach(user -> user.getTenant()
-                                            .setValue(matchingTenants.fetchCachedTenant(user.getTenant())
-                                                                     .orElse(null)));
     }
 
     private boolean isCurrentlySpying(WebContext webContext) {

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountController.java
@@ -61,19 +61,6 @@ public class SQLUserAccountController extends UserAccountController<Long, SQLTen
     @Override
     protected BasePageHelper<SQLUserAccount, ?, ?, ?> getSelectableUsersAsPage() {
         SmartQuery<SQLUserAccount> baseQuery = oma.select(SQLUserAccount.class)
-                                                  .fields(SQLEntity.ID,
-                                                          UserAccount.TENANT.join(Tenant.TENANT_DATA.inner(TenantData.NAME)),
-                                                          UserAccount.TENANT.join(Tenant.TENANT_DATA.inner(TenantData.ACCOUNT_NUMBER)),
-                                                          UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.PERSON)
-                                                                                       .inner(PersonData.TITLE),
-                                                          UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.PERSON)
-                                                                                       .inner(PersonData.SALUTATION),
-                                                          UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.PERSON)
-                                                                                       .inner(PersonData.LASTNAME),
-                                                          UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.PERSON)
-                                                                                       .inner(PersonData.FIRSTNAME),
-                                                          UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.LOGIN)
-                                                                                       .inner(LoginData.USERNAME))
                                                   .orderAsc(UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.PERSON)
                                                                                          .inner(PersonData.LASTNAME))
                                                   .orderAsc(UserAccount.USER_ACCOUNT_DATA.inner(UserAccountData.PERSON)


### PR DESCRIPTION
`withTotalCount` was recently added to the select page, which triggers a count query if more than 25 users are selectable. This causes an error as we also specify fields for the query to select.

We no longer display the tenant info on the select page, which makes the joins unnecessary.

Fixes: [SE-12876](https://scireum.myjetbrains.com/youtrack/issue/SE-12876)