### PR TITLE
Parses unused NLS keys from other nodes correctly

### DIFF
--- a/src/main/java/sirius/biz/util/ReportUnusedNLSKeysJob.java
+++ b/src/main/java/sirius/biz/util/ReportUnusedNLSKeysJob.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import sirius.biz.cluster.InterconnectClusterManager;
 import sirius.biz.jobs.StandardCategories;
 import sirius.biz.jobs.batch.SimpleBatchProcessJobFactory;
@@ -83,7 +84,7 @@ public class ReportUnusedNLSKeysJob extends SimpleBatchProcessJobFactory {
         clusterManager.callEachNode("/system/nls/unused/" + clusterManager.getClusterAPIToken())
                       .forEach(missingKeysOfNode -> {
                           Set<String> keysOfNode = Json.streamEntries(Json.getArray(missingKeysOfNode, "unused"))
-                                                       .map(Object::toString)
+                                                       .map(JsonNode::asText)
                                                        .collect(Collectors.toSet());
 
                           process.log(ProcessLog.info()


### PR DESCRIPTION

### Description

This removed all keys from the missing keys set, as toString on a text node wraps the text into "", resulting in ""Key"" which is not contained in the initial set.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-901](https://scireum.myjetbrains.com/youtrack/issue/SIRI-901)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
