### PR TITLE
Revamps Storage URLs validity and caching

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -61,8 +61,8 @@ public class URLBuilder {
     protected String filename;
     protected String baseURL;
     protected String addonText;
-    protected boolean reusable;
     protected boolean delayResolve;
+    protected boolean eternallyValid;
     protected boolean forceDownload;
     protected boolean suppressCache;
     protected String hook;
@@ -298,9 +298,21 @@ public class URLBuilder {
      * downstream proxy should still be able to leverage its caching capabilities.
      *
      * @return the builder itself for fluent method calls
+     * @deprecated use {@link #delayResolve()} and {@link #eternallyValid()} instead.
      */
+    @Deprecated(forRemoval = true)
     public URLBuilder reusable() {
-        this.reusable = true;
+        return this.delayResolve().eternallyValid();
+    }
+
+    /**
+     * Makes this URL eternally valid.
+     * <p>
+     *
+     * @return the builder itself for fluent method calls
+     */
+    public URLBuilder eternallyValid() {
+        this.eternallyValid = true;
         return this;
     }
 
@@ -388,12 +400,6 @@ public class URLBuilder {
             return new UrlResult(null, UrlType.EMPTY);
         }
 
-        if (reusable) {
-            // If the caller requested a reusable URL (one to be output and sent to 3rd parties), we probably also
-            // want it to be valid as long as the "blob lives" and not to become obsolete once the blob contents
-            // change...
-            return new UrlResult(createVirtualDeliveryUrl(), UrlType.VIRTUAL);
-        }
         if (suppressCache) {
             // Manual cache control is only supported in virtual calls, not physical...
             return new UrlResult(createVirtualDeliveryUrl(), UrlType.VIRTUAL);
@@ -601,7 +607,7 @@ public class URLBuilder {
     }
 
     private String computeAccessToken(String authToken) {
-        if (reusable) {
+        if (eternallyValid) {
             return utils.computeEternallyValidHash(authToken);
         } else {
             return utils.computeHash(authToken, 0);

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -271,26 +271,6 @@ public class URLBuilder {
     }
 
     /**
-     * Makes this URL reusable.
-     * <p>
-     * Such URLs use a virtual access path so that these URLs remain constant for the same blob whereas physical URLs
-     * change once the underlying blob is updated. Therefore, these URLs can be passed on to 3rd parties as they remain
-     * valid as long as the referenced blob "lives".
-     * <p>
-     * Note however, that these URLs (their responses) are not as cacheable as physical ones (which are infinitely
-     * cached). However, unless {@link #suppressCaching()} is invoked, we still try to keep them in cache for a limited
-     * time. We also redirect to the physical URL once the virtual one is requested (if possible). Therefore, a
-     * downstream proxy should still be able to leverage its caching capabilities.
-     *
-     * @return the builder itself for fluent method calls
-     * @deprecated use {@link #delayResolve()} and {@link #eternallyValid()} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public URLBuilder reusable() {
-        return this.delayResolve().eternallyValid();
-    }
-
-    /**
      * Makes this URL eternally valid.
      * <p>
      *

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -186,21 +186,6 @@ public class URLBuilder {
     }
 
     /**
-     * Make the URL a download url using the given filename.
-     *
-     * @param path the filename to send to the browser
-     * @return the builder itself for fluent method calls
-     * @deprecated use {@link #withFileName(String)} in combination with {@link #asDownload()} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public URLBuilder asDownload(String path) {
-        this.filename = Files.getFilenameAndExtension(path);
-        this.forceDownload = true;
-
-        return this;
-    }
-
-    /**
      * Make the URL a download url using the filename of the blob.
      *
      * @return the builder itself for fluent method calls

--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -619,7 +619,7 @@ public class TenantData extends Composite implements Journaled {
      * @return a URLBuilder which is used to fetch the small image of this tenant
      */
     public URLBuilder fetchSmallUrl() {
-        return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_SMALL);
+        return image.url().eternallyValid().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_SMALL);
     }
 
     /**
@@ -628,7 +628,7 @@ public class TenantData extends Composite implements Journaled {
      * @return a URLBuilder which is used to fetch the medium image of this tenant
      */
     public URLBuilder fetchMediumUrl() {
-        return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_MEDIUM);
+        return image.url().eternallyValid().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_MEDIUM);
     }
 
     /**
@@ -637,6 +637,6 @@ public class TenantData extends Composite implements Journaled {
      * @return a URLBuilder which is used to fetch the large image of this tenant
      */
     public URLBuilder fetchLargeUrl() {
-        return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_LARGE);
+        return image.url().eternallyValid().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_LARGE);
     }
 }

--- a/src/main/java/sirius/biz/tenants/UserAccountData.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountData.java
@@ -487,7 +487,7 @@ public class UserAccountData extends Composite implements MessageProvider {
      * @return a URLBuilder which is used to fetch the small image of this user
      */
     public URLBuilder fetchSmallUrl() {
-        return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_SMALL);
+        return image.url().eternallyValid().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_SMALL);
     }
 
     /**
@@ -496,7 +496,7 @@ public class UserAccountData extends Composite implements MessageProvider {
      * @return a URLBuilder which is used to fetch the medium image of this user
      */
     public URLBuilder fetchMediumUrl() {
-        return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_MEDIUM);
+        return image.url().eternallyValid().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_MEDIUM);
     }
 
     /**
@@ -505,6 +505,6 @@ public class UserAccountData extends Composite implements MessageProvider {
      * @return a URLBuilder which is used to fetch the large image of this user
      */
     public URLBuilder fetchLargeUrl() {
-        return image.url().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_LARGE);
+        return image.url().eternallyValid().withFallbackUri(IMAGE_FALLBACK_URI).withVariant(IMAGE_VARIANT_LARGE);
     }
 }

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1101,6 +1101,7 @@ storage {
             user-accounts {
                 readPermission = "disabled"
                 touchTracking = true
+                urlValidityDays = 30
             }
         }
     }

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1094,6 +1094,7 @@ storage {
             tenants {
                 readPermission = "disabled"
                 touchTracking = true
+                urlValidityDays = 30
             }
 
             # This space is used to store image files for UserAccounts


### PR DESCRIPTION
### Description

#### BREAKING
- The return of `StorageUtils.verifyHash` has changed from boolean to Optional<Integer>. This method is unlikely called by products directly but if so, an empty optional means `false`.
- Kills `URLBuilder.reusable()`. Technically speaking this is the same as `.delayResolved().eternallyValid()`

#### Changes
- Re-Introduces `URLBuilder.eternallyValid()` which solely dictates URL validity, independent on URL type (virtual x physical)
- Ties the cache of a generated URL to its validity. Eg: if an URL in only valid 30 days, its Cache-Control & Expires headers will react so.
- Increases the validity of RAW tenant and user-account files to 30 days
- Makes variant URLs of tenants and user-accounts eternally valid

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10300](https://scireum.myjetbrains.com/youtrack/issue/OX-10300)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
