### PR TITLE
Translates field when generating job documentation pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>dev-38.5.0</sirius.kernel>
         <sirius.web>dev-72.2.0</sirius.web>
-        <sirius.db>dev-55.1.0</sirius.db>
+        <sirius.db>dev-56.1.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/importer/format/BaseFieldDefinitionTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/BaseFieldDefinitionTransformer.java
@@ -36,6 +36,7 @@ public abstract class BaseFieldDefinitionTransformer<S extends Property>
             FieldDefinition field = new FieldDefinition(property.getName(), determineType(property));
             field.addAlias(property.getName());
             field.withLabel(property::getLabel);
+            field.addTranslatedAliases("$" + property.getLabelKey());
 
             processAutoImportSettings(property, field);
             customizeField(property, field);


### PR DESCRIPTION
### Description

We already do that when adding aliases defined by `importer.aliases.<entity>.<field>`, but not for the fields itself.

**Before**
<img width="1253" alt="Bildschirmfoto 2023-10-25 um 16 22 33" src="https://github.com/scireum/sirius-biz/assets/54799255/6e093914-45c4-4aa0-923e-c2085ad2e120">

**After**
<img width="1253" alt="Bildschirmfoto 2023-10-25 um 16 21 51" src="https://github.com/scireum/sirius-biz/assets/54799255/02ebb836-2652-4df8-8a9f-a780b204b9fa">

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-866](https://scireum.myjetbrains.com/youtrack/issue/SIRI-866)
- This PR is related to PR: https://github.com/scireum/sirius-db/pull/599

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
