### PR TITLE
LookupValueProperty: Considers empty strings as null

### DIFF
--- a/src/main/java/sirius/biz/codelists/LookupValueProperty.java
+++ b/src/main/java/sirius/biz/codelists/LookupValueProperty.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
- * Provides the propery used to handle {@link LookupValue lookup values} in database entities.
+ * Provides the property used to handle {@link LookupValue lookup values} in database entities.
  */
 public class LookupValueProperty extends StringProperty {
 
@@ -119,5 +119,13 @@ public class LookupValueProperty extends StringProperty {
     protected Object transformValueFromImport(Value value) {
         String importValue = value.trim();
         return referenceValue.getTable().normalizeInput(importValue).orElse(importValue);
+    }
+
+    @Override
+    protected boolean isConsideredNull(Object propertyValue) {
+        if (propertyValue instanceof String stringValue) {
+            return Strings.isEmpty(stringValue);
+        }
+        return propertyValue == null;
     }
 }


### PR DESCRIPTION
### Description

Otherwise, `EntityDescription.isChanged` always reports empty LookupValueProperty as changed since they hold an empty string, opposed to `null` as persisted in the DB.

Drive-By: typo fix

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10597](https://scireum.myjetbrains.com/youtrack/issue/OX-10597)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
