### PR TITLE
Fix: Current Tenant from `UserInfo`

### DIFF
--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -131,9 +131,9 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
     }
 
     /**
-     * Returns the tenant of the currently logged in user or throws an exception if no user is present.
+     * Returns the tenant of the currently logged-in user or throws an exception if no user is present.
      *
-     * @return the tenant of the currently logged in user
+     * @return the tenant of the currently logged-in user
      */
     @Nonnull
     public T getRequiredTenant() {

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -127,7 +127,7 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
      */
     @Nonnull
     public Optional<T> getCurrentTenant() {
-        return getCurrentUser().flatMap(u -> Optional.ofNullable(u.getTenant().fetchValue()));
+        return fetchCachedTenant(UserContext.getCurrentUser().getTenantId());
     }
 
     /**


### PR DESCRIPTION
### Description

The previous implementation used `tenants.getCurrentUser()` which resolves a database object. However, if we use synthetic users (as we do, for instance, in `tenants.runAsAdminOfTenant(…)`), there is no database entry, and this method always returned **null**. A `UserInfo` object on the other hand can always be resolved, and along with it a tenant object.

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
