### PR TITLE
Fixes alignment for tenant permission table in safari

### DIFF
--- a/src/main/resources/default/templates/biz/packages/additional-and-revoked-permissions.html.pasta
+++ b/src/main/resources/default/templates/biz/packages/additional-and-revoked-permissions.html.pasta
@@ -9,7 +9,7 @@
         <table class="table">
             <thead>
             <tr>
-                <th style="vertical-align: top">
+                <th class="col-8" style="vertical-align: top">
                     <div>@i18n("Packages.permission.name")</div>
                     <div class="text-small text-muted">@i18n("Packages.permission.description")</div>
                 </th>


### PR DESCRIPTION
### Description
Before:
![image](https://github.com/scireum/sirius-biz/assets/150906388/9698411e-9113-4001-aa9f-2cd9a993a181)
After:
![image](https://github.com/scireum/sirius-biz/assets/150906388/0369fe94-9a9a-4e10-9a9b-58ff8a96de0d)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10622](https://scireum.myjetbrains.com/youtrack/issue/OX-10622)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
