### PR TITLE
SIRI-814: Fix Exporting SQL Results

### DIFF
--- a/src/main/java/sirius/biz/jdbc/DatabaseController.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseController.java
@@ -91,9 +91,8 @@ public class DatabaseController extends BasicController {
     @DefaultRoute
     public void sql(WebContext ctx) {
         // Only display selectable databases which are properly configured...
-        List<String> availableDatabases = selectableDatabases.stream()
-                                                             .filter(name -> databases.getDatabases().contains(name))
-                                                             .toList();
+        List<String> availableDatabases =
+                selectableDatabases.stream().filter(name -> databases.getDatabases().contains(name)).toList();
         ctx.respondWith().template("/templates/biz/model/sql.html.pasta", availableDatabases, defaultDatabase);
     }
 

--- a/src/main/java/sirius/biz/jdbc/DatabaseController.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseController.java
@@ -37,13 +37,9 @@ import sirius.web.security.UserContext;
 import sirius.web.services.InternalService;
 import sirius.web.services.JSONStructuredOutput;
 
-import javax.annotation.Nullable;
-import java.sql.Array;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Provides the management GUI for database related activities.
@@ -81,6 +77,9 @@ public class DatabaseController extends BasicController {
 
     @Part
     private Jobs jobs;
+
+    @Part
+    private DatabaseDisplayUtils databaseDisplayUtils;
 
     /**
      * Renders the UI to execute SQL queries.
@@ -227,29 +226,9 @@ public class DatabaseController extends BasicController {
         }
         out.beginArray("row");
         for (Tuple<String, Object> col : row.getFieldsList()) {
-            out.property("column", formatValue(col.getSecond()));
+            out.property("column", databaseDisplayUtils.formatValueForDisplay(col.getSecond()));
         }
         out.endArray();
-    }
-
-    private String formatValue(@Nullable Object value) {
-        if (value == null) {
-            return "";
-        }
-
-        if (value.getClass().isArray()) {
-            return Arrays.stream((Object[]) value).map(NLS::toUserString).collect(Collectors.joining(", "));
-        }
-
-        if (value instanceof Array sqlArrayValue) {
-            try {
-                return Arrays.stream((Object[]) sqlArrayValue.getArray()).map(NLS::toUserString).collect(Collectors.joining(", "));
-            } catch (SQLException e) {
-                Exceptions.ignore(e);
-            }
-        }
-
-        return NLS.toUserString(value);
     }
 
     /**

--- a/src/main/java/sirius/biz/jdbc/DatabaseDisplayUtils.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseDisplayUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jdbc;
+
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.nls.NLS;
+
+import javax.annotation.Nullable;
+import java.sql.Array;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Helps in displaying database contents in the UI and in export files.
+ */
+@Register(classes = DatabaseDisplayUtils.class)
+public class DatabaseDisplayUtils {
+
+    /**
+     * Formats the given value from the database for display.
+     *
+     * @param value the value to format
+     * @return the formatted value
+     */
+    public String formatValueForDisplay(@Nullable Object value) {
+        if (value == null) {
+            return "";
+        }
+
+        if (value.getClass().isArray()) {
+            return Arrays.stream((Object[]) value).map(NLS::toUserString).collect(Collectors.joining(", "));
+        }
+
+        if (value instanceof Array sqlArrayValue) {
+            try {
+                return Arrays.stream((Object[]) sqlArrayValue.getArray())
+                             .map(NLS::toUserString)
+                             .collect(Collectors.joining(", "));
+            } catch (SQLException e) {
+                Exceptions.ignore(e);
+            }
+        }
+
+        return NLS.toUserString(value);
+    }
+}

--- a/src/main/java/sirius/biz/jdbc/ExportQueryResultJobFactory.java
+++ b/src/main/java/sirius/biz/jdbc/ExportQueryResultJobFactory.java
@@ -21,6 +21,7 @@ import sirius.db.jdbc.Row;
 import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Tuple;
+import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 import sirius.web.security.Permission;
@@ -37,6 +38,9 @@ import java.util.function.Consumer;
 @Register(framework = Processes.FRAMEWORK_PROCESSES)
 @Permission(TenantUserManager.PERMISSION_SYSTEM_ADMINISTRATOR)
 public class ExportQueryResultJobFactory extends LineBasedExportJobFactory {
+
+    @Part
+    private DatabaseDisplayUtils databaseDisplayUtils;
 
     /**
      * Contains the part-name of this factory.
@@ -79,7 +83,11 @@ public class ExportQueryResultJobFactory extends LineBasedExportJobFactory {
                 if (monoflop.firstCall()) {
                     export.addListRow(Tuple.firsts(row.getFieldsList()));
                 }
-                export.addListRow(Tuple.seconds(row.getFieldsList()));
+                export.addListRow(row.getFieldsList()
+                                     .stream()
+                                     .map(Tuple::getSecond)
+                                     .map(value -> databaseDisplayUtils.formatValueForDisplay(value))
+                                     .toList());
                 process.incCounter("Row");
             } catch (IOException e) {
                 throw process.handle(e);

--- a/src/main/java/sirius/biz/jdbc/ExportQueryResultJobFactory.java
+++ b/src/main/java/sirius/biz/jdbc/ExportQueryResultJobFactory.java
@@ -46,7 +46,7 @@ public class ExportQueryResultJobFactory extends LineBasedExportJobFactory {
      * Contains the part-name of this factory.
      */
     public static final String FACTORY_NAME = "export-query-result";
-    
+
     private final Parameter<Database> databaseParameter = new DatabaseParameter().markRequired().build();
     private final Parameter<String> sqlParameter = new TextareaParameter("query", "Query").markRequired().build();
 


### PR DESCRIPTION
Previously, for Clickhouse queries, the exported data would not be formatted correctly. See screenshot:
<img width="538" alt="Bildschirm_foto 2023-05-16 um 08 09 18" src="https://github.com/scireum/sirius-biz/assets/53555813/6e86e1ca-f95e-4d57-9ae7-8ba5d015a838">

Now, the data displayed on the page and the exported data will match.
