### PR TITLE
Upgrades the mongo container to 6.0.13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     hostname: redis-jupiter
 
   mongo:
-    image: mongo:5.0.9
+    image: mongo:6.0.13
     ports:
       - "27017"
     hostname: mongo

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     hostname: redis-jupiter
 
   mongo:
-    image: mongo:5.0.9
+    image: mongo:6.0.13
     ports:
       - "27017"
     hostname: mongo


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [DO-139](https://scireum.myjetbrains.com/youtrack/issue/DO-139)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? Check if the `featureCompatibilityVersion` is currently set to 5.0 and if not, set it with the 2nd. command. After the container starts, set it to 6.0. If you do not use mongodb locally, you can delete the container as a new one will be created.

```js
db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )
db.adminCommand( { setFeatureCompatibilityVersion: "6.0" } )
```
