### PR TITLE
Introduces the Blob.duplicate() method

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
@@ -16,7 +16,6 @@ import sirius.kernel.async.Promise;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Streams;
 import sirius.kernel.commons.Strings;
-import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.settings.Extension;
 import sirius.web.http.Response;
@@ -51,9 +50,6 @@ public class FSObjectStorageSpace extends ObjectStorageSpace {
      * Contains the base directory which will contain a subdirectory per storage space.
      */
     public static final String CONFIG_KEY_LAYER1_BASE_DIR = "baseDir";
-
-    @Part
-    private static StorageUtils utils;
 
     private final File baseDir;
 

--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
@@ -297,11 +297,4 @@ public class FSObjectStorageSpace extends ObjectStorageSpace {
             }
         });
     }
-
-    @Override
-    public void copyPhysicalObject(String sourceObjectKey, String targetObjectKey, String targetStorageSpace)
-            throws IOException {
-        File sourceFile = getFile(sourceObjectKey);
-        objectStorage.getSpace(targetStorageSpace).upload(targetObjectKey, sourceFile);
-    }
 }

--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
@@ -297,4 +297,11 @@ public class FSObjectStorageSpace extends ObjectStorageSpace {
             }
         });
     }
+
+    @Override
+    public void copyPhysicalObject(String sourceObjectKey, String targetObjectKey, String targetStorageSpace)
+            throws IOException {
+        File sourceFile = getFile(sourceObjectKey);
+        objectStorage.getSpace(targetStorageSpace).upload(targetObjectKey, sourceFile);
+    }
 }

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -69,6 +69,9 @@ public abstract class ObjectStorageSpace {
     @Part
     private static Tasks tasks;
 
+    @Part
+    protected static ObjectStorage objectStorage;
+
     private static final Counter UPLOADS = new Counter();
     private static final Counter DOWNLOADS = new Counter();
     private static final Counter STREAMS = new Counter();
@@ -245,6 +248,28 @@ public abstract class ObjectStorageSpace {
      */
     protected abstract void storePhysicalObject(String objectKey, File file, ByteBlockTransformer transformer)
             throws IOException;
+
+    /**
+     * Copies the given object to the given target object key in the current storage space.
+     *
+     * @param sourceObjectKey    the source object key to copy from
+     * @param targetObjectKey    the target object key to copy to
+     * @param targetStorageSpace the target storage space to copy to
+     * @throws IOException in case of an IO error
+     */
+    public abstract void copyPhysicalObject(String sourceObjectKey, String targetObjectKey, String targetStorageSpace)
+            throws IOException;
+
+    /**
+     * Copies the given object to the given target object key in the current storage space.
+     *
+     * @param sourceObjectKey the source object key to copy from
+     * @param targetObjectKey the target object key to copy to
+     * @throws IOException in case of an IO error
+     */
+    public void copyPhysicalObject(String sourceObjectKey, String targetObjectKey) throws IOException {
+        copyPhysicalObject(sourceObjectKey, targetObjectKey, getName());
+    }
 
     /**
      * Stores the given data for the given object key.

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -255,20 +255,23 @@ public abstract class ObjectStorageSpace {
      * @param sourceObjectKey    the source object key to copy from
      * @param targetObjectKey    the target object key to copy to
      * @param targetStorageSpace the target storage space to copy to
-     * @throws IOException in case of an IO error
      */
-    public abstract void copyPhysicalObject(String sourceObjectKey, String targetObjectKey, String targetStorageSpace)
-            throws IOException;
+    public void duplicatePhysicalObject(String sourceObjectKey, String targetObjectKey, String targetStorageSpace) {
+        download(sourceObjectKey).ifPresent(fileHandle -> {
+            try (fileHandle) {
+                objectStorage.getSpace(targetStorageSpace).upload(targetObjectKey, fileHandle.getFile());
+            }
+        });
+    }
 
     /**
      * Copies the given object to the given target object key in the current storage space.
      *
      * @param sourceObjectKey the source object key to copy from
      * @param targetObjectKey the target object key to copy to
-     * @throws IOException in case of an IO error
      */
-    public void copyPhysicalObject(String sourceObjectKey, String targetObjectKey) throws IOException {
-        copyPhysicalObject(sourceObjectKey, targetObjectKey, getName());
+    public void duplicatePhysicalObject(String sourceObjectKey, String targetObjectKey) {
+        duplicatePhysicalObject(sourceObjectKey, targetObjectKey, getName());
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
@@ -9,6 +9,7 @@
 package sirius.biz.storage.layer1;
 
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import sirius.biz.storage.layer1.replication.ReplicationManager;
 import sirius.biz.storage.layer1.transformer.ByteBlockTransformer;
 import sirius.biz.storage.layer1.transformer.TransformingInputStream;
 import sirius.biz.storage.s3.BucketName;
@@ -54,6 +55,9 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
 
     @Part
     private static ObjectStores objectStores;
+
+    @Part
+    private static ReplicationManager replicationManager;
 
     @Part
     private static Tasks tasks;
@@ -253,6 +257,9 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
                                  sourceObjectKey,
                                  s3ObjectStorageSpace.bucketName().getName(),
                                  targetObjectKey);
+                long size =
+                        store.getClient().getObjectMetadata(bucketName().getName(), sourceObjectKey).getContentLength();
+                replicationManager.notifyAboutUpdate(s3ObjectStorageSpace, targetObjectKey, size);
             } else {
                 // ... but the source and target buckets resides in different systems. We have to download and upload.
                 downloadAndUploadFile(sourceObjectKey, targetObjectKey, targetSpace);

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
@@ -272,7 +272,7 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
 
         FileHandle fileHandle = optionalFileHandle.get();
         try (fileHandle) {
-            targetSpace.storePhysicalObject(targetObjectKey, fileHandle.getFile());
+            targetSpace.upload(targetObjectKey, fileHandle.getFile());
         }
     }
 }

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1215,10 +1215,10 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * @throws Exception in case of an error while updating the metadata
      */
     @Nonnull
-    public abstract Optional<String> updateBlob(@Nonnull B blob,
-                                                @Nonnull String nextPhysicalId,
-                                                long size,
-                                                @Nullable String filename) throws Exception;
+    protected abstract Optional<String> updateBlob(@Nonnull B blob,
+                                                   @Nonnull String nextPhysicalId,
+                                                   long size,
+                                                   @Nullable String filename) throws Exception;
 
     /**
      * Updates the contents of the given blob with the given stream data and optional filename.

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1860,6 +1860,16 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     protected abstract V createVariant(B blob, String variantName);
 
     /**
+     * Creates the required database object for the given variant and physical object key.
+     *
+     * @param blob              the blob for which the variant is to be created
+     * @param variantName       the variant to generate
+     * @param physicalObjectKey the physical object to set
+     * @return the newly created database object
+     */
+    protected abstract V createVariant(B blob, String variantName, String physicalObjectKey, long size);
+
+    /**
      * Detects if the variant is still unique.
      * <p>
      * Note that this is kind of a negative approach - if the method returns <tt>true</tt> a collision was detected

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1215,10 +1215,10 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      * @throws Exception in case of an error while updating the metadata
      */
     @Nonnull
-    protected abstract Optional<String> updateBlob(@Nonnull B blob,
-                                                   @Nonnull String nextPhysicalId,
-                                                   long size,
-                                                   @Nullable String filename) throws Exception;
+    public abstract Optional<String> updateBlob(@Nonnull B blob,
+                                                @Nonnull String nextPhysicalId,
+                                                long size,
+                                                @Nullable String filename) throws Exception;
 
     /**
      * Updates the contents of the given blob with the given stream data and optional filename.

--- a/src/main/java/sirius/biz/storage/layer2/Blob.java
+++ b/src/main/java/sirius/biz/storage/layer2/Blob.java
@@ -300,4 +300,13 @@ public interface Blob {
      */
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     URLBuilder url();
+
+    /**
+     * Creates a new {@link BlobDuplicator} for this blob.
+     *
+     * @return a new duplicator for this blob
+     */
+    default BlobDuplicator duplicate() {
+        return BlobDuplicator.create(this);
+    }
 }

