### PR TITLE
Redirects to the correct KB entry point on typo

### DIFF
--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseController.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseController.java
@@ -47,6 +47,18 @@ public class KnowledgeBaseController extends BizController {
     }
 
     /**
+     * Redirects to the entry point of the knowledge base in the current language.
+     * <p>
+     * Sometimes, users may open the wrong URL. Therefore, we redirect to the correct one.
+     *
+     * @param webContext the current request to respond to
+     */
+    @Routed("/kba")
+    public void kbRedirect(WebContext webContext) {
+        webContext.respondWith().redirectPermanently("/kb");
+    }
+
+    /**
      * Renders the entry point of the knowledge base in the given language.
      *
      * @param webContext the current request to respond to


### PR DESCRIPTION
### Description

This is a common mistake (by me) when quickly trying to open the Knowledge Base.

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
