### PR TITLE
Read-Out of Multi-Language-Strings for All Users (OX-10242)

### DIFF
--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -326,13 +326,6 @@ public class MultiLanguageString extends SafeMap<String, String> {
                     "Can not call fetchTextOrFallback on a MultiLanguageString without fallback enabled.");
         }
 
-        if (!isEnabled()) {
-            // If the multi-language features are disabled for the field, returns the fallback value by default,
-            // falling back to the requested language as last resort. The fallback key is what gets written to the
-            // database on save for fields in this state.
-            return data().getOrDefault(FALLBACK_KEY, data().get(language));
-        }
-
         return data().getOrDefault(language, data().get(FALLBACK_KEY));
     }
 


### PR DESCRIPTION
> [OX-10242](https://scireum.myjetbrains.com/youtrack/issue/OX-10242)

This commit reverts 78eec2eae0f5e0af06a4980e8d4be6549cd6bbec. It caused users without the `content-i18n` permission to lose access to translated strings. This was particularly problematic in the OX Frontend where content is resolved for the `(public)` user who happens not to have this permission. That lead to OX delivering non-translated content.
