### PR TITLE
Improvements handling S3 responses

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -10,6 +10,7 @@ package sirius.biz.storage.layer1;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.http.ConnectionClosedException;
 import sirius.biz.storage.layer1.replication.ReplicationManager;
 import sirius.biz.storage.layer1.transformer.ByteBlockTransformer;
 import sirius.biz.storage.layer1.transformer.CipherFactory;
@@ -550,7 +551,10 @@ public abstract class ObjectStorageSpace {
     }
 
     private void handleDeliveryError(Response response, String objectId, Exception exception) {
-        if (exception instanceof ClosedChannelException || exception.getCause() instanceof ClosedChannelException) {
+        if (exception instanceof ClosedChannelException
+            || exception.getCause() instanceof ClosedChannelException
+            || exception instanceof ConnectionClosedException
+            || exception.getCause() instanceof ConnectionClosedException) {
             // If the user unexpectedly closes the connection, we do not need to log an error...
             Exceptions.ignore(exception);
             return;

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -35,6 +35,7 @@ import sirius.web.http.Response;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.ClosedChannelException;
@@ -350,6 +351,9 @@ public abstract class ObjectStorageSpace {
             } else {
                 return Optional.ofNullable(getData(objectId));
             }
+        } catch (FileNotFoundException exception) {
+            StorageUtils.LOG.WARN(exception.getMessage());
+            return Optional.empty();
         } catch (IOException exception) {
             throw Exceptions.handle()
                             .error(exception)
@@ -460,6 +464,9 @@ public abstract class ObjectStorageSpace {
             } else {
                 return Optional.ofNullable(getAsStream(objectId));
             }
+        } catch (FileNotFoundException exception) {
+            StorageUtils.LOG.WARN(exception.getMessage());
+            return Optional.empty();
         } catch (IOException exception) {
             throw Exceptions.handle()
                             .error(exception)

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -217,9 +217,9 @@ public abstract class ObjectStorageSpace {
                 storePhysicalObject(objectId, file);
                 replicationManager.notifyAboutUpdate(this, objectId, file.length());
             }
-        } catch (IOException e) {
+        } catch (IOException exception) {
             throw Exceptions.handle()
-                            .error(e)
+                            .error(exception)
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage("Layer 1: An error occurred when uploading %s to %s (%s): %s (%s)",
                                                     file.getAbsolutePath(),
@@ -291,9 +291,9 @@ public abstract class ObjectStorageSpace {
                 storePhysicalObject(objectId, inputStream, contentLength);
                 replicationManager.notifyAboutUpdate(this, objectId, contentLength);
             }
-        } catch (IOException e) {
+        } catch (IOException exception) {
             throw Exceptions.handle()
-                            .error(e)
+                            .error(exception)
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage("Layer 1: An error occurred when uploading data to %s (%s): %s (%s)",
                                                     objectId,
@@ -350,9 +350,9 @@ public abstract class ObjectStorageSpace {
             } else {
                 return Optional.ofNullable(getData(objectId));
             }
-        } catch (IOException e) {
+        } catch (IOException exception) {
             throw Exceptions.handle()
-                            .error(e)
+                            .error(exception)
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage("Layer 1: An error occurred when downloading %s (%s): %s (%s)",
                                                     objectId,
@@ -460,9 +460,9 @@ public abstract class ObjectStorageSpace {
             } else {
                 return Optional.ofNullable(getAsStream(objectId));
             }
-        } catch (IOException e) {
+        } catch (IOException exception) {
             throw Exceptions.handle()
-                            .error(e)
+                            .error(exception)
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage(
                                     "Layer 1: An error occurred when obtaining an input stream for %s (%s): %s (%s)",
@@ -636,9 +636,9 @@ public abstract class ObjectStorageSpace {
         try {
             deletePhysicalObject(objectId);
             replicationManager.notifyAboutDelete(this, objectId);
-        } catch (IOException e) {
+        } catch (IOException exception) {
             throw Exceptions.handle()
-                            .error(e)
+                            .error(exception)
                             .to(StorageUtils.LOG)
                             .withSystemErrorMessage("Layer 1: An error occurred when deleting %s (%s): %s (%s)",
                                                     objectId,

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.storage.layer1;
 
+import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import sirius.biz.storage.layer1.replication.ReplicationManager;
 import sirius.biz.storage.layer1.transformer.ByteBlockTransformer;
@@ -219,14 +220,13 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
     @Nullable
     @Override
     protected InputStream getAsStream(String objectKey) throws IOException {
-        return store.getClient().getObject(bucketName().getName(), objectKey).getObjectContent();
+        return getS3Object(objectKey).getObjectContent();
     }
 
     @Nullable
     @Override
     protected InputStream getAsStream(String objectKey, ByteBlockTransformer transformer) throws IOException {
-        S3ObjectInputStream rawStream =
-                store.getClient().getObject(bucketName().getName(), objectKey).getObjectContent();
+        S3ObjectInputStream rawStream = getS3Object(objectKey).getObjectContent();
         return new TransformingInputStream(rawStream, transformer);
     }
 
@@ -272,5 +272,9 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
 
         // If source or target uses a transformer, we can no longer perform a straight copy.
         return !hasTransformer() && !s3ObjectStorageSpace.hasTransformer();
+    }
+
+    private S3Object getS3Object(String objectKey) {
+        return store.getClient().getObject(bucketName().getName(), objectKey);
     }
 }


### PR DESCRIPTION
### Description

- Handles a kind of rare error seen in our systems: `Premature end of Content-Length`
- Logs missing objects as warning and not a useless stack trace.

#### Before
<img width="1482" alt="image" src="https://github.com/scireum/sirius-biz/assets/54799255/061c5f4b-280a-40a5-9621-bd80a46c6264">

#### After
<img width="1481" alt="image" src="https://github.com/scireum/sirius-biz/assets/54799255/6d5b616a-aad7-485f-bc83-775cfe36ea16">

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-922](https://scireum.myjetbrains.com/youtrack/issue/SIRI-922)
- This PR fixes or works on following ticket(s): [SIRI-923](https://scireum.myjetbrains.com/youtrack/issue/SIRI-923)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
