### PR TITLE
Avoids computing metrics for user education

### DIFF
--- a/src/main/java/sirius/biz/tenants/metrics/computers/UserAccountAcademyMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/metrics/computers/UserAccountAcademyMetricComputer.java
@@ -58,6 +58,9 @@ public abstract class UserAccountAcademyMetricComputer<E extends BaseEntity<?> &
 
     @Override
     public void compute(MetricComputerContext context, E userAccount) throws Exception {
+        if (!context.periodOutsideOfCurrentInterest()) {
+            return;
+        }
         long totalVideos = queryEligibleOnboardingVideos(userAccount).count();
 
         if (totalVideos == 0) {
@@ -77,12 +80,10 @@ public abstract class UserAccountAcademyMetricComputer<E extends BaseEntity<?> &
         int educationLevel = (int) (watchedVideos * 100 / totalVideos);
         metrics.updateMonthlyMetric(userAccount, METRIC_USER_EDUCATION_LEVEL, context.date(), educationLevel);
 
-        if (!context.periodOutsideOfCurrentInterest()) {
-            userAccount.getPerformanceData()
-                       .modify()
-                       .set(getAcademyUserFlag(), educationLevel >= minEducationLevel)
-                       .commit();
-        }
+        userAccount.getPerformanceData()
+                   .modify()
+                   .set(getAcademyUserFlag(), educationLevel >= minEducationLevel)
+                   .commit();
     }
 
     /**


### PR DESCRIPTION
### Description

The onboarding videos have no history like event, therefore counts are only valid in the current period of interest.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10593](https://scireum.myjetbrains.com/youtrack/issue/OX-10593)

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
