### PR TITLE
Filter out duplicated defined custom-entries and only take the custom one

### DIFF
--- a/src/main/java/sirius/biz/codelists/CustomLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CustomLookupTable.java
@@ -107,7 +107,7 @@ class CustomLookupTable extends LookupTable {
                              baseTable.performSearch(searchTerm, Limit.UNLIMITED, language))
                      .skip(limit.getItemsToSkip())
                      .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems())
-                     .collect(Collectors.toMap(LookupTableEntry::getCode, Function.identity(), (a, b) -> a))
+                     .collect(filterCustomDuplicateCollector())
                      .values()
                      .stream();
     }

--- a/src/main/java/sirius/biz/codelists/CustomLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CustomLookupTable.java
@@ -95,10 +95,10 @@ class CustomLookupTable extends LookupTable {
         return Stream.concat(customTable.performSuggest(Limit.UNLIMITED, searchTerm, language),
                              baseTable.performSuggest(Limit.UNLIMITED, searchTerm, language))
                      .skip(limit.getItemsToSkip())
-                     .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems())
                      .collect(filterCustomDuplicateCollector())
                      .values()
-                     .stream();
+                     .stream()
+                     .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems());
     }
 
     @Override
@@ -106,20 +106,20 @@ class CustomLookupTable extends LookupTable {
         return Stream.concat(customTable.performSearch(searchTerm, Limit.UNLIMITED, language),
                              baseTable.performSearch(searchTerm, Limit.UNLIMITED, language))
                      .skip(limit.getItemsToSkip())
-                     .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems())
                      .collect(filterCustomDuplicateCollector())
                      .values()
-                     .stream();
+                     .stream()
+                     .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems());
     }
 
     @Override
     public Stream<LookupTableEntry> scan(String language, Limit limit) {
         return Stream.concat(customTable.scan(language, Limit.UNLIMITED), baseTable.scan(language, Limit.UNLIMITED))
                      .skip(limit.getItemsToSkip())
-                     .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems())
                      .collect(filterCustomDuplicateCollector())
                      .values()
-                     .stream();
+                     .stream()
+                     .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems());
     }
 
     @Override


### PR DESCRIPTION
### Description
This is needed to "override"  base defined entries in a custom file and not duplicate it in the system (where the difference is not easily visible)
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
