### PR TITLE
Adds a sidebar to the base of the kb and enables it in the kb articles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>dev-40.0.0</sirius.kernel>
-        <sirius.web>dev-73.4.0</sirius.web>
+        <sirius.web>dev-74.3.0</sirius.web>
         <sirius.db>dev-56.1.1</sirius.db>
     </properties>
 

--- a/src/main/resources/default/taglib/k/article.html.pasta
+++ b/src/main/resources/default/taglib/k/article.html.pasta
@@ -28,6 +28,9 @@
         <i:render name="description"/>
     </i:block>
 
+    <i:block name="sidebar">
+        <i:render name="sidebar"/>
+    </i:block>
+
     <i:render name="body"/>
 </k:base>
-

--- a/src/main/resources/default/taglib/k/base.html.pasta
+++ b/src/main/resources/default/taglib/k/base.html.pasta
@@ -108,44 +108,53 @@
             </i:if>
         </i:block>
 
-        <div class="row">
-            <div class="col-xl-9 col-lg-12">
-                <i:render name="body"/>
-            </div>
-        </div>
+        <t:sidebar renderSidebarIfEmpty="false" class="sticky-sidebar sticky-top mb-4">
+            <i:local name="sidebarContents" value="@renderToString('sidebar')"/>
 
-        <div class="row">
-            <div class="col-xl-9 col-lg-12">
-                <i:local name="references" value="article.queryCrossReferences()"/>
-                <i:if test="!references.isEmpty()">
-                    <k:section heading="@i18n('KnowledgeBase.crossReferencesLabel')">
-                        <i:for type="sirius.biz.tycho.kb.KnowledgeBaseArticle" var="reference" items="references">
-                            <div class="pb-2">
-                                <div>
-                                    <a href="/kba/@reference.getLanguage()/@reference.getArticleId()">
-                                        <i:if test="reference.isChapter()">
-                                            <i class="fa fa-book"></i>
-                                            <i:else>
-                                                <i class="fa fa-file-alt"></i>
-                                            </i:else>
-                                        </i:if>
-                                        @reference.getTitle()
-                                    </a>
-                                </div>
-                                <div class="text-muted">
-                                    @reference.getDescription()
-                                </div>
-                            </div>
-                        </i:for>
-                    </k:section>
-                </i:if>
+            <i:block name="sidebar">
+                <i:render name="sidebar"/>
+            </i:block>
+
+
+            <div class="row">
+                <div class="@if (isFilled(sidebarContents)) { col } else { col-xl-9 col-lg-12 }">
+                    <i:render name="body"/>
+                </div>
             </div>
-        </div>
+
+            <div class="row">
+                <div class="@if (isFilled(sidebarContents)) { col } else { col-xl-9 col-lg-12 }">
+                    <i:local name="references" value="article.queryCrossReferences()"/>
+                    <i:if test="!references.isEmpty()">
+                        <k:section heading="@i18n('KnowledgeBase.crossReferencesLabel')">
+                            <i:for type="sirius.biz.tycho.kb.KnowledgeBaseArticle" var="reference" items="references">
+                                <div class="pb-2">
+                                    <div>
+                                        <a href="/kba/@reference.getLanguage()/@reference.getArticleId()">
+                                            <i:if test="reference.isChapter()">
+                                                <i class="fa fa-book"></i>
+                                                <i:else>
+                                                    <i class="fa fa-file-alt"></i>
+                                                </i:else>
+                                            </i:if>
+                                            @reference.getTitle()
+                                        </a>
+                                    </div>
+                                    <div class="text-muted">
+                                        @reference.getDescription()
+                                    </div>
+                                </div>
+                            </i:for>
+                        </k:section>
+                    </i:if>
+                </div>
+            </div>
+        </t:sidebar>
 
         <script>
             sirius.ready(function () {
                 PR.prettyPrint();
-                mermaid.initialize({ startOnLoad: true });
+                mermaid.initialize({startOnLoad: true});
             });
         </script>
     </t:page>

--- a/src/main/resources/default/taglib/k/base.html.pasta
+++ b/src/main/resources/default/taglib/k/base.html.pasta
@@ -115,15 +115,14 @@
                 <i:render name="sidebar"/>
             </i:block>
 
-
             <div class="row">
-                <div class="@if (isFilled(sidebarContents)) { col } else { col-xl-9 col-lg-12 }">
+                <div class="@if(isFilled(sidebarContents)) { col } else { col-xl-9 col-lg-12 }">
                     <i:render name="body"/>
                 </div>
             </div>
 
             <div class="row">
-                <div class="@if (isFilled(sidebarContents)) { col } else { col-xl-9 col-lg-12 }">
+                <div class="@if(isFilled(sidebarContents)) { col } else { col-xl-9 col-lg-12 }">
                     <i:local name="references" value="article.queryCrossReferences()"/>
                     <i:if test="!references.isEmpty()">
                         <k:section heading="@i18n('KnowledgeBase.crossReferencesLabel')">


### PR DESCRIPTION
### Description

* By default no sidebar is rendered in an article or any kb page which uses the kb base as long as there is no sidebar block with content.
* An article must have a `<i:block name="sidebar">` block with actual content in order for the sidebar to show up.

-> Therefore, every article and part of the kb should behave as before.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-890](https://scireum.myjetbrains.com/youtrack/issue/SIRI-890)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

