### PR TITLE
t:blobHardRefImage: uses the high-res default image from URLBuilder.IMAGE_FALLBACK_URI

### DIFF
--- a/src/main/resources/default/taglib/t/blobImageHardRefField.html.pasta
+++ b/src/main/resources/default/taglib/t/blobImageHardRefField.html.pasta
@@ -9,7 +9,7 @@
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the dropzone."/>
 <i:arg name="btnClass" type="String" default=""
        description="Lists additional CSS classes to apply to the upload button."/>
-<i:arg name="defaultPreview" type="String" default="/assets/images/placeholder.png"/>
+<i:arg name="defaultPreview" type="String" default="/assets/images/blob_image_fallback.png"/>
 <i:arg name="previewVariant" type="String" default="raw"/>
 <i:arg name="acceptedFiles" type="String" default="image/*,application/pdf,svg"/>
 <i:arg name="uploadUrl" type="String" default="@apply('/dasd/upload-file/%s', objectRef.getSpace())"/>


### PR DESCRIPTION
## Before
<img width="750" alt="image" src="https://github.com/scireum/sirius-biz/assets/54799255/640d5b89-7acf-4626-83d3-d79c8d9e7a93">

## After
<img width="650" alt="image" src="https://github.com/scireum/sirius-biz/assets/54799255/57ad2d03-fc63-4dab-be66-0bcf81a0c858">

