### PR TITLE
Fixes sftp inputstream reads

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplink.java
@@ -30,6 +30,7 @@ import sirius.kernel.health.Exceptions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -368,7 +369,7 @@ public class SFTPUplink extends ConfigBasedUplink {
             try {
                 InputStream rawStream = connector.connector().read(path);
 
-                return new WatchableInputStream(rawStream).onCompletion(connector::safeClose);
+                return new WatchableInputStream(new BufferedInputStream(rawStream)).onCompletion(connector::safeClose);
             } catch (Exception e) {
                 connector.safeClose();
                 if (attempt.shouldThrow(e)) {


### PR DESCRIPTION
- org.apache.sshd.sftp.client.impl.SftpInputStreamAsync#read(byte[], int, int) sometimes behaves incorrectly when reading a length of 0 by returning -1 whilst the actual buffer does not hit EOF yet
- see https://github.com/apache/mina-sshd/issues/398 for details
- the BufferedInputStream is a workaround, as it early returns 0 when requesting length 0