### PR TITLE
Defines a new permission for unlocking files

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
@@ -40,6 +40,11 @@ import java.util.function.Function;
 public class VirtualFileSystem {
 
     /**
+     * Contains the permission required to unlock files.
+     */
+    public static final String PERMISSION_UNLOCK_FILES = "permission-unlock-files";
+
+    /**
      * Defines the name of the sub scope used by the {@link sirius.biz.storage.layer3.downlink.ftp.FTPServer} and
      * {@link sirius.biz.storage.layer3.downlink.ssh.SSHServer} which grants access per FTP, SFTP or SCP.
      */

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystemController.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystemController.java
@@ -10,7 +10,6 @@ package sirius.biz.storage.layer3;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import sirius.biz.storage.layer2.Blob;
-import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.tycho.QuickAction;
 import sirius.biz.tycho.UserAssistant;
 import sirius.biz.web.BizController;
@@ -324,7 +323,7 @@ public class VirtualFileSystemController extends BizController {
      */
     @LoginRequired
     @Routed("/fs/unlock")
-    @Permission(TenantUserManager.PERMISSION_SYSTEM_ADMINISTRATOR)
+    @Permission(VirtualFileSystem.PERMISSION_UNLOCK_FILES)
     public void unlock(WebContext webContext) {
         VirtualFile file = vfs.resolve(webContext.get("path").asString());
         if (!file.exists()) {

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1486,6 +1486,7 @@ security {
             permission-delete-user-accounts = true
             permission-control-disaster-mode = true
             permission-system-scripting = true
+            permission-unlock-files = true
 
             # By default we only permit sys admins to change the configs of any user in any
             # tenant as this is quite a specific and dangerous task...

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1419,6 +1419,7 @@ security {
         permission-view-files           : "Required to view files stored in the system"
         permission-view-processes       : "Required to view processes"
         permission-view-audit-log       : "Required to view the audit log"
+        permission-unlock-files         : "Required to unlock read-only files"
 
         feature-bypass-process-log-limits : "Required to bypass log limits of processes via a job parameter"
 

--- a/src/main/resources/default/templates/biz/storage/list.html.pasta
+++ b/src/main/resources/default/templates/biz/storage/list.html.pasta
@@ -162,7 +162,7 @@
                                                 </t:dropdownSection>
                                             </i:if>
 
-                                            <t:permission permission="flag-system-administrator">
+                                            <t:permission permission="permission-unlock-files">
                                                 <i:if test="child.readOnly()">
                                                     <t:dropdownItem
                                                             url="@apply('/fs/unlock?path=%s', urlEncode(child.path()))"


### PR DESCRIPTION
### Description

The new permission `permission-unlock-files` is now used to allow a user to unlock files, which the goal to customized roles to support this action.

Sys admins have the permission by default, thus non-breaking.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-927](https://scireum.myjetbrains.com/youtrack/issue/SIRI-927)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
