### PR TITLE
Process Persistence

### DIFF
--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -552,7 +552,7 @@ public class Processes {
      * @param persistencePeriod specifies the new persistence period
      * @return <tt>true</tt> if the process was successfully modified, <tt>false</tt> otherwise
      */
-    protected boolean updatePersistence(String processId, PersistencePeriod persistencePeriod) {
+    public boolean updatePersistence(String processId, PersistencePeriod persistencePeriod) {
         return modify(processId, process -> process.getPersistencePeriod() != persistencePeriod, process -> {
             PersistencePeriod currentPersistence = process.getPersistencePeriod();
             process.setPersistencePeriod(persistencePeriod);


### PR DESCRIPTION
### Description

Makes existing "setter" for process persistence publicly visible. This enables process to change their default persistence, depending on the outcome.

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
