### PR TITLE
SE-13063: Fixes not being able to save configurations more than once.

### DIFF
--- a/src/main/resources/default/templates/biz/tenants/tenant-config.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenant-config.html.pasta
@@ -3,7 +3,7 @@
 
 <i:invoke template="/templates/biz/tenants/tenant.html.pasta" tenant="tenant" controller="controller" page="config">
     <t:codeEditor id="editor" mode="json">@tenant.getTenantData().getConfigString()</t:codeEditor>
-    <t:formBar backButton="false"/>
+    <t:formBar backButton="false" singleClick="false"/>
 
     <script type="text/javascript">
         sirius.ready(function () {

--- a/src/main/resources/default/templates/biz/tenants/user-account-config.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-account-config.html.pasta
@@ -2,7 +2,7 @@
 
 <i:invoke template="/templates/biz/tenants/user-account.html.pasta" account="account" page="config">
     <t:codeEditor id="editor" mode="json">@account.getUserAccountData().getPermissions().getConfigString()</t:codeEditor>
-    <t:formBar backButton="false"/>
+    <t:formBar backButton="false" singleClick="false"/>
 
     <script type="text/javascript">
         sirius.ready(function () {


### PR DESCRIPTION
This error only manifests itself in Chrome browser (possibly other chromium browsers), as the javascript is not executed due to `event.stopPropagation();`. Firefox for instance was never affected. This issue was introduced by https://github.com/scireum/sirius-web/pull/1286

Fixes: [SE-13063](https://scireum.myjetbrains.com/youtrack/issue/SE-13063)