### PR TITLE
SIRI-896 Correct scrolling on anchor links for needed space of fixed header

### DIFF
--- a/src/main/resources/default/assets/styles/kb.scss
+++ b/src/main/resources/default/assets/styles/kb.scss
@@ -10,3 +10,8 @@
 .kb-code {
 
 }
+
+// Correct scrolling on anchor links for needed space of fixed header
+.anchor-scroll-margin {
+  scroll-margin-top: 100px;
+}

--- a/src/main/resources/default/taglib/k/section.html.pasta
+++ b/src/main/resources/default/taglib/k/section.html.pasta
@@ -14,7 +14,7 @@
     <div class="card-body">
         <div class="d-flex justify-content-between @if (!isFilled(heading)) { flex-row-reverse }">
             <i:if test="isFilled(heading)">
-                <h5 id="@anchor" class="card-title @headingClass">
+                <h5 id="@anchor" class="card-title anchor-scroll-margin @headingClass">
                     <i:if test="isFilled(headingIcon)">
                         <i class="@headingIcon"></i>
                     </i:if>


### PR DESCRIPTION
- fixes: SIRI-896

### Description
sections with anchors in kba now will jump to the correct height (including space for the fixed header)
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-](https://scireum.myjetbrains.com/youtrack/issue/SIRI-)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
