### PR TITLE
Fixes an issue where paperclip files have not been deleted from the S3 storage, although they were older than the retention date

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -992,7 +992,6 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                .eq(SQLBlob.DELETED, false)
                .where(OMA.FILTERS.lt(SQLBlob.LAST_MODIFIED, LocalDateTime.now().minusDays(retentionDays)))
                .where(OMA.FILTERS.ltOrEmpty(SQLBlob.LAST_TOUCHED, LocalDateTime.now().minusDays(retentionDays)))
-               .limit(256)
                .iterateAll(this::markBlobAsDeleted);
         } catch (Exception exception) {
             Exceptions.handle()
@@ -1010,7 +1009,6 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                .eq(SQLBlob.DELETED, false)
                .eq(SQLBlob.TEMPORARY, true)
                .where(OMA.FILTERS.lt(SQLBlob.LAST_MODIFIED, LocalDateTime.now().minusHours(4)))
-               .limit(256)
                .iterateAll(this::markBlobAsDeleted);
         } catch (Exception exception) {
             Exceptions.handle()

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -885,7 +885,6 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                  .where(QueryBuilder.FILTERS.lt(MongoBlob.LAST_MODIFIED, LocalDateTime.now().minusDays(retentionDays)))
                  .where(QueryBuilder.FILTERS.ltOrEmpty(MongoBlob.LAST_TOUCHED,
                                                        LocalDateTime.now().minusDays(retentionDays)))
-                 .limit(256)
                  .iterateAll(this::markBlobAsDeleted);
         } catch (Exception e) {
             Exceptions.handle()
@@ -903,7 +902,6 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                  .eq(MongoBlob.DELETED, false)
                  .eq(MongoBlob.TEMPORARY, true)
                  .where(QueryBuilder.FILTERS.lt(MongoBlob.LAST_MODIFIED, LocalDateTime.now().minusHours(4)))
-                 .limit(256)
                  .iterateAll(this::markBlobAsDeleted);
         } catch (Exception e) {
             Exceptions.handle()


### PR DESCRIPTION
This was caused by a limit inside the 'mark as deleted' loop. The limit was set to 256 entities. Also, the loop was only executed once per day. This was problematic since we create over 1000 paperclips a day which resulted in a big yam, and it looked like we are not deleting files past their retention date.

Removing the limit should be safe since we only switch a flag/update each entity. The actual deletion is performed in another task which has a limit. The limit here is not a problem since the actual deletion task is executed "constantly" in a loop with other tasks.

Fixes: [SIRI-785](https://scireum.myjetbrains.com/youtrack/issue/SIRI-785)