### PR TITLE
Encased description in raw to implement HTML formatting in /fs

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
@@ -108,8 +108,7 @@ public class MutableVirtualFile extends VirtualFile {
     /**
      * Provides an additional description which can be shown in the web based UI.
      *
-     * @param description the description to show
-     *                    (this will be {@link sirius.kernel.nls.NLS#smartGet(String) smart translated}).
+     * @param description the description to show (this will be {@link sirius.kernel.nls.NLS#smartGet(String) smart translated}).
      * @return the file itself for fluent method calls
      */
     public MutableVirtualFile withDescription(String description) {
@@ -120,8 +119,7 @@ public class MutableVirtualFile extends VirtualFile {
     /**
      * Provides an additional description, containing html tags, which can be shown in the web based UI.
      *
-     * @param htmlDescription the description to show
-     *                    (this will be {@link sirius.kernel.nls.NLS#smartGet(String) smart translated}).
+     * @param htmlDescription the description, containing html tags, to show.
      * @return the file itself for fluent method calls
      */
     public MutableVirtualFile withHtmlDescription(String htmlDescription) {

--- a/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
@@ -117,9 +117,9 @@ public class MutableVirtualFile extends VirtualFile {
     }
 
     /**
-     * Provides an additional description, containing html tags, which can be shown in the web based UI.
+     * Provides an additional description, containing html tags, which can be shown in the web-based UI.
      *
-     * @param htmlDescription the description, containing html tags, to show.
+     * @param htmlDescription the description to show, containing html tags.
      * @return the file itself for fluent method calls
      */
     public MutableVirtualFile withHtmlDescription(String htmlDescription) {

--- a/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
@@ -118,6 +118,18 @@ public class MutableVirtualFile extends VirtualFile {
     }
 
     /**
+     * Provides an additional description, containing html tags, which can be shown in the web based UI.
+     *
+     * @param htmlDescription the description to show
+     *                    (this will be {@link sirius.kernel.nls.NLS#smartGet(String) smart translated}).
+     * @return the file itself for fluent method calls
+     */
+    public MutableVirtualFile withHtmlDescription(String htmlDescription) {
+        this.htmlDescription = htmlDescription;
+        return this;
+    }
+
+    /**
      * Determines if children can be created for this file.
      *
      * @param canCreateChildrenHandler the predicate used to determine if children can be created for the given file

--- a/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
@@ -108,7 +108,7 @@ public class MutableVirtualFile extends VirtualFile {
     /**
      * Provides an additional description which can be shown in the web based UI.
      *
-     * @param description the description to show (this will be {@link sirius.kernel.nls.NLS#smartGet(String) smart translated}).
+     * @param description the description to show (this will be {@linkplain sirius.kernel.nls.NLS#smartGet(String) smartly translated}).
      * @return the file itself for fluent method calls
      */
     public MutableVirtualFile withDescription(String description) {
@@ -119,7 +119,7 @@ public class MutableVirtualFile extends VirtualFile {
     /**
      * Provides an additional description, containing html tags, which can be shown in the web-based UI.
      *
-     * @param htmlDescription the description to show, containing html tags.
+     * @param htmlDescription the description to show, containing html tags
      * @return the file itself for fluent method calls
      */
     public MutableVirtualFile withHtmlDescription(String htmlDescription) {

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -287,7 +287,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     /**
      * Returns a short description, containing html tags, of the file.
      *
-     * @return the description, containing html tags, of the file
+     * @return the description of the file, containing html tags
      */
     @Nullable
     public String htmlDescription() {

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -16,7 +16,6 @@ import sirius.biz.storage.layer1.FileHandle;
 import sirius.biz.storage.layer2.Blob;
 import sirius.biz.storage.util.Attempt;
 import sirius.biz.storage.util.StorageUtils;
-import sirius.kernel.Sirius;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Streams;
@@ -86,6 +85,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
 
     protected String name;
     protected String description;
+    protected String htmlDescription;
     protected VirtualFile parent;
     protected ChildProvider childProvider;
     protected ToLongFunction<VirtualFile> lastModifiedSupplier;
@@ -282,6 +282,16 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
     @Nullable
     public String description() {
         return NLS.smartGet(description);
+    }
+
+    /**
+     * Returns a short description, containing html tags, of the file.
+     *
+     * @return the description, containing html tags, of the file
+     */
+    @Nullable
+    public String htmlDescription() {
+        return NLS.smartGet(htmlDescription);
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -291,7 +291,7 @@ public abstract class VirtualFile extends Composable implements Comparable<Virtu
      */
     @Nullable
     public String htmlDescription() {
-        return NLS.smartGet(htmlDescription);
+        return htmlDescription;
     }
 
     /**

--- a/src/main/resources/default/templates/biz/storage/list.html.pasta
+++ b/src/main/resources/default/templates/biz/storage/list.html.pasta
@@ -102,10 +102,10 @@
                                         </div>
                                         <div>
                                             <small class="text-muted">
-                                                <i:if test="child.htmlDescription()==null">
-                                                    @child.description()
+                                                <i:if test="isFilled(child.htmlDescription())">
+                                                    <i:raw>@child.htmlDescription()</i:raw>
                                                     <i:else>
-                                                        <i:raw>@child.htmlDescription()</i:raw>
+                                                        @child.description()
                                                     </i:else>
                                                 </i:if>
                                             </small>

--- a/src/main/resources/default/templates/biz/storage/list.html.pasta
+++ b/src/main/resources/default/templates/biz/storage/list.html.pasta
@@ -101,7 +101,9 @@
                                             </a>
                                         </div>
                                         <div>
-                                            <small class="text-muted">@child.description()</small>
+                                            <small class="text-muted">
+                                                <i:raw>@child.description()</i:raw>
+                                            </small>
                                         </div>
                                     </td>
                                     <td class="text-right">

--- a/src/main/resources/default/templates/biz/storage/list.html.pasta
+++ b/src/main/resources/default/templates/biz/storage/list.html.pasta
@@ -102,7 +102,12 @@
                                         </div>
                                         <div>
                                             <small class="text-muted">
-                                                <i:raw>@child.description()</i:raw>
+                                                <i:if test="child.htmlDescription()==null">
+                                                    @child.description()
+                                                    <i:else>
+                                                        <i:raw>@child.htmlDescription()</i:raw>
+                                                    </i:else>
+                                                </i:if>
                                             </small>
                                         </div>
                                     </td>


### PR DESCRIPTION
### Description
Before:
![image](https://github.com/scireum/sirius-biz/assets/150906388/58813b64-18c7-479c-a110-e66a0dccc1f8)

After:
![image](https://github.com/scireum/sirius-biz/assets/150906388/a9237db1-b0cf-4d71-a9b3-65595fd3a6a4)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10603](https://scireum.myjetbrains.com/youtrack/issue/OX-10603)
- This PR is related to PR: https://github.com/scireum/oxomi/pull/10773

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
