### PR TITLE
Fix: Restores Synthetic Administrator User in Processes

### DIFF
--- a/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
@@ -48,15 +48,15 @@ import java.util.stream.Collectors;
  * (via {@link DistributedTaskExecutorLoadAction}). When and where those tasks are executed is controlled
  * via the system configuration in <tt>async.distributed</tt>. See <tt>component-biz.conf</tt> for examples.
  * <p>
- * Also a queue can be globally or locally disabled via {@link NeighborhoodWatch} and its configuration.
+ * Also, a queue can be globally or locally disabled via {@link NeighborhoodWatch} and its configuration.
  * <p>
  * This framework supports two type of queues. Simple FIFOs which execute tasks in the order they are
- * scheduled. Additionally prioritized queues are supported. For these queues a <tt>penalty token</tt>
+ * scheduled. Additionally, prioritized queues are supported. For these queues a <tt>penalty token</tt>
  * per task is supplied (e.g. a user or tenant id). The system then counts the number of already queued
  * tasks for this token and computes a penalty time. Now if now other tasks are queued, a task with a
  * penalty time applied will still be immediatelly executed. However, as soon as other tasks are scheduled
- * a task might be delayed up until its penalty time is over. Currently the penalty time is a static
- * value set in the system configuration and multiplied by the number of already queued tasks. Therefore this
+ * a task might be delayed up until its penalty time is over. Currently, the penalty time is a static
+ * value set in the system configuration and multiplied by the number of already queued tasks. Therefore, this
  * should be roughly equal to the estimated execution time.
  * <p>
  * Use this helper via an {@link Part} annotation.
