### PR TITLE
SE-12943: Allows Configuring a Custom Number of retries for 503 Responses

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -16,6 +16,7 @@ import sirius.biz.storage.layer1.FileHandle;
 import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.util.Attempt;
 import sirius.biz.storage.util.StorageUtils;
+import sirius.kernel.Sirius;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Streams;
@@ -82,7 +83,6 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     private static final String HANDLER_CONSUME_FILE_HANDLER = "consumeFileHandler";
     private static final String MESSAGE_KEY_LOAD_FROM_URL_FAILED = "$VirtualFile.loadFromUrlFailed";
     private static final String MESSAGE_KEY_LOAD_FROM_URL_DISABLED = "$VirtualFile.loadFromUrlDisabled";
-    private static final int NUMBER_OF_RETRIES_FOR_SERVICE_UNAVAILABLE = 3;
 
     protected String name;
     protected String description;
@@ -1390,8 +1390,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
                 return false;
             }
 
-            HttpResponse<InputStream> response =
-                    requestFileFromUri(uri, mode, NUMBER_OF_RETRIES_FOR_SERVICE_UNAVAILABLE);
+            HttpResponse<InputStream> response = requestFileFromUri(uri, mode, getMaxRetriesForServiceUnavailable());
 
             if (response.statusCode() == HttpResponseStatus.NOT_MODIFIED.code()) {
                 tryTouch();
@@ -1431,14 +1430,14 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
 
             if (retries > 0) {
                 // Wait 200ms, 700ms, 1200ms...
-                Wait.millis(200 + (NUMBER_OF_RETRIES_FOR_SERVICE_UNAVAILABLE - retries) * 500);
+                Wait.millis(200 + (getMaxRetriesForServiceUnavailable() - retries) * 500);
                 return requestFileFromUri(uri, mode, retries - 1);
             }
 
             throw new IOException(Strings.apply("The server responded with status %s (%s) after %s retries!",
                                                 HttpResponseStatus.valueOf(response.statusCode()).toString(),
                                                 response.statusCode(),
-                                                NUMBER_OF_RETRIES_FOR_SERVICE_UNAVAILABLE));
+                                                getMaxRetriesForServiceUnavailable()));
         }
 
         if (response.statusCode() >= 400) {
@@ -1457,6 +1456,10 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
         // (unless the mode is set to ALWAYS_FETCH...)
         return mode == FetchFromUrlMode.NON_EXISTENT || (mode == FetchFromUrlMode.NON_EXISTENT_OR_MODIFIED
                                                          && lastModifiedDate().isAfter(LocalDate.now().atStartOfDay()));
+    }
+
+    private int getMaxRetriesForServiceUnavailable() {
+        return Sirius.getSettings().get("storage.layer3.retriesForServiceUnavailable").asInt(0);
     }
 
     /**

--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -1367,6 +1367,10 @@ storage {
         # to determine if the file-extension of a file-url contains the effective filename or if the path
         # is just a script and we need to inspect the ContentDisposition (etc.) to obtain the actual file name
         serverSidedScriptingExtensions = [ "php", "php3", "php4", "php5", "cgi", "asp", "aspx", "jsp", "jspx", "cfm", "cfml", "xml" ]
+
+        # Defines the number of retries for service unavailable responses (HTTP 503).
+        # The first retry will wait 200ms with each consequent retry waiting 500ms longer than the previous one.
+        retriesForServiceUnavailable = 3
     }
 
 }


### PR DESCRIPTION
Some systems may deal with fetching files from external servers that may require a while to respond with a valid file (e.g. when an image variant must be generated first).

Fixes: SE-12943