### PR TITLE
Optimizes user UI

### DIFF
--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -192,7 +192,6 @@ public abstract class UserAccountController<I extends Serializable, T extends Ba
         U userAccount = findForTenant(getUserClass(), accountId);
 
         boolean requestHandled = prepareSave(webContext).withAfterCreateURI("/user-account/${id}")
-                                                        .withAfterSaveURI(LIST_ROUTE)
                                                         .withPreSaveHandler(isNew -> {
                                                             if (isUserLockingHimself(userAccount)) {
                                                                 throw Exceptions.createHandled()

--- a/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
@@ -23,8 +23,10 @@
                     </div>
                 </i:block>
                 <i:block name="title">
+                    <div class="overflow-hidden text-ellipsis text-nowrap">
                     <t:langFlag lang="@account.getUserAccountData().getLanguage().getValue()"/>
                     <span>@account.getUserAccountData()</span>
+                    </div>
                 </i:block>
                 <i:block name="actions">
                     <i:if test="enableCardActions">

--- a/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
@@ -12,7 +12,7 @@
                     headerLeftAlignmentClass="align-items-stretch text-break break-word"
                     link="@apply('%s/%s', cardBaseUrl , account.getIdAsString())">
                 <i:block name="header">
-                    <div class="pl-2 pr-1 align-self-center">
+                    <div class="pl-3 pr-1 align-self-center">
                         <div class="d-flex flex-column align-items-center justify-content-center"
                              style="width: 80px">
                             <img style="border-radius: 50%; object-fit: cover; object-position: center;"

--- a/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
@@ -24,8 +24,8 @@
                 </i:block>
                 <i:block name="title">
                     <div class="overflow-hidden text-ellipsis text-nowrap">
-                    <t:langFlag lang="@account.getUserAccountData().getLanguage().getValue()"/>
-                    <span>@account.getUserAccountData()</span>
+                        <t:langFlag lang="@account.getUserAccountData().getLanguage().getValue()"/>
+                        <span>@account.getUserAccountData()</span>
                     </div>
                 </i:block>
                 <i:block name="actions">


### PR DESCRIPTION
- saving user routes to user instead of overview
- user image centered
- long mail addresses are shortened and don't result in a line break anymore 
    -> made changes in web necessary (datacard.html.pasta), the layout of other datacards isn't affected by this as far as I 
         can see but if anyone has a better solution which doesn't involve web tell me:)
    -> see https://github.com/scireum/sirius-web/pull/1270

fixes: OX-10216

![Bildschirmfoto 2023-08-07 um 13 45 06](https://github.com/scireum/sirius-biz/assets/133775629/3450f684-0c88-4d11-a7c7-b4d329a5eb11)
