### PR TITLE
Unlocks files when extraction fails

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -137,17 +137,20 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
                               .withContext("size", NLS.formatSize(sourceFile.size())));
 
         try (FileHandle archive = sourceFile.download()) {
-            extractor.extractAll(sourceFile.name(),
-                                 archive.getFile(),
-                                 null,
-                                 file -> handleExtractedFile(file,
-                                                             process,
-                                                             overrideMode,
-                                                             targetDirectory,
-                                                             flattenDirs));
+            try {
+                extractor.extractAll(sourceFile.name(),
+                                     archive.getFile(),
+                                     null,
+                                     file -> handleExtractedFile(file,
+                                                                 process,
+                                                                 overrideMode,
+                                                                 targetDirectory,
+                                                                 flattenDirs));
+                process.forceUpdateState(NLS.get("ExtractArchiveJob.completed"));
+            } catch (Exception exception) {
+                process.handle(exception);
+            }
         }
-
-        process.forceUpdateState(NLS.get("ExtractArchiveJob.completed"));
 
         if (!process.isErroneous() && process.require(deleteArchiveParameter).booleanValue()) {
             process.log(ProcessLog.info().withNLSKey("ExtractArchiveJob.deletingArchive"));


### PR DESCRIPTION
### Description

as the unhandled exception exists the job execution thus skipping proper handling of the source file's read-only flag.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-899](https://scireum.myjetbrains.com/youtrack/issue/SIRI-899)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