@@ -140,7 +140,7 @@ public class DistributedTasks implements MetricProvider {
     /**
      * Represents an executable task.
      * <p>
-     * This is basically the call to the appropriate {@link DistributedTaskExecutor} along with some book keeping.
+     * This is basically the call to the appropriate {@link DistributedTaskExecutor} along with some bookkeeping.
      */
     protected class DistributedTask {
 

--- a/src/main/java/sirius/biz/jobs/Jobs.java
+++ b/src/main/java/sirius/biz/jobs/Jobs.java
@@ -94,7 +94,7 @@ public class Jobs {
      * @param name         the name of the job factory to resolve
      * @param expectedType a type to cast the job factory to
      * @param <J>          the generic version of <tt>expectedType</tt>
-     * @return the job factory with the given name, casted to the given class
+     * @return the job factory with the given name, cast to the given class
      */
     @SuppressWarnings("unchecked")
     public <J extends JobFactory> J findFactory(String name, Class<J> expectedType) {

--- a/src/main/java/sirius/biz/jobs/JobsRoot.java
+++ b/src/main/java/sirius/biz/jobs/JobsRoot.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  * Provides a {@link VFSRoot} to trigger jobs via the built-in {@link VirtualFileSystem}.
  * <p>
  * This will provide a <b>jobs</b> folder (if {@link JobPresets} are enabled and the current user is allowed to
- * execute jobs). Within this directory, there is a sub-directory for each job which accepts a file. Each job folder
+ * execute jobs). Within this directory, there is a subdirectory for each job which accepts a file. Each job folder
  * contains on folder per preset (as any other parameter than the file has to be specified elsewhere).
  * <p>
  * If a file is uploaded into a preset folder it is put into the {@link TmpRoot temporary space} and a job

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessTaskExecutor.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessTaskExecutor.java
@@ -39,15 +39,14 @@ public abstract class BatchProcessTaskExecutor implements DistributedTaskExecuto
     @Override
     public void executeWork(ObjectNode context) throws Exception {
         String factoryId = context.path(BatchProcessJobFactory.CONTEXT_JOB_FACTORY).asText(null);
+        String processId = context.path(BatchProcessJobFactory.CONTEXT_PROCESS).asText(null);
 
         setupTaskContext(factoryId);
 
         if (shouldExecutePartially()) {
-            processes.partiallyExecute(context.path(BatchProcessJobFactory.CONTEXT_PROCESS).asText(null),
-                                       process -> partiallyExecuteInProcess(factoryId, process));
+            processes.partiallyExecute(processId, process -> partiallyExecuteInProcess(factoryId, process));
         } else {
-            processes.execute(context.path(BatchProcessJobFactory.CONTEXT_PROCESS).asText(null),
-                              process -> executeInProcess(factoryId, process));
+            processes.execute(processId, process -> executeInProcess(factoryId, process));
         }
     }
 

--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -329,12 +329,12 @@ class ProcessEnvironment implements ProcessContext {
     }
 
     @Nullable
-    public String getUserId() {
+    public String fetchUserId() {
         return processes.fetchProcess(processId).map(Process::getUserId).orElse(null);
     }
 
     @Nullable
-    public String getTenantId() {
+    public String fetchTenantId() {
         return processes.fetchProcess(processId).map(Process::getTenantId).orElse(null);
     }
 

--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -328,11 +328,21 @@ class ProcessEnvironment implements ProcessContext {
                         .orElse(false) && tasks.isRunning();
     }
 
+    /**
+     * Fetches the identifier of the user who started the process.
+     *
+     * @return the identifier of the user who started the process
+     */
     @Nullable
     public String fetchUserId() {
         return processes.fetchProcess(processId).map(Process::getUserId).orElse(null);
     }
 
+    /**
+     * Fetches the identifier of the tenant which started the process.
+     *
+     * @return the identifier of the tenant which started the process
+     */
     @Nullable
     public String fetchTenantId() {
         return processes.fetchProcess(processId).map(Process::getTenantId).orElse(null);

--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -339,6 +339,16 @@ class ProcessEnvironment implements ProcessContext {
     }
 
     /**
+     * Fetches the name of the user who started the process.
+     *
+     * @return the name of the user who started the process
+     */
+    @Nullable
+    public String fetchUserName() {
+        return processes.fetchProcess(processId).map(Process::getUserName).orElse(null);
+    }
+
+    /**
      * Fetches the identifier of the tenant which started the process.
      *
      * @return the identifier of the tenant which started the process
@@ -346,6 +356,16 @@ class ProcessEnvironment implements ProcessContext {
     @Nullable
     public String fetchTenantId() {
         return processes.fetchProcess(processId).map(Process::getTenantId).orElse(null);
+    }
+
+    /**
+     * Fetches the name of the tenant which started the process.
+     *
+     * @return the name of the tenant which started the process
+     */
+    @Nullable
+    public String fetchTenantName() {
+        return processes.fetchProcess(processId).map(Process::getTenantName).orElse(null);
     }
 
     @Override

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -934,10 +934,13 @@ public class Processes {
      * @param env         the process environment to read the user infos from
      */
     private void installUserOfProcess(UserContext userContext, ProcessEnvironment env) {
-        if (env.getUserId() != null) {
-            UserInfo user = userContext.getUserManager().findUserByUserId(env.getUserId());
+        String userId = env.getUserId();
+        String tenantId = env.getTenantId();
+
+        if (userId != null) {
+            UserInfo user = userContext.getUserManager().findUserByUserId(userId);
             if (user != null) {
-                user = userContext.getUserManager().createUserWithTenant(user, env.getTenantId());
+                user = userContext.getUserManager().createUserWithTenant(user, tenantId);
                 userContext.setCurrentUser(user);
             }
         }

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -937,12 +937,14 @@ public class Processes {
         String userId = environment.getUserId();
         String tenantId = environment.getTenantId();
 
-        if (userId != null) {
-            UserInfo user = userContext.getUserManager().findUserByUserId(userId);
-            if (user != null) {
-                user = userContext.getUserManager().createUserWithTenant(user, tenantId);
-                userContext.setCurrentUser(user);
-            }
+        if (Strings.isEmpty(userId)) {
+            return;
+        }
+
+        UserInfo user = userContext.getUserManager().findUserByUserId(userId);
+        if (user != null) {
+            user = userContext.getUserManager().createUserWithTenant(user, tenantId);
+            userContext.setCurrentUser(user);
         }
     }
 

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -115,9 +115,6 @@ public class Processes {
     @Part
     private TableProcessOutputType tableProcessOutputType;
 
-    @Part
-    private Tenants<?, ?, ?> tenants;
-
     /**
      * Due to some shortcomings in Elasticsearch (1-second delay until writes are visible), we need a layered cache
      * architecture here.
@@ -939,14 +936,13 @@ public class Processes {
     private void installUserOfProcess(UserContext userContext, ProcessEnvironment environment) {
         String userId = environment.fetchUserId();
         String tenantId = environment.fetchTenantId();
+        String tenantName = environment.fetchTenantName();
 
         if (Strings.isEmpty(userId)) {
             return;
         }
 
         if (Strings.areEqual(userId, UserInfo.SYNTHETIC_ADMIN_USER_ID) && Strings.isFilled(tenantId)) {
-            String tenantName =
-                    tenants.fetchCachedTenant(tenantId).map(tenant -> tenant.getTenantData().getName()).orElse(null);
             userContext.setCurrentUser(UserInfo.Builder.createSyntheticAdminUser(tenantId, tenantName).build());
             return;
         }

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -937,8 +937,8 @@ public class Processes {
      * @param environment the process environment to read the user infos from
      */
     private void installUserOfProcess(UserContext userContext, ProcessEnvironment environment) {
-        String userId = environment.getUserId();
-        String tenantId = environment.getTenantId();
+        String userId = environment.fetchUserId();
+        String tenantId = environment.fetchTenantId();
 
         if (Strings.isEmpty(userId)) {
             return;

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -944,15 +944,10 @@ public class Processes {
             return;
         }
 
-        if (Strings.areEqual(userId, Tenants.SYNTHETIC_ADMIN_USER_ID) && Strings.isFilled(tenantId)) {
+        if (Strings.areEqual(userId, UserInfo.SYNTHETIC_ADMIN_USER_ID) && Strings.isFilled(tenantId)) {
             String tenantName =
                     tenants.fetchCachedTenant(tenantId).map(tenant -> tenant.getTenantData().getName()).orElse(null);
-            userContext.setCurrentUser(UserInfo.Builder.createUser(Tenants.SYNTHETIC_ADMIN_USER_ID)
-                                                       .withUsername(Tenants.SYNTHETIC_ADMIN_USER_NAME)
-                                                       .withTenantId(tenantId)
-                                                       .withTenantName(tenantName)
-                                                       .withEveryPermission(true)
-                                                       .build());
+            userContext.setCurrentUser(UserInfo.Builder.createSyntheticAdminUser(tenantId, tenantName).build());
             return;
         }
 

--- a/src/main/java/sirius/biz/tenants/Tenant.java
+++ b/src/main/java/sirius/biz/tenants/Tenant.java
@@ -61,7 +61,7 @@ public interface Tenant<I extends Serializable>
     /**
      * Returns the reference to the parent tenant (if available).
      *
-     * @return the reference to lookup the parent tenant
+     * @return the reference to look up the parent tenant
      */
     BaseEntityRef<I, ? extends Tenant<I>> getParent();
 

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -56,6 +56,16 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
      */
     public static final String FRAMEWORK_TENANTS = "biz.tenants";
 
+    /**
+     * Defines the user ID used to represent the synthetic "Administrator" user.
+     */
+    public static final String SYNTHETIC_ADMIN_USER_ID = "ADMIN";
+
+    /**
+     * Defines the name used for the synthetic "Administrator" user.
+     */
+    public static final String SYNTHETIC_ADMIN_USER_NAME = "Administrator";
+
     @Part
     protected Mixing mixing;
 
@@ -561,8 +571,8 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
         UserContext userContext = UserContext.get();
         UserInfo currentUser = userContext.getUser();
         try {
-            userContext.setCurrentUser(UserInfo.Builder.createUser("ADMIN")
-                                                       .withUsername("Administrator")
+            userContext.setCurrentUser(UserInfo.Builder.createUser(SYNTHETIC_ADMIN_USER_ID)
+                                                       .withUsername(SYNTHETIC_ADMIN_USER_NAME)
                                                        .withTenantId(tenantId)
                                                        .withTenantName(tenantName)
                                                        .withEveryPermission(true)

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -97,7 +97,7 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
     /**
      * Returns the current user or throws an exception if no user is currently available.
      *
-     * @return the currently logged in user
+     * @return the currently logged-in user
      */
     @Nonnull
     public U getRequiredUser() {
@@ -237,7 +237,7 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
     /**
      * Applies an appropriate filter to the given query to only return entities which belong to the current tenant.
      *
-     * @param qry the query to extent
+     * @param qry the query to extend
      * @param <E> the type of entities processed by the query
      * @param <Q> the type of the query which is being extended
      * @return the query with an additional constraint filtering on the current tenant

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -56,16 +56,6 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
      */
     public static final String FRAMEWORK_TENANTS = "biz.tenants";
 
-    /**
-     * Defines the user ID used to represent the synthetic "Administrator" user.
-     */
-    public static final String SYNTHETIC_ADMIN_USER_ID = "ADMIN";
-
-    /**
-     * Defines the name used for the synthetic "Administrator" user.
-     */
-    public static final String SYNTHETIC_ADMIN_USER_NAME = "Administrator";
-
     @Part
     protected Mixing mixing;
 
@@ -571,12 +561,7 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
         UserContext userContext = UserContext.get();
         UserInfo currentUser = userContext.getUser();
         try {
-            userContext.setCurrentUser(UserInfo.Builder.createUser(SYNTHETIC_ADMIN_USER_ID)
-                                                       .withUsername(SYNTHETIC_ADMIN_USER_NAME)
-                                                       .withTenantId(tenantId)
-                                                       .withTenantName(tenantName)
-                                                       .withEveryPermission(true)
-                                                       .build());
+            userContext.setCurrentUser(UserInfo.Builder.createSyntheticAdminUser(tenantId, tenantName).build());
             return task.create();
         } finally {
             userContext.setCurrentUser(currentUser);

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 /**
  * Helps for extract the current {@link UserAccount} and {@link Tenant}.
  * <p>
- * Also some boilerplate methods are provided to perform some assertions.
+ * Also, some boilerplate methods are provided to perform some assertions.
  *
  * @param <I> the type of database IDs used by the concrete implementation
  * @param <T> specifies the effective entity type used to represent Tenants

--- a/src/main/java/sirius/biz/tenants/UserAccountData.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountData.java
@@ -273,7 +273,7 @@ public class UserAccountData extends Composite implements MessageProvider {
 
     /**
      * Generates a string representation of this user.
-     * By default this uses the full Name {@link PersonData#toString()}
+     * By default, this uses the full Name {@link PersonData#toString()}
      * If {@link #hasName} is false, returns {@link LoginData#getUsername()}.
      * If this is also empty, {@link #email)} is returned.
      * As last option an anonymous identifier is used.
@@ -297,7 +297,7 @@ public class UserAccountData extends Composite implements MessageProvider {
 
     /**
      * Generates a short name, for this user.
-     * By default this is "Firstname Lastname", if the lastname is filled.
+     * By default, this is "Firstname Lastname", if the lastname is filled.
      * If {@link #hasName} is false, {@link #toString} is called.
      *
      * @return a short name for this user


### PR DESCRIPTION
### Description

Previously, synthetic admin users were not restored when launching a process, as the `ADMIN` identifier does not belong to an actual database entity. Therefore, like in `Tenants.asAdminOfTenant(…)`, we need to initialise a new synthetic user with all respective permissions.

### Migration

- `ProcessEnvironment.getUserId()` → `ProcessEnvironment.fetchUserId()`
- `ProcessEnvironment.getTenantId()` → `ProcessEnvironment.fetchTenantId()`

### Additional Notes

- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1327

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
