### PR TITLE
Clarifies priority of lookup table fallbacks

### DIFF
--- a/src/main/java/sirius/biz/codelists/LookupTables.java
+++ b/src/main/java/sirius/biz/codelists/LookupTables.java
@@ -66,12 +66,12 @@ public class LookupTables {
         // If no IDB config is present or Jupiter is disabled, ...
         if (Strings.isEmpty(baseTable) || jupiter == null) {
             String codeList = extension.get(CONFIG_KEY_CODE_LIST).asString();
-            if (Strings.isEmpty(codeList)) {
-                // ...and no codeList is given
-                return new ConfigLookupTable(extension);
+            if (Strings.isFilled(codeList)) {
+                // ...if configured, use code list based tables
+                return new CodeListLookupTable(extension, codeList);
             } else {
-                // ...we resort to code list based tables
-                return new CodeListLookupTable(extension, Strings.firstFilled(codeList, name));
+                // ...or fallback to configuration based table
+                return new ConfigLookupTable(extension);
             }
         }
 


### PR DESCRIPTION
### Description
- in the past the 'lookup-tables' extension 'name' was used as fallback using a Strings#firstFilled
- this was broken in https://github.com/scireum/sirius-biz/commit/6e23dfb39d94fb8f380f701d842e649b7eefa1ef as by now, only a configured code list in the 'lookup-tables' extension field 'codeList' does lead to the usage of the code list implementation
- as this break did not cause major damage, lets stay with the current behavior
- so by now, configuration of lookup-tables.XYZ.codeList.XYZ will remain mandatory for code lists
- and the code gets cleaned for clarity
- 
### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-908](https://scireum.myjetbrains.com/youtrack/issue/SIRI-908)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/1784

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
