### PR TITLE
Fixes Iterating a Virtual File Directory

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileWalker.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileWalker.java
@@ -70,7 +70,7 @@ class VirtualFileWalker implements Spliterator<VirtualFile> {
         }
 
         children = stack.removeLast();
-        return true;
+        return prepareNext();
     }
 
     private boolean shouldProcessAsFile(VirtualFile next) {
@@ -82,7 +82,7 @@ class VirtualFileWalker implements Spliterator<VirtualFile> {
     }
 
     private boolean shouldEnterDirectory() {
-        return (settings.maxDepth < 0 || stack.size() < settings.maxDepth) && children.hasNext();
+        return settings.maxDepth < 0 || stack.size() < settings.maxDepth;
     }
 
     private boolean shouldProcessAsDirectory() {


### PR DESCRIPTION
1. Entering a directory should not be dependent on whether the directory has an adjacent file/directory. Thus, the 'children.hasNext()' check should be removed.

2. When leaving a directory, it can not be assumed that the parent directory has a next file/directory. Thus, 'prepareNext()' must be called recursively after setting the 'children' iterator to the next in the stack..

Fixes: SE-12943