### PR TITLE
Storage: Only warns about a failing update task when deletion is queued

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
@@ -157,8 +157,17 @@ public class MongoReplicationTaskStorage
                                        .set(MongoReplicationTask.EARLIEST_EXECUTION,
                                             LocalDateTime.now().plus(retryReplicationDelay))
                                        .inc(MongoReplicationTask.FAILURE_COUNTER, 1);
-                if (task.getFailureCounter() + 1 > maxReplicationAttempts) {
+                if (!task.isPerformDelete() && fetchIsEquivalentDeletionTaskQueued(task)) {
                     updater.set(MongoReplicationTask.FAILED, true);
+
+                    StorageUtils.LOG.WARN(
+                            "Layer 1/replication: A storage replication task (%s) was marked as failed as a deletion task for the same object is already queued: Primary space: %s, object: %s",
+                            task.getIdAsString(),
+                            task.getPrimarySpace(),
+                            task.getObjectKey());
+                } else if (task.getFailureCounter() + 1 > maxReplicationAttempts) {
+                    updater.set(MongoReplicationTask.FAILED, true);
+
                     Exceptions.handle()
                               .to(StorageUtils.LOG)
                               .error(ex)
@@ -175,5 +184,13 @@ public class MongoReplicationTaskStorage
                 Exceptions.handle(StorageUtils.LOG, e);
             }
         }
+    }
+
+    private boolean fetchIsEquivalentDeletionTaskQueued(MongoReplicationTask task) {
+        return mango.select(MongoReplicationTask.class)
+                    .eq(MongoReplicationTask.PRIMARY_SPACE, task.getPrimarySpace())
+                    .eq(MongoReplicationTask.OBJECT_KEY, task.getObjectKey())
+                    .eq(MongoReplicationTask.PERFORM_DELETE, true)
+                    .exists();
     }
 }


### PR DESCRIPTION
Normally this class has a mechanism that deletes previous tasks when a new task is created. Regardless this failed for a few files and an update task existed even though a deletion also existed. This means the update task cant succeed as the file is already removed from the main storage. To reduce the amount of scary error messages in such cases we check whether a equivalent deletion task exists when an update task fails. If that is the case we only output a warning (so its still traceable if noticed). Also we mark the task as failed to prevent the loop from re-trying the update.

Fixes: [SIRI-878](https://scireum.myjetbrains.com/youtrack/issue/SIRI-878)