### PR TITLE
Fixes sftp deletion on S3 backed filesystems

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeFileSystem.java
@@ -83,17 +83,12 @@ public class BridgeFileSystem extends FileSystem {
         if (Strings.isEmpty(first)) {
             return new BridgePath(virtualFileSystem.root(), this);
         }
-        if (more.length == 0) {
-            VirtualFile topLevelDirectory = virtualFileSystem.root().resolve(first);
-            topLevelDirectory.assertExists();
-            return new BridgePath(topLevelDirectory, this);
+        VirtualFile topLevelDirectory = virtualFileSystem.root().resolve(first);
+        for (String part : more) {
+            topLevelDirectory = topLevelDirectory.resolve(part);
         }
-        // We only seem to have to handle the root access - we throw the following exception if our
-        // assumption is falsified...
-        throw new IllegalArgumentException(Strings.apply(
-                "A non root directory was requested in BridgeFileSystem.getPath: %s - %s",
-                first,
-                Strings.join(",", more)));
+        topLevelDirectory.assertExists();
+        return new BridgePath(topLevelDirectory, this);
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgePath.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgePath.java
@@ -70,7 +70,11 @@ public class BridgePath implements Path {
 
     @Override
     public Path getRoot() {
-        return this;
+        VirtualFile parent = virtualFile;
+        while (parent.parent() != null) {
+            parent = parent.parent();
+        }
+        return new BridgePath(parent, fileSystem);
     }
 
     @Override
@@ -100,7 +104,16 @@ public class BridgePath implements Path {
 
     @Override
     public Path getName(int index) {
-        return this;
+        int nameCount = getNameCount();
+        // use '-1' as we want to get the first name, e.g. for index=0 at /foo/bar/baz we want 'foo'
+        int steps = nameCount - index - 1;
+
+        VirtualFile parentFile = virtualFile;
+        for (int i = 0; i < steps; i++) {
+            parentFile = virtualFile.parent();
+        }
+
+        return new StringPath(parentFile.name());
     }
 
     @Override


### PR DESCRIPTION
### Description
- with S3, the new apache mina root directory symlink check behaves a little different than with local filesystems, thus we need to implement more methods at BridgePath
- also we need to remove the restriction at BridgeFileSystem
- Note: Removing the restriction would be enough to fix this specific bug, but it does not feel good to have the apache mina library work on invalid paths. So the BridgePath do fix this as well

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-913](https://scireum.myjetbrains.com/youtrack/issue/SIRI-913)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
