### PR TITLE
StoredIncidents: Limits errors messages in incident list to 5 lines

### DIFF
--- a/src/main/java/sirius/biz/protocol/IncidentController.java
+++ b/src/main/java/sirius/biz/protocol/IncidentController.java
@@ -27,44 +27,44 @@ public class IncidentController extends BizController {
     /**
      * Lists all recorded errors.
      *
-     * @param ctx the current request
+     * @param webContext the current request
      */
     @Permission(Protocols.PERMISSION_SYSTEM_PROTOCOLS)
     @DefaultRoute
     @Routed("/system/errors")
-    public void errors(WebContext ctx) {
-        ElasticPageHelper<StoredIncident> ph = ElasticPageHelper.withQuery(elastic.select(StoredIncident.class)
-                                                                                  .orderDesc(StoredIncident.LAST_OCCURRENCE));
-        ph.withContext(ctx);
-        ph.addTermAggregation(StoredIncident.CATEGORY, 100);
-        ph.addTermAggregation(StoredIncident.NODE);
-        ph.addTimeAggregation(StoredIncident.LAST_OCCURRENCE,
-                              false,
-                              DateRange.LAST_FIVE_MINUTES,
-                              DateRange.LAST_FIFTEEN_MINUTES,
-                              DateRange.LAST_TWO_HOURS,
-                              DateRange.TODAY,
-                              DateRange.YESTERDAY,
-                              DateRange.THIS_WEEK,
-                              DateRange.LAST_WEEK);
-        ph.withSearchFields(QueryField.contains(StoredIncident.SEARCH_FIELD));
+    public void errors(WebContext webContext) {
+        ElasticPageHelper<StoredIncident> pageHelper = ElasticPageHelper.withQuery(elastic.select(StoredIncident.class)
+                                                                                          .orderDesc(StoredIncident.LAST_OCCURRENCE));
+        pageHelper.withContext(webContext);
+        pageHelper.addTermAggregation(StoredIncident.CATEGORY, 100);
+        pageHelper.addTermAggregation(StoredIncident.NODE);
+        pageHelper.addTimeAggregation(StoredIncident.LAST_OCCURRENCE,
+                                      false,
+                                      DateRange.LAST_FIVE_MINUTES,
+                                      DateRange.LAST_FIFTEEN_MINUTES,
+                                      DateRange.LAST_TWO_HOURS,
+                                      DateRange.TODAY,
+                                      DateRange.YESTERDAY,
+                                      DateRange.THIS_WEEK,
+                                      DateRange.LAST_WEEK);
+        pageHelper.withSearchFields(QueryField.contains(StoredIncident.SEARCH_FIELD));
 
-        ctx.respondWith()
-           .template("/templates/biz/protocol/errors.html.pasta",
-                     ph.asPage(),
-                     (int) elastic.select(StoredIncident.class).count());
+        webContext.respondWith()
+                  .template("/templates/biz/protocol/errors.html.pasta",
+                            pageHelper.asPage(),
+                            (int) elastic.select(StoredIncident.class).count());
     }
 
     /**
      * Shows the details of the given error
      *
-     * @param id  the ID of the {@link StoredIncident} to show
-     * @param ctx the current request
+     * @param incidentId the ID of the {@link StoredIncident} to show
+     * @param webContext the current request
      */
     @Permission(Protocols.PERMISSION_SYSTEM_PROTOCOLS)
     @Routed("/system/error/:1")
-    public void error(WebContext ctx, String id) {
-        StoredIncident incident = find(StoredIncident.class, id);
-        ctx.respondWith().template("/templates/biz/protocol/error.html.pasta", incident);
+    public void error(WebContext webContext, String incidentId) {
+        StoredIncident incident = find(StoredIncident.class, incidentId);
+        webContext.respondWith().template("/templates/biz/protocol/error.html.pasta", incident);
     }
 }

--- a/src/main/resources/default/templates/biz/protocol/errors.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/errors.html.pasta
@@ -69,7 +69,7 @@
                                     <div class="row">
                                         <div class="col-md-12 error-code">
                                             <pre class="mb-0 pt-2"
-                                                 style="white-space: break-spaces; overflow-wrap: anywhere;">@i.getMessage()</pre>
+                                                 style="white-space: break-spaces; overflow-wrap: anywhere;display: -webkit-box;-webkit-line-clamp: 5;line-clamp: 5;-webkit-box-orient: vertical;overflow: hidden;">@i.getMessage()</pre>
                                         </div>
                                     </div>
                                 </td>

--- a/src/main/resources/default/templates/biz/protocol/errors.html.pasta
+++ b/src/main/resources/default/templates/biz/protocol/errors.html.pasta
@@ -47,29 +47,29 @@
                         </tr>
                         </thead>
                         <tbody>
-                        <i:for type="sirius.biz.protocol.StoredIncident" var="i" items="errors.getItems()">
+                        <i:for type="sirius.biz.protocol.StoredIncident" var="incident" items="errors.getItems()">
                             <tr>
                                 <td>
                                     <div class="row">
                                         <div class="col-md-4 text-small">
                                             <div>
-                                                <a href="/system/error/@i.getId()">@toUserString(i.getLastOccurrence())</a>
+                                                <a href="/system/error/@incident.getId()">@toUserString(incident.getLastOccurrence())</a>
                                             </div>
-                                            <div class="text-muted">@toUserString(i.getFirstOccurrence())</div>
+                                            <div class="text-muted">@toUserString(incident.getFirstOccurrence())</div>
                                         </div>
                                         <div class="col-md-4 text-small text-muted">
-                                            <div>@i.getNumberOfOccurrences()</div>
-                                            <div>@i.getCategory()</div>
+                                            <div>@incident.getNumberOfOccurrences()</div>
+                                            <div>@incident.getCategory()</div>
                                         </div>
                                         <div class="col-md-4 text-small text-muted">
-                                            <div>@i.getUser()</div>
-                                            <div>@i.getNode()</div>
+                                            <div>@incident.getUser()</div>
+                                            <div>@incident.getNode()</div>
                                         </div>
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12 error-code">
                                             <pre class="mb-0 pt-2"
-                                                 style="white-space: break-spaces; overflow-wrap: anywhere;display: -webkit-box;-webkit-line-clamp: 5;line-clamp: 5;-webkit-box-orient: vertical;overflow: hidden;">@i.getMessage()</pre>
+                                                 style="white-space: break-spaces; overflow-wrap: anywhere; display: -webkit-box; -webkit-line-clamp: 5; line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden;">@incident.getMessage()</pre>
                                         </div>
                                     </div>
                                 </td>


### PR DESCRIPTION
This will work in all modern browsers, which should be enough as this is an internal view. Also the fallback behavior for non-supported browsers is just the previous behavior without the improvement.

The full message can always be viewed in the details page of the incident.

**Before:**

<img width="824" alt="image" src="https://github.com/scireum/sirius-biz/assets/2427877/4cd22211-2511-45f6-875f-b5bd03d7dc44">

**After:**

<img width="820" alt="image" src="https://github.com/scireum/sirius-biz/assets/2427877/67455737-582d-4962-be16-b0de67d8cb36">
