### PR TITLE
Fuzzy matches entity names in Query Tool

### DIFF
--- a/src/main/java/sirius/biz/model/QueryController.java
+++ b/src/main/java/sirius/biz/model/QueryController.java
@@ -237,16 +237,13 @@ public class QueryController extends BizController {
     public void entityTypeAutocomplete(WebContext webContext) {
         AutocompleteHelper.handle(webContext, ((query, result) -> {
             String effectiveQuery = query.toLowerCase();
-            fetchRelevantDescriptors().filter(descriptor -> filterMatch(effectiveQuery, descriptor))
+            fetchRelevantDescriptors().filter(descriptor -> fuzzyMatches(effectiveQuery, descriptor.getName())
+                                                            || fuzzyMatches(effectiveQuery,
+                                                                            descriptor.getType().getSimpleName()))
                                       .map(this::createCompletion)
                                       .limit(AutocompleteHelper.DEFAULT_LIMIT)
                                       .forEach(result);
         }));
-    }
-
-    private boolean filterMatch(String effectiveQuery, EntityDescriptor descriptor) {
-        return fuzzyMatches(effectiveQuery, descriptor.getName()) || fuzzyMatches(effectiveQuery,
-                                                                                  descriptor.getType().getSimpleName());
     }
 
     /**

--- a/src/main/java/sirius/biz/model/QueryController.java
+++ b/src/main/java/sirius/biz/model/QueryController.java
@@ -245,12 +245,35 @@ public class QueryController extends BizController {
     }
 
     private boolean filterMatch(String effectiveQuery, EntityDescriptor descriptor) {
-        return filterMatch(effectiveQuery, descriptor.getName()) || filterMatch(effectiveQuery,
-                                                                                descriptor.getType().getSimpleName());
+        return fuzzyMatches(effectiveQuery, descriptor.getName()) || fuzzyMatches(effectiveQuery,
+                                                                                  descriptor.getType().getSimpleName());
     }
 
-    private boolean filterMatch(String effectiveQuery, String searchedValue) {
-        return searchedValue.toLowerCase().contains(effectiveQuery);
+    /**
+     * Checks if the given query is contained in the searched value.
+     * <p>
+     * This checks if the characters of the query are contained in the searched value in the correct order.
+     * It also ignores casing.
+     *
+     * @param effectiveQuery the lower-cased query text to search for
+     * @param searchedValue  the value to search in
+     * @return <tt>true</tt> if the query is contained in the searched value
+     */
+    private boolean fuzzyMatches(String effectiveQuery, String searchedValue) {
+        String effectiveSearchedValue = searchedValue.toLowerCase();
+        int queryIndex = 0;
+        // Iterate over the characters of the searched value.
+        // Break if we reached the end of the query or searched value.
+        for (int targetIndex = 0;
+             targetIndex < effectiveSearchedValue.length() && queryIndex < effectiveQuery.length();
+             targetIndex++) {
+            if (effectiveQuery.charAt(queryIndex) == effectiveSearchedValue.charAt(targetIndex)) {
+                // If the current character matches, we move to the next character in the query
+                queryIndex++;
+            }
+        }
+        // If we reached the end of the query, we found a match
+        return queryIndex == effectiveQuery.length();
     }
 
     private AutocompleteHelper.Completion createCompletion(EntityDescriptor descriptor) {

--- a/src/main/java/sirius/biz/model/QueryController.java
+++ b/src/main/java/sirius/biz/model/QueryController.java
@@ -245,10 +245,12 @@ public class QueryController extends BizController {
     }
 
     private boolean filterMatch(String effectiveQuery, EntityDescriptor descriptor) {
-        return descriptor.getName().toLowerCase().contains(effectiveQuery) || descriptor.getType()
-                                                                                        .getSimpleName()
-                                                                                        .toLowerCase()
-                                                                                        .contains(effectiveQuery);
+        return filterMatch(effectiveQuery, descriptor.getName()) || filterMatch(effectiveQuery,
+                                                                                descriptor.getType().getSimpleName());
+    }
+
+    private boolean filterMatch(String effectiveQuery, String searchedValue) {
+        return searchedValue.toLowerCase().contains(effectiveQuery);
     }
 
     private AutocompleteHelper.Completion createCompletion(EntityDescriptor descriptor) {


### PR DESCRIPTION
Enhances the suggestion filtering algorithm used in the entity dropdown of the Query Tool.
This allows to more easily search for sub-texts of the entity names.

Examples:

![image](https://github.com/scireum/sirius-biz/assets/2427877/a2e2cb81-798e-4dd9-974c-1bf8ead8295c)

![image](https://github.com/scireum/sirius-biz/assets/2427877/3eeff732-f85d-4813-933f-ffb2d8a696cd)

![image](https://github.com/scireum/sirius-biz/assets/2427877/f0ab1e1a-d475-4016-9237-feca2011a9a5)
