### PR TITLE
Tycho: Escapes single ticks in the dropzone upload URLs

### DIFF
--- a/src/main/resources/default/taglib/t/blobImageHardRefField.html.pasta
+++ b/src/main/resources/default/taglib/t/blobImageHardRefField.html.pasta
@@ -71,7 +71,7 @@
     });
 
     Dropzone.options[sirius.camelize('@id')].url = function (files) {
-        const uploadUrl = '@raw {@uploadUrl}';
+        const uploadUrl = '@raw { @escapeJS(uploadUrl) }';
         let parameterIndicator = '?';
         if (uploadUrl.indexOf('?') >= 0) {
             parameterIndicator = '&';


### PR DESCRIPTION
This lead to problems when customers created folders with single ticks (') in their names. Which is quite common in some languages.

Fixes: [SIRI-807](https://scireum.myjetbrains.com/youtrack/issue/SIRI-807)