### PR TITLE
KB: Allows to easily copy the deeplink of an article section

### DIFF
--- a/src/main/resources/default/taglib/k/section.html.pasta
+++ b/src/main/resources/default/taglib/k/section.html.pasta
@@ -2,7 +2,8 @@
 <i:arg type="String" name="anchor" default="" description="Defines an anchor to which a link can directly jump."/>
 <i:arg type="String" name="class" default="" description="Defines additional css-classes for the card element."/>
 <i:arg type="String" name="headingClass" default="" description="Defines additional css-classes for the card heading."/>
-<i:arg type="String" name="headingIcon" default="" description="Defines the icon left to the heading via a declarative css-class. Requires a heading." />
+<i:arg type="String" name="headingIcon" default=""
+       description="Defines the icon left to the heading via a declarative css-class. Requires a heading."/>
 
 <i:pragma name="description">
     Renders a block of an KB article. This is required to proper visual styling and layouting of
@@ -11,14 +12,31 @@
 
 <div class="card mb-4 @class">
     <div class="card-body">
-        <i:if test="isFilled(heading)">
-            <h5 id="@anchor" class="card-title @headingClass">
-                <i:if test="isFilled(headingIcon)">
-                    <i class="@headingIcon"></i>
-                </i:if>
-                @heading
-            </h5>
-        </i:if>
+        <div class="d-flex justify-content-between @if (!isFilled(heading)) { flex-row-reverse }">
+            <i:if test="isFilled(heading)">
+                <h5 id="@anchor" class="card-title @headingClass">
+                    <i:if test="isFilled(headingIcon)">
+                        <i class="@headingIcon"></i>
+                    </i:if>
+                    @heading
+                </h5>
+            </i:if>
+            <i:if test="isFilled(anchor)">
+                <i:local name="copyAnchorId" value="generateId('copy-anchor-%s')"/>
+                <a id="@copyAnchorId" class="text-sirius-gray cursor-pointer"><i class="fa fa-link"></i></a>
+                <script type="text/javascript">
+                    sirius.ready(function () {
+                        document.getElementById('@copyAnchorId').addEventListener('click', function () {
+                            const signedArticleId = document.getElementById('urlField').value;
+                            copyToClipboard(signedArticleId + '#@anchor')
+
+                            clearMessages();
+                            addSuccessMessage('@i18n("KnowledgeBase.urlClipboardSuccess")');
+                        });
+                    });
+                </script>
+            </i:if>
+        </div>
         <i:render name="body"/>
     </div>
 </div>


### PR DESCRIPTION
This renders a button in the header of a section when an anchor is given as parameter. When the button is clicked the signed URL (valid for 30 days) is expanded by the anchor, which opens the article directly at the given section.

This works for sections with and without a heading. When no anchor is given no button is rendered.

![image](https://github.com/scireum/sirius-biz/assets/2427877/edf13f65-effb-4283-a1ff-fab5513b8531)