### PR TITLE
Adds a method which calculates the cumulative sum of metrics, commencing from the specified startDate and continuing until the untilDate is reached

### DIFF
--- a/src/main/java/sirius/biz/analytics/metrics/MetricQuery.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricQuery.java
@@ -187,6 +187,17 @@ public class MetricQuery {
     }
 
     /**
+     * Calculates the cumulative sum of metrics, commencing from the specified  <tt>startDate</tt> and continuing until the <tt>untilDate</tt> is reached.
+     *
+     * @param startDate the first date to calculate the sum of the metrics for
+     * @param untilDate the last date to calculate the sum of the metrics for
+     * @return the sum of the metrics fetched for the given period
+     */
+    public Integer sum(LocalDate startDate, LocalDate untilDate) {
+        return values(startDate, untilDate).stream().mapToInt(Integer::intValue).sum();
+    }
+
+    /**
      * Fetches a value for each of the dates in the given stream.
      *
      * @param dates the stream of dates to handle


### PR DESCRIPTION

Fixes: OX-10190