### PR TITLE
Improves process deletion and persistence changes

### DIFF
--- a/src/main/java/sirius/biz/process/DeleteExpiredProcessesTask.java
+++ b/src/main/java/sirius/biz/process/DeleteExpiredProcessesTask.java
@@ -14,6 +14,8 @@ import sirius.kernel.Sirius;
 import sirius.kernel.async.Tasks;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.HandledException;
 import sirius.kernel.timer.EndOfDayTask;
 
 import java.time.LocalDate;
@@ -48,11 +50,22 @@ public class DeleteExpiredProcessesTask implements EndOfDayTask {
         elastic.select(Process.class)
                .eq(Process.STATE, ProcessState.TERMINATED)
                .where(Elastic.FILTERS.lte(Process.EXPIRES, LocalDate.now()))
-               .delete();
+               .iterateAll(this::deleteProcess);
 
         elastic.select(Process.class)
                .eq(Process.STATE, ProcessState.STANDBY)
                .iterateAll(this::deleteExpiredStandbyLogs);
+    }
+
+    private void deleteProcess(Process process) {
+        try {
+            elastic.delete(process);
+        } catch (HandledException exception) {
+            // The delete-by-query might fail if too many logs exist. The deletion in ElasticSearch might still
+            // be running, it could also have stopped. We ignore this error here, the process will remain in the
+            // database and the deletion will be retried in the next run.
+            Exceptions.ignore(exception);
+        }
     }
 
     private void deleteExpiredStandbyLogs(Process process) {

--- a/src/main/java/sirius/biz/process/Process.java
+++ b/src/main/java/sirius/biz/process/Process.java
@@ -17,6 +17,7 @@ import sirius.biz.tenants.Tenant;
 import sirius.db.es.annotations.ESOption;
 import sirius.db.es.annotations.IndexMode;
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.BeforeDelete;
 import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.ComplexDelete;
 import sirius.db.mixing.annotations.NullAllowed;
@@ -287,6 +288,13 @@ public class Process extends SearchableEntity {
                 persistencePeriod = PersistencePeriod.SIX_YEARS;
             }
         }
+    }
+
+    @BeforeDelete
+    @ComplexDelete
+    protected void truncateLogs() {
+        // Deletes all process logs using delete-by-query
+        elastic.select(ProcessLog.class).eq(ProcessLog.PROCESS, getId()).truncate();
     }
 
     /**

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -553,9 +553,17 @@ public class Processes {
      * @return <tt>true</tt> if the process was successfully modified, <tt>false</tt> otherwise
      */
     protected boolean updatePersistence(String processId, PersistencePeriod persistencePeriod) {
-        return modify(processId,
-                      process -> process.getPersistencePeriod() != persistencePeriod,
-                      process -> process.setPersistencePeriod(persistencePeriod));
+        return modify(processId, process -> process.getPersistencePeriod() != persistencePeriod, process -> {
+            PersistencePeriod currentPersistence = process.getPersistencePeriod();
+            process.setPersistencePeriod(persistencePeriod);
+
+            LocalDate expires = process.getExpires();
+            if (expires != null) {
+                expires = currentPersistence.minus(expires);
+                expires = persistencePeriod.plus(expires);
+                process.setExpires(expires);
+            }
+        });
     }
 
     /**

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -107,7 +107,7 @@ public class ProcessLog extends SearchableEntity {
      * Contains the process for which this log entry was created.
      */
     public static final Mapping PROCESS = Mapping.named("process");
-    private final ElasticRef<Process> process = ElasticRef.writeOnceOn(Process.class, BaseEntityRef.OnDelete.CASCADE);
+    private final ElasticRef<Process> process = ElasticRef.writeOnceOn(Process.class, BaseEntityRef.OnDelete.IGNORE);
 
     /**
      * Contains the type or severity of this log entry.


### PR DESCRIPTION
Drastically improves process deletion performance for processes with too many logs.
Recalculates the expiration date (needed for deletion) if the persistence is changed.

For the latter, the following script can be used to detect and optionally correct the date:

```js
let elastic = part(Elastic.class);
let tenants = part(Tenants.class);
let correct = false;

tenants.runAsAdminProcess("Check process expires", |process| {
    elastic.select(Process.class).iterateAll(|proc| {
        if (proc.getExpires() == null || proc.getCompleted() == null || proc.getPersistencePeriod() == null) {
            return;
        }
        let expectedExpires = proc.getPersistencePeriod().plus(proc.getCompleted().toLocalDate());
        if (expectedExpires != proc.getExpires()) {
            log(proc.getId() + " - expected: " + expectedExpires + ", has: " + proc.getExpires());
            if (correct) {
                proc.setExpires(expectedExpires);
                elastic.update(proc);
            }
        }
    });
})
```

Fixes: [SIRI-853](https://scireum.myjetbrains.com/youtrack/issue/SIRI-853)