### PR TITLE
SIRI-837: Fix Pagination on Tenant Select Page

### DIFF
--- a/src/main/resources/default/templates/biz/tenants/select-tenant.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/select-tenant.html.pasta
@@ -25,7 +25,7 @@
 
         <i:invoke template="/templates/biz/tenants/tenants-list.html.pasta"
                   tenants="tenants"
-                  paginationBaseUrl="@('/tenants')"
+                  paginationBaseUrl="@('/tenants/select')"
                   cardBaseUrl="@('/tenants/select')"
                   enableCardActions="false"/>
     </t:sidebar>


### PR DESCRIPTION
Previously, jumping from "/tenants/select" to the second page would jump to "/tenants?start=26", which is wrong and not all users have access to it.