### PR TITLE
streamBlockwise deletions SIRI-915

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <url>http://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-40.0.0</sirius.kernel>
-        <sirius.web>dev-74.3.1</sirius.web>
-        <sirius.db>dev-56.1.1</sirius.db>
+        <sirius.kernel>dev-41.0.0</sirius.kernel>
+        <sirius.web>dev-74.8.0</sirius.web>
+        <sirius.db>dev-56.2.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/process/DeleteExpiredProcessesTask.java
+++ b/src/main/java/sirius/biz/process/DeleteExpiredProcessesTask.java
@@ -50,11 +50,13 @@ public class DeleteExpiredProcessesTask implements EndOfDayTask {
         elastic.select(Process.class)
                .eq(Process.STATE, ProcessState.TERMINATED)
                .where(Elastic.FILTERS.lte(Process.EXPIRES, LocalDate.now()))
-               .iterateAll(this::deleteProcess);
+               .streamBlockwise()
+               .forEach(this::deleteProcess);
 
         elastic.select(Process.class)
                .eq(Process.STATE, ProcessState.STANDBY)
-               .iterateAll(this::deleteExpiredStandbyLogs);
+               .streamBlockwise()
+               .forEach(this::deleteExpiredStandbyLogs);
     }
 
     private void deleteProcess(Process process) {

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
@@ -109,7 +109,7 @@ public class SQLReplicationTaskStorage
             SmartQuery<SQLReplicationTask> query = oma.select(SQLReplicationTask.class);
             query.eq(SQLReplicationTask.FAILED, false);
             query.eq(SQLReplicationTask.TRANSACTION_ID, txnId);
-            query.iterateAll(this::executeTask);
+            query.streamBlockwise().forEach(this::executeTask);
         }
     }
 

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
@@ -115,7 +115,7 @@ public class MongoReplicationTaskStorage
             MongoQuery<MongoReplicationTask> query = mango.select(MongoReplicationTask.class);
             query.eq(MongoReplicationTask.FAILED, false);
             query.eq(MongoReplicationTask.TRANSACTION_ID, txnId);
-            query.iterateAll(this::executeTask);
+            query.streamBlockwise().forEach(this::executeTask);
         }
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -992,7 +992,8 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                .eq(SQLBlob.DELETED, false)
                .where(OMA.FILTERS.lt(SQLBlob.LAST_MODIFIED, LocalDateTime.now().minusDays(retentionDays)))
                .where(OMA.FILTERS.ltOrEmpty(SQLBlob.LAST_TOUCHED, LocalDateTime.now().minusDays(retentionDays)))
-               .iterateAll(this::markBlobAsDeleted);
+               .streamBlockwise()
+               .forEach(this::markBlobAsDeleted);
         } catch (Exception exception) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)
@@ -1009,7 +1010,8 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
                .eq(SQLBlob.DELETED, false)
                .eq(SQLBlob.TEMPORARY, true)
                .where(OMA.FILTERS.lt(SQLBlob.LAST_MODIFIED, LocalDateTime.now().minusHours(4)))
-               .iterateAll(this::markBlobAsDeleted);
+               .streamBlockwise()
+               .forEach(this::markBlobAsDeleted);
         } catch (Exception exception) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -31,7 +31,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void deleteBlobs(Runnable counter) {
-        buildBaseQuery(SQLBlob.class, query -> query.eq(SQLBlob.DELETED, true)).iterateAll(blob -> {
+        buildBaseQuery(SQLBlob.class, query -> query.eq(SQLBlob.DELETED, true)).streamBlockwise().forEach(blob -> {
             try {
                 deletePhysicalObject(blob);
                 oma.delete(blob);
@@ -44,7 +44,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void deleteDirectories(Runnable counter) {
-        buildBaseQuery(SQLDirectory.class, query -> query.eq(SQLDirectory.DELETED, true)).iterateAll(dir -> {
+        buildBaseQuery(SQLDirectory.class, query -> query.eq(SQLDirectory.DELETED, true)).streamBlockwise().forEach(dir -> {
             try {
                 propagateDelete(dir);
                 oma.delete(dir);
@@ -107,7 +107,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processRenamedDirectories(Runnable counter) {
-        buildBaseQuery(SQLDirectory.class, query -> query.eq(SQLDirectory.RENAMED, true)).iterateAll(dir -> {
+        buildBaseQuery(SQLDirectory.class, query -> query.eq(SQLDirectory.RENAMED, true)).streamBlockwise().forEach(dir -> {
             try {
                 propagateRename(dir);
                 oma.updateStatement(SQLDirectory.class)
@@ -157,7 +157,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
                                       String updateExceptionType,
                                       Runnable counter) {
         SmartQuery<SQLBlob> query = buildBaseQuery(SQLBlob.class, queryExtender);
-        query.iterateAll(blob -> {
+        query.streamBlockwise().forEach(blob -> {
             blobConsumer.accept(blob);
 
             try {

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -44,14 +44,16 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void deleteDirectories(Runnable counter) {
-        buildBaseQuery(SQLDirectory.class, query -> query.eq(SQLDirectory.DELETED, true)).streamBlockwise().forEach(dir -> {
-            try {
-                propagateDelete(dir);
-                oma.delete(dir);
-                counter.run();
-            } catch (Exception e) {
-                handleDirectoryDeletionException(dir, e);
-            }
+        buildBaseQuery(SQLDirectory.class, query -> {
+            query.eq(SQLDirectory.DELETED, true).streamBlockwise().forEach(dir -> {
+                try {
+                    propagateDelete(dir);
+                    oma.delete(dir);
+                    counter.run();
+                } catch (Exception e) {
+                    handleDirectoryDeletionException(dir, e);
+                }
+            });
         });
     }
 
@@ -107,17 +109,19 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void processRenamedDirectories(Runnable counter) {
-        buildBaseQuery(SQLDirectory.class, query -> query.eq(SQLDirectory.RENAMED, true)).streamBlockwise().forEach(dir -> {
-            try {
-                propagateRename(dir);
-                oma.updateStatement(SQLDirectory.class)
-                   .set(SQLDirectory.RENAMED, false)
-                   .where(SQLDirectory.ID, dir.getId())
-                   .executeUpdate();
-                counter.run();
-            } catch (Exception e) {
-                handleDirectoryDeletionException(dir, e);
-            }
+        buildBaseQuery(SQLDirectory.class, query -> {
+            query.eq(SQLDirectory.RENAMED, true).streamBlockwise().forEach(dir -> {
+                try {
+                    propagateRename(dir);
+                    oma.updateStatement(SQLDirectory.class)
+                       .set(SQLDirectory.RENAMED, false)
+                       .where(SQLDirectory.ID, dir.getId())
+                       .executeUpdate();
+                    counter.run();
+                } catch (Exception e) {
+                    handleDirectoryDeletionException(dir, e);
+                }
+            });
         });
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -31,7 +31,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
 
     @Override
     protected void deleteBlobs(Runnable counter) {
-        buildBaseQuery(SQLBlob.class, query -> query.eq(SQLBlob.DELETED, true)).streamBlockwise().forEach(blob -> {
+        buildBaseQuery(SQLBlob.class, query -> query.eq(SQLBlob.DELETED, true)).iterateAll(blob -> {
             try {
                 deletePhysicalObject(blob);
                 oma.delete(blob);
@@ -45,7 +45,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
     @Override
     protected void deleteDirectories(Runnable counter) {
         buildBaseQuery(SQLDirectory.class, query -> {
-            query.eq(SQLDirectory.DELETED, true).streamBlockwise().forEach(dir -> {
+            query.eq(SQLDirectory.DELETED, true).iterateAll(dir -> {
                 try {
                     propagateDelete(dir);
                     oma.delete(dir);
@@ -110,7 +110,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
     @Override
     protected void processRenamedDirectories(Runnable counter) {
         buildBaseQuery(SQLDirectory.class, query -> {
-            query.eq(SQLDirectory.RENAMED, true).streamBlockwise().forEach(dir -> {
+            query.eq(SQLDirectory.RENAMED, true).iterateAll(dir -> {
                 try {
                     propagateRename(dir);
                     oma.updateStatement(SQLDirectory.class)
@@ -161,7 +161,7 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
                                       String updateExceptionType,
                                       Runnable counter) {
         SmartQuery<SQLBlob> query = buildBaseQuery(SQLBlob.class, queryExtender);
-        query.streamBlockwise().forEach(blob -> {
+        query.iterateAll(blob -> {
             blobConsumer.accept(blob);
 
             try {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -885,7 +885,8 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                  .where(QueryBuilder.FILTERS.lt(MongoBlob.LAST_MODIFIED, LocalDateTime.now().minusDays(retentionDays)))
                  .where(QueryBuilder.FILTERS.ltOrEmpty(MongoBlob.LAST_TOUCHED,
                                                        LocalDateTime.now().minusDays(retentionDays)))
-                 .iterateAll(this::markBlobAsDeleted);
+                 .streamBlockwise()
+                 .forEach(this::markBlobAsDeleted);
         } catch (Exception e) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)
@@ -902,7 +903,8 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
                  .eq(MongoBlob.DELETED, false)
                  .eq(MongoBlob.TEMPORARY, true)
                  .where(QueryBuilder.FILTERS.lt(MongoBlob.LAST_MODIFIED, LocalDateTime.now().minusHours(4)))
-                 .iterateAll(this::markBlobAsDeleted);
+                 .streamBlockwise()
+                 .forEach(this::markBlobAsDeleted);
         } catch (Exception e) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)

--- a/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLEntitiesTask.java
@@ -30,7 +30,7 @@ public abstract class DeleteSQLEntitiesTask<E extends SQLTenantAware> extends De
 
     @Override
     public void execute(ProcessContext processContext, Tenant<?> tenant) throws Exception {
-        getQuery(tenant).iterateAll(entity -> {
+        getQuery(tenant).streamBlockwise().forEach(entity -> {
             Watch watch = Watch.start();
             beforeDelete(entity);
             oma.delete(entity);

--- a/src/main/java/sirius/biz/tenants/mongo/DeleteMongoEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/mongo/DeleteMongoEntitiesTask.java
@@ -30,7 +30,7 @@ public abstract class DeleteMongoEntitiesTask<E extends MongoTenantAware> extend
 
     @Override
     public void execute(ProcessContext processContext, Tenant<?> tenant) {
-        getQuery(tenant).iterateAll(entity -> {
+        getQuery(tenant).streamBlockwise().forEach(entity -> {
             Watch watch = Watch.start();
             beforeDelete(entity);
             mango.delete(entity);


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
To avoid database-connection-timeouts we use streamBlockwise insted of iterate/iterateAll on deletions
### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-915](https://scireum.myjetbrains.com/youtrack/issue/SIRI-915)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