--- a/src/main/java/sirius/biz/storage/layer2/Blob.java
+++ b/src/main/java/sirius/biz/storage/layer2/Blob.java
@@ -307,6 +307,6 @@ public interface Blob {
      * @return a new duplicator for this blob
      */
     default BlobDuplicator duplicate() {
-        return BlobDuplicator.create(this);
+        return new BlobDuplicator(this);
     }
 }

--- a/src/main/java/sirius/biz/storage/layer2/BlobDuplicator.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDuplicator.java
@@ -12,7 +12,6 @@ import sirius.db.KeyGenerator;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -90,7 +89,7 @@ public class BlobDuplicator {
             String newKey = keyGenerator.generateId();
             blob.getStorageSpace()
                 .getPhysicalSpace()
-                .copyPhysicalObject(blob.getPhysicalObjectKey(), newKey, storageSpace);
+                .duplicatePhysicalObject(blob.getPhysicalObjectKey(), newKey, storageSpace);
             space.updateBlob(newBlob, newKey, blob.getSize(), blob.getFilename());
         } catch (Exception exception) {
             throw Exceptions.createHandled().error(exception).handle();
@@ -101,14 +100,10 @@ public class BlobDuplicator {
             .filter(blobVariant -> variants.contains(blobVariant.getVariantName()))
             .forEach(blobVariant -> {
                 String newKey = keyGenerator.generateId();
-                try {
-                    blob.getStorageSpace()
-                        .getPhysicalSpace()
-                        .copyPhysicalObject(blobVariant.getPhysicalObjectKey(), newKey, storageSpace);
-                    space.createVariant(newBlob, blobVariant.getVariantName(), newKey, blobVariant.getSize());
-                } catch (IOException exception) {
-                    throw Exceptions.createHandled().error(exception).handle();
-                }
+                blob.getStorageSpace()
+                    .getPhysicalSpace()
+                    .duplicatePhysicalObject(blobVariant.getPhysicalObjectKey(), newKey, storageSpace);
+                space.createVariant(newBlob, blobVariant.getVariantName(), newKey, blobVariant.getSize());
             });
 
         return newBlob;

--- a/src/main/java/sirius/biz/storage/layer2/BlobDuplicator.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDuplicator.java
@@ -37,11 +37,7 @@ public class BlobDuplicator {
      * @param blob the blob to duplicate
      * @return a new duplicator for the given blob
      */
-    public static BlobDuplicator create(Blob blob) {
-        return new BlobDuplicator(blob);
-    }
-
-    private BlobDuplicator(Blob blob) {
+    public BlobDuplicator(Blob blob) {
         this.blob = blob;
         this.storageSpace = blob.getSpaceName();
     }

--- a/src/main/java/sirius/biz/storage/layer2/BlobDuplicator.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDuplicator.java
@@ -1,0 +1,111 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.layer2;
+
+import sirius.db.KeyGenerator;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.health.Exceptions;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Defines parameters used to duplicate a {@link Blob} in a new temporary copy.
+ */
+public class BlobDuplicator {
+
+    @Part
+    private static BlobStorage blobStorage;
+
+    @Part
+    private static KeyGenerator keyGenerator;
+
+    private final Blob blob;
+    private String storageSpace;
+    private final Set<String> variants = new HashSet<>();
+
+    /**
+     * Creates a new duplicator for the given blob.
+     *
+     * @param blob the blob to duplicate
+     * @return a new duplicator for the given blob
+     */
+    public static BlobDuplicator create(Blob blob) {
+        return new BlobDuplicator(blob);
+    }
+
+    private BlobDuplicator(Blob blob) {
+        this.blob = blob;
+        this.storageSpace = blob.getSpaceName();
+    }
+
+    /**
+     * Adds a variant name to be duplicated among with the blob.
+     *
+     * @param variantName the variant name to duplicate
+     * @return the duplicator itself for fluent method calls
+     */
+    public BlobDuplicator withVariant(String variantName) {
+        this.variants.add(variantName);
+        return this;
+    }
+
+    /**
+     * Adds all variants of the blob to be duplicated.
+     *
+     * @return the duplicator itself for fluent method calls
+     */
+    public BlobDuplicator withAllVariants() {
+        blob.fetchVariants().forEach(blobVariant -> variants.add(blobVariant.getVariantName()));
+        return this;
+    }
+
+    /**
+     * Defines storage space to use for the duplicated blob.
+     * <p>
+     * By default, the new blob is created in the same space as the original one. Note that if the space is not
+     * in the same storage system as the original blob, the copy might not be performant.
+     *
+     * @param storageSpace the storage space to use for the duplicated blob
+     * @return the duplicator itself for fluent method calls
+     */
+    public BlobDuplicator withStorageSpace(String storageSpace) {
+        this.storageSpace = storageSpace;
+        return this;
+    }
+
+    /**
+     * Returns the temporary blob as a replica of the original one.
+     *
+     * @return the cloned blob
+     */
+    @SuppressWarnings("unchecked")
+    public Blob execute() {
+        Blob newBlob = blobStorage.getSpace(storageSpace).createTemporaryBlob(blob.getTenantId());
+        try {
+            String newKey = keyGenerator.generateId();
+            blob.getStorageSpace()
+                .getPhysicalSpace()
+                .copyPhysicalObject(blob.getPhysicalObjectKey(), newKey, storageSpace);
+            BasicBlobStorageSpace space = (BasicBlobStorageSpace) newBlob.getStorageSpace();
+            space.updateBlob(newBlob, newKey, blob.getSize(), blob.getFilename());
+        } catch (Exception exception) {
+            throw Exceptions.createHandled().error(exception).handle();
+        }
+
+        blob.fetchVariants()
+            .stream()
+            .filter(blobVariant -> variants.contains(blobVariant.getVariantName()))
+            .forEach(blobVariant -> {
+                //TODO variants
+            });
+
+        return newBlob;
+    }
+}

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -542,10 +542,10 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
     @Override
     @SuppressWarnings("java:S2259")
     @Explain("String filled check is performed on filename.")
-    public Optional<String> updateBlob(@Nonnull SQLBlob blob,
-                                       @Nonnull String nextPhysicalId,
-                                       long size,
-                                       @Nullable String filename) throws Exception {
+    protected Optional<String> updateBlob(@Nonnull SQLBlob blob,
+                                          @Nonnull String nextPhysicalId,
+                                          long size,
+                                          @Nullable String filename) throws Exception {
         int retries = UPDATE_BLOB_RETRIES;
         while (retries-- > 0) {
             UpdateStatement updateStatement = oma.updateStatement(SQLBlob.class)

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -886,6 +886,24 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
     }
 
     @Override
+    protected SQLVariant createVariant(SQLBlob blob, String variantName, String physicalObjectKey, long size) {
+        SQLVariant variant = new SQLVariant();
+        variant.getSourceBlob().setValue(blob);
+        variant.setVariantName(variantName);
+        variant.setQueuedForConversion(false);
+        variant.setNumAttempts(0);
+        variant.setConversionDuration(0);
+        variant.setTransferDuration(0);
+        variant.setPhysicalObjectKey(physicalObjectKey);
+        variant.setSize(size);
+        variant.setNode(CallContext.getNodeName());
+        variant.setLastConversionAttempt(LocalDateTime.now());
+        variant.setNumAttempts(1);
+        oma.update(variant);
+        return variant;
+    }
+
+    @Override
     protected boolean detectAndRemoveDuplicateVariant(SQLVariant variant, SQLBlob blob, String variantName) {
         if (oma.select(SQLVariant.class)
                .ne(SQLVariant.ID, variant.getId())

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -542,10 +542,10 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
     @Override
     @SuppressWarnings("java:S2259")
     @Explain("String filled check is performed on filename.")
-    protected Optional<String> updateBlob(@Nonnull SQLBlob blob,
-                                          @Nonnull String nextPhysicalId,
-                                          long size,
-                                          @Nullable String filename) throws Exception {
+    public Optional<String> updateBlob(@Nonnull SQLBlob blob,
+                                       @Nonnull String nextPhysicalId,
+                                       long size,
+                                       @Nullable String filename) throws Exception {
         int retries = UPDATE_BLOB_RETRIES;
         while (retries-- > 0) {
             UpdateStatement updateStatement = oma.updateStatement(SQLBlob.class)

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -453,10 +453,10 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
     @Override
     @SuppressWarnings("java:S2259")
     @Explain("String filled check is performed on filename.")
-    public Optional<String> updateBlob(@Nonnull MongoBlob blob,
-                                       @Nonnull String nextPhysicalId,
-                                       long size,
-                                       @Nullable String filename) throws Exception {
+    protected Optional<String> updateBlob(@Nonnull MongoBlob blob,
+                                          @Nonnull String nextPhysicalId,
+                                          long size,
+                                          @Nullable String filename) throws Exception {
         int retries = UPDATE_BLOB_RETRIES;
         while (retries-- > 0) {
             Updater updater = mongo.update()

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -796,6 +796,24 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
     }
 
     @Override
+    protected MongoVariant createVariant(MongoBlob blob, String variantName, String physicalObjectKey, long size) {
+        MongoVariant variant = new MongoVariant();
+        variant.getBlob().setValue(blob);
+        variant.setVariantName(variantName);
+        variant.setQueuedForConversion(false);
+        variant.setNumAttempts(0);
+        variant.setConversionDuration(0);
+        variant.setTransferDuration(0);
+        variant.setPhysicalObjectKey(physicalObjectKey);
+        variant.setSize(size);
+        variant.setNode(CallContext.getNodeName());
+        variant.setLastConversionAttempt(LocalDateTime.now());
+        variant.setNumAttempts(1);
+        mango.update(variant);
+        return variant;
+    }
+
+    @Override
     protected boolean detectAndRemoveDuplicateVariant(MongoVariant variant, MongoBlob blob, String variantName) {
         if (mango.select(MongoVariant.class)
                  .ne(MongoVariant.ID, variant.getId())

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -453,10 +453,10 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
     @Override
     @SuppressWarnings("java:S2259")
     @Explain("String filled check is performed on filename.")
-    protected Optional<String> updateBlob(@Nonnull MongoBlob blob,
-                                          @Nonnull String nextPhysicalId,
-                                          long size,
-                                          @Nullable String filename) throws Exception {
+    public Optional<String> updateBlob(@Nonnull MongoBlob blob,
+                                       @Nonnull String nextPhysicalId,
+                                       long size,
+                                       @Nullable String filename) throws Exception {
         int retries = UPDATE_BLOB_RETRIES;
         while (retries-- > 0) {
             Updater updater = mongo.update()

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -211,6 +211,15 @@ public class ObjectStore {
     }
 
     /**
+     * Returns the name of the store.
+     *
+     * @return the store's name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
      * Transforms the given bucket name into the effective name.
      *
      * @param bucket the bucket name to use

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -62,6 +62,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
@@ -208,15 +209,6 @@ public class ObjectStore {
      */
     public AmazonS3 getClient() {
         return client;
-    }
-
-    /**
-     * Returns the name of the store.
-     *
-     * @return the store's name
-     */
-    public String getName() {
-        return name;
     }
 
     /**
@@ -862,5 +854,18 @@ public class ObjectStore {
                                                            .withPartSize(buffer.readableBytes())
                                                            .withInputStream(new ByteBufInputStream(buffer));
         return getClient().uploadPart(request).getPartETag();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof ObjectStore otherObjectStore) {
+            return name.equals(otherObjectStore.name);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
     }
 }


### PR DESCRIPTION
Used to clone a blob. This method delivers a BlobDuplicator class which collects parameters for the copy, such as variants to clone with or a new target storage space.

The new blob created is temporary and must be handled after creation (for example, attaching it to an actual BlobHardRef), otherwise it will be deleted from the system after a while.

Under the hood, it can handle copies from/to different stores.

In case of S3, a server-side copy can be performed if possible, falling back to regular download/upload when a straight copy cannot be performed.

Fixes: [SIRI-851](https://scireum.myjetbrains.com/youtrack/issue/SIRI-851)