### PR TITLE
Tenants: Uses identity converter for tenant and user images

### DIFF
--- a/src/main/resources/component-biz.conf
+++ b/src/main/resources/component-biz.conf
@@ -991,39 +991,22 @@ storage {
                 }
 
                 tenant-small {
-                    converter = "plain-png"
-                    width = 80
-                    height = 80
+                    converter = "identity"
                 }
-
                 tenant-medium {
-                    converter = "plain-png"
-                    width = 180
-                    height = 180
+                    converter = "identity"
                 }
-
                 tenant-large {
-                    converter = "plain-png"
-                    width = 350
-                    height = 350
+                    converter = "identity"
                 }
-
                 user-small {
-                    converter = "plain-jpeg"
-                    width = 80
-                    height = 80
+                    converter = "identity"
                 }
-
                 user-medium {
-                    converter = "plain-jpeg"
-                    width = 180
-                    height = 180
+                    converter = "identity"
                 }
-
                 user-large {
-                    converter = "plain-jpeg"
-                    width = 350
-                    height = 350
+                    converter = "identity"
                 }
             }
 

--- a/src/main/resources/default/taglib/t/blobImageHardRefField.html.pasta
+++ b/src/main/resources/default/taglib/t/blobImageHardRefField.html.pasta
@@ -71,7 +71,7 @@
     });
 
     Dropzone.options[sirius.camelize('@id')].url = function (files) {
-        const uploadUrl = '@raw { @escapeJS(uploadUrl) }';
+        const uploadUrl = '@raw {@escapeJS(uploadUrl)}';
         let parameterIndicator = '?';
         if (uploadUrl.indexOf('?') >= 0) {
             parameterIndicator = '&';


### PR DESCRIPTION
This is actually the only converter that is registered by default. All other (more complex) converters have to be implemented by users of sirius.

Fixes: [SIRI-887](https://scireum.myjetbrains.com/youtrack/issue/SIRI-887)