### PR TITLE
correct autofocus for pages with useful autofocus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>dev-38.5.0</sirius.kernel>
-        <sirius.web>dev-72.2.0</sirius.web>
+        <sirius.web>dev-73.2.1</sirius.web>
         <sirius.db>dev-56.1.0</sirius.db>
     </properties>
 

--- a/src/main/resources/default/extensions/tycho-page-menu/menu.html.pasta
+++ b/src/main/resources/default/extensions/tycho-page-menu/menu.html.pasta
@@ -14,7 +14,7 @@
                     <form class="form-inline menu-search-form" method="POST" action="/open-search">
                         <span><i class="fa fa-search"></i></span>
                         <input name="query"
-                               class="form-control autofocus"
+                               class="form-control autofocus-js"
                                type="search"
                                placeholder="@i18n('OpenSearchController.label')"
                                aria-label="Search">

--- a/src/main/resources/default/taglib/t/actions.html.pasta
+++ b/src/main/resources/default/taglib/t/actions.html.pasta
@@ -12,7 +12,7 @@
                 <div class="input-group">
                     <input type="text" id="actionsQueryField"
                            class="form-control primary-autofocus-js"
-                           placeholder="@i18n('NLS.searchkey')" autofocus/>
+                           placeholder="@i18n('NLS.searchkey')"/>
                     <div class="input-group-append">
                         <a class="btn btn-outline-secondary">
                             <i class="fa fa-search"></i>

--- a/src/main/resources/default/templates/biz/model/query-header.html.pasta
+++ b/src/main/resources/default/templates/biz/model/query-header.html.pasta
@@ -14,9 +14,8 @@
                            name="query"
                            id="query"
                            placeholder="Enter query here"
-                           class="form-control"
-                           value="@query"
-                           autofocus/>
+                           class="form-control primary-autofocus-js"
+                           value="@query"/>
                     <div class="input-group-append"
                          onclick="sirius.requestSubmitForm(document.querySelector('form.edit-form'))">
                     <span class="btn btn-outline-secondary">

--- a/src/main/resources/default/templates/biz/model/redis.html.pasta
+++ b/src/main/resources/default/templates/biz/model/redis.html.pasta
@@ -16,9 +16,11 @@
             <div class="row">
                 <div class="col-10">
                     <div class="input-group">
-                        <input type="text" id="query" name="query"
-                               class="form-control primary-autofocus"
-                               placeholder="@i18n('NLS.searchkey')" autofocus/>
+                        <input type="text"
+                               id="query"
+                               name="query"
+                               class="form-control primary-autofocus-js"
+                               placeholder="@i18n('NLS.searchkey')"/>
                         <div class="input-group-append">
                             <a class="btn btn-outline-secondary" onclick="execute()">
                                 <i class="fa fa-search"></i>

--- a/src/main/resources/default/templates/biz/model/sql.html.pasta
+++ b/src/main/resources/default/templates/biz/model/sql.html.pasta
@@ -21,7 +21,13 @@
         <div class="card-body">
             <div class="row">
                 <div class="col-12 col-md-10 d-flex align-items-start">
-                    <t:textarea name="query" id="query" value="" class="flex-grow-1 primary-autofocus" rows="1"/>
+                    <t:textarea name="query"
+                                id="query"
+                                value=""
+                                class="flex-grow-1"
+                                fieldClass="primary-autofocus-js"
+                                rows="1"
+                                placeholder="@i18n('NLS.searchkey')"/>
                     <a class="btn btn-outline-secondary ml-1" onclick="execute()">
                         <i class="fa fa-search"></i>
                     </a>

--- a/src/main/resources/default/templates/biz/password/password-tycho.html.pasta
+++ b/src/main/resources/default/templates/biz/password/password-tycho.html.pasta
@@ -5,7 +5,8 @@
        name="requireOldPassword"
        default="true"/>
 
-<i:invoke template="/templates/biz/password/password-tycho-script.html.pasta" minLength="minLength" saneLength="saneLength" />
+<i:invoke template="/templates/biz/password/password-tycho-script.html.pasta" minLength="minLength"
+          saneLength="saneLength"/>
 
 <div class="row">
     <div class="col-md-5">
@@ -20,9 +21,8 @@
                             <input id="oldPassword"
                                    name="oldPassword"
                                    type="password"
-                                   autofocus="autofocus"
                                    autocomplete="off"
-                                   class="form-control input-block-level"/>
+                                   class="form-control input-block-level primary-autofocus-js"/>
                         </div>
                     </div>
 
@@ -43,7 +43,7 @@
                                name="newPassword"
                                type="password"
                                autocomplete="off"
-                               class="form-control input-block-level"/>
+                               class="form-control input-block-level primary-autofocus-js"/>
                     </div>
                 </div>
 
@@ -55,7 +55,6 @@
                         <input id="confirmation"
                                name="confirmation"
                                type="password"
-                               autofocus="autofocus"
                                autocomplete="off"
                                class="form-control input-block-level"/>
                     </div>

--- a/src/main/resources/default/templates/biz/tycho/analytics/data-explorer.html.pasta
+++ b/src/main/resources/default/templates/biz/tycho/analytics/data-explorer.html.pasta
@@ -457,8 +457,8 @@
 
         <div class="input-group">
             <input type="text" id="entityQueryField"
-                   class="form-control"
-                   placeholder="@i18n('NLS.searchkey')" autofocus/>
+                   class="form-control primary-autofocus-js"
+                   placeholder="@i18n('NLS.searchkey')"/>
             <div class="input-group-append">
                 <a class="btn btn-outline-secondary">
                     <i class="fa fa-search"></i>

--- a/src/main/resources/default/templates/biz/tycho/search/search.html.pasta
+++ b/src/main/resources/default/templates/biz/tycho/search/search.html.pasta
@@ -18,7 +18,9 @@
             <div class="row">
                 <div class="col-8 col-lg-9">
                     <div class="input-group">
-                        <input type="text" id="queryField" class="form-control primary-autofocus"
+                        <input type="text"
+                               id="queryField"
+                               class="form-control primary-autofocus-js"
                                value="@query"
                                placeholder="@i18n('NLS.searchkey')"/>
                         <div class="input-group-append">


### PR DESCRIPTION
fields are automatically autofocused via primary-autofocus-js so extra autofocus on input has to be removed.

### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
![Bildschirmfoto 2023-10-27 um 15 14 59](https://github.com/scireum/sirius-biz/assets/55080004/d230d5df-ad14-4860-920b-e3a2fc740119)

### Additional Notes

- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->
- https://github.com/scireum/sirius-web/pull/1311

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
