### PR TITLE
Restores Fix for `MultiLanguageString` that has been "unfixed" in OX HF2

### DIFF
--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -326,13 +326,6 @@ public class MultiLanguageString extends SafeMap<String, String> {
                     "Can not call fetchTextOrFallback on a MultiLanguageString without fallback enabled.");
         }
 
-        if (!isEnabled()) {
-            // If the multi-language features are disabled for the field, returns the fallback value by default,
-            // falling back to the requested language as last resort. The fallback key is what gets written to the
-            // database on save for fields in this state.
-            return data().getOrDefault(FALLBACK_KEY, data().get(language));
-        }
-
         return data().getOrDefault(language, data().get(FALLBACK_KEY));
     }
 


### PR DESCRIPTION
This restores 9488d6b40c1d403275812545c815c7c2d61a99df (https://github.com/scireum/sirius-biz/pull/1783).