### PR TITLE
Changes the fallback language for the knowledgebase to german since almost every knowledgebase article is written in german

### DIFF
--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -169,7 +169,7 @@ sirius.nodeAddress = ""
 sirius.clusterToken = ""
 
 # By default the fallback language for the knowledge base is english.
-knowledgebase.fallbackLang = "en"
+knowledgebase.fallbackLang = "de"
 
 # Contains settings for the built-in firewall and rate-limiting facility
 isenguard {


### PR DESCRIPTION
Fixes: SIRI-865