### PR TITLE
Allows to unlock all locks at once

### DIFF
--- a/src/main/resources/default/templates/biz/cluster/locks.html.pasta
+++ b/src/main/resources/default/templates/biz/cluster/locks.html.pasta
@@ -1,12 +1,16 @@
 <i:invoke template="/templates/biz/cluster/cluster.html.pasta" page="locks" title="Locks">
     <i:local name="locks" value="Injector.context().getPart(sirius.biz.locks.Locks.class)"/>
-    <i:local name="currentLocks" value="locks != null ? locks.getLocks() : java.util.ArrayList.new()"/>
+    <i:local name="currentLocks"
+             value="locks != null ? locks.getLocks() : java.util.ArrayList.new().stream().toList()"/>
 
     <i:block name="breadcrumbs">
         <li><a href="/system/cluster/locks">Locks</a></li>
     </i:block>
 
     <i:block name="actions">
+        <i:local name="locks" value="Injector.context().getPart(sirius.biz.locks.Locks.class)"/>
+        <i:local name="currentLocks"
+                 value="locks != null ? locks.getLocks() : java.util.ArrayList.new().stream().toList()"/>
         <i:if test="currentLocks != null && !currentLocks.isEmpty()">
             <a href="@apply('/system/cluster/locks/release-all')"
                class="btn btn-outline-danger confirm-link-js">


### PR DESCRIPTION
### Description

Redefining the locals inside is a workaround for locals seemingly not being passed into a block.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-928](https://scireum.myjetbrains.com/youtrack/issue/SIRI-928)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
