### PR TITLE
Jupiter: Usability for Products without the Tenant Framework

### DIFF
--- a/src/main/java/sirius/biz/analytics/explorer/EntityChartObjectResolver.java
+++ b/src/main/java/sirius/biz/analytics/explorer/EntityChartObjectResolver.java
@@ -14,6 +14,7 @@ import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.Mixing;
 import sirius.kernel.di.std.Part;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
@@ -30,6 +31,7 @@ public abstract class EntityChartObjectResolver<E extends BaseEntity<?>> impleme
     protected Mixing mixing;
 
     @Part
+    @Nullable
     protected Tenants<?, ?, ?> tenants;
 
     @Override

--- a/src/main/java/sirius/biz/jupiter/JupiterSync.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSync.java
@@ -644,7 +644,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
             return tenants.getSystemTenantId();
         }
 
-        return null;
+        throw Exceptions.createHandled().withSystemErrorMessage("Cannot resolve system tenant.").handle();
     }
 
     private String resolveSystemTenantName() {
@@ -652,6 +652,6 @@ public class JupiterSync implements Startable, EndOfDayTask {
             return tenants.getSystemTenantName();
         }
 
-        return null;
+        throw Exceptions.createHandled().withSystemErrorMessage("Cannot resolve system tenant.").handle();
     }
 }

--- a/src/main/java/sirius/biz/jupiter/JupiterSync.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSync.java
@@ -121,6 +121,10 @@ public class JupiterSync implements Startable, EndOfDayTask {
     private Tenants<?, ?, ?> tenants;
 
     @Part
+    @Nullable
+    private JupiterSyncSystemTenantSupplier tenantSupplier;
+
+    @Part
     private Jupiter jupiter;
 
     @Part
@@ -644,12 +648,20 @@ public class JupiterSync implements Startable, EndOfDayTask {
             return tenants.getSystemTenantId();
         }
 
+        if (tenantSupplier != null) {
+            return tenantSupplier.getSystemTenantId();
+        }
+
         throw Exceptions.createHandled().withSystemErrorMessage("Cannot resolve system tenant.").handle();
     }
 
     private String resolveSystemTenantName() {
         if (tenants != null) {
             return tenants.getSystemTenantName();
+        }
+
+        if (tenantSupplier != null) {
+            return tenantSupplier.getSystemTenantName();
         }
 
         throw Exceptions.createHandled().withSystemErrorMessage("Cannot resolve system tenant.").handle();

--- a/src/main/java/sirius/biz/jupiter/JupiterSync.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSync.java
@@ -218,7 +218,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
         processContext.log(ProcessLog.info().withFormattedMessage("Executing data provider: %s", provider.getName()));
 
         Blob blob = blobStorage.getSpace(localRepoSpaceName)
-                               .findOrCreateByPath(tenants.getTenantUserManager().getSystemTenantId(),
+                               .findOrCreateByPath(tenants.getSystemTenantId(),
                                                    provider.getFilename());
 
         try (OutputStream out = blob.createOutputStream(Files.getFilenameAndExtension(provider.getFilename()))) {
@@ -506,7 +506,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
 
         try {
             Directory root = blobStorage.getSpace(localRepoSpaceName)
-                                        .getRoot(tenants.getTenantUserManager().getSystemTenantId());
+                                        .getRoot(tenants.getSystemTenantId());
             visitLocalDirectory(processContext,
                                 null,
                                 root,
@@ -634,7 +634,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
             throw new IllegalStateException("No local repository is configured.");
         }
         Blob blob = blobStorage.getSpace(localRepoSpaceName)
-                               .findOrCreateByPath(tenants.getTenantUserManager().getSystemTenantId(), path);
+                               .findOrCreateByPath(tenants.getSystemTenantId(), path);
         return blob.createOutputStream(() -> {
             runInStandbyProcess(processContext -> performSyncInProcess(processContext, false, false, true));
         }, Files.getFilenameAndExtension(path));

--- a/src/main/java/sirius/biz/jupiter/JupiterSync.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSync.java
@@ -218,8 +218,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
         processContext.log(ProcessLog.info().withFormattedMessage("Executing data provider: %s", provider.getName()));
 
         Blob blob = blobStorage.getSpace(localRepoSpaceName)
-                               .findOrCreateByPath(tenants.getSystemTenantId(),
-                                                   provider.getFilename());
+                               .findOrCreateByPath(tenants.getSystemTenantId(), provider.getFilename());
 
         try (OutputStream out = blob.createOutputStream(Files.getFilenameAndExtension(provider.getFilename()))) {
             provider.execute(out);
@@ -505,8 +504,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
                                                              connection.getName()));
 
         try {
-            Directory root = blobStorage.getSpace(localRepoSpaceName)
-                                        .getRoot(tenants.getSystemTenantId());
+            Directory root = blobStorage.getSpace(localRepoSpaceName).getRoot(tenants.getSystemTenantId());
             visitLocalDirectory(processContext,
                                 null,
                                 root,
@@ -633,8 +631,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
         if (Strings.isEmpty(localRepoSpaceName) || blobStorage == null) {
             throw new IllegalStateException("No local repository is configured.");
         }
-        Blob blob = blobStorage.getSpace(localRepoSpaceName)
-                               .findOrCreateByPath(tenants.getSystemTenantId(), path);
+        Blob blob = blobStorage.getSpace(localRepoSpaceName).findOrCreateByPath(tenants.getSystemTenantId(), path);
         return blob.createOutputStream(() -> {
             runInStandbyProcess(processContext -> performSyncInProcess(processContext, false, false, true));
         }, Files.getFilenameAndExtension(path));

--- a/src/main/java/sirius/biz/jupiter/JupiterSyncSystemTenantSupplier.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSyncSystemTenantSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jupiter;
+
+import sirius.kernel.di.std.AutoRegister;
+
+/**
+ * Provides the system tenant for Jupiter when the {@linkplain sirius.biz.tenants.Tenants#FRAMEWORK_TENANTS tenants framework}
+ * is not available. In this case, products need to implement this interface and {@linkplain sirius.kernel.di.std.Register register}
+ * the implementation.
+ */
+@AutoRegister
+public interface JupiterSyncSystemTenantSupplier {
+
+    /**
+     * Returns the identifier of the system tenant.
+     *
+     * @return the identifier of the system tenant
+     */
+    String getSystemTenantId();
+
+    /**
+     * Returns the name of the system tenant.
+     *
+     * @return the name of the system tenant
+     */
+    String getSystemTenantName();
+}

--- a/src/main/java/sirius/biz/tenants/flags/CustomizationFlags.java
+++ b/src/main/java/sirius/biz/tenants/flags/CustomizationFlags.java
@@ -19,6 +19,7 @@ import sirius.kernel.settings.Settings;
 import sirius.web.http.WebContext;
 import sirius.web.security.UserContext;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -47,6 +48,7 @@ public class CustomizationFlags {
     private static final List<CustomizationFlag> knownFlags = new ArrayList<>();
 
     @Part
+    @Nullable
     private Tenants<?, ?, ?> tenants;
 
     protected static synchronized void addKnownFlag(CustomizationFlag flag) {


### PR DESCRIPTION
Enables products that do not use the _Tenants_ framework to use Jupiter by providing the system tenant differently.