### PR TITLE
Improves query performance when directories are deleted

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -91,11 +91,15 @@ public class SQLProcessBlobChangesLoop extends ProcessBlobChangesLoop {
             oma.updateStatement(SQLDirectory.class)
                .set(SQLDirectory.DELETED, true)
                .set(SQLDirectory.PARENT, null)
+               .where(SQLDirectory.SPACE_NAME, dir.getSpaceName())
+               .where(SQLDirectory.DELETED, false)
                .where(SQLDirectory.PARENT, directoryId)
                .executeUpdate();
             oma.updateStatement(SQLBlob.class)
                .set(SQLBlob.DELETED, true)
                .set(SQLBlob.PARENT, null)
+               .where(SQLBlob.SPACE_NAME, dir.getSpaceName())
+               .where(SQLBlob.DELETED, false)
                .where(SQLBlob.PARENT, directoryId)
                .executeUpdate();
         } catch (SQLException e) {

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
@@ -92,10 +92,14 @@ public class MongoProcessBlobChangesLoop extends ProcessBlobChangesLoop {
         String directoryId = dir.getIdAsString();
         mongo.update()
              .set(MongoDirectory.DELETED, true)
+             .where(MongoDirectory.SPACE_NAME, dir.getSpaceName())
+             .where(MongoDirectory.DELETED, false)
              .where(MongoDirectory.PARENT, directoryId)
              .executeForMany(MongoDirectory.class);
         mongo.update()
              .set(MongoBlob.DELETED, true)
+             .where(MongoBlob.SPACE_NAME, dir.getSpaceName())
+             .where(MongoBlob.DELETED, false)
              .where(MongoBlob.PARENT, directoryId)
              .executeForMany(MongoBlob.class);
     }


### PR DESCRIPTION
### Description

when a directory is deleted, we mark all children as deleted as well. For this, we also provide the **spaceName** and **deleted** fields in the constraint in order to hit an index.

Children of a directory NEVER BELONGS to a different space than its parent.

You can temporarily mitigate this issue by adding a temporary index to `[MongoBlob|Sql]Blob.parent`

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-932](https://scireum.myjetbrains.com/youtrack/issue/SIRI-932)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
