### PR TITLE
ensure unique labels in import-dictionaries

### DIFF
--- a/src/main/java/sirius/biz/importer/format/ImportDictionary.java
+++ b/src/main/java/sirius/biz/importer/format/ImportDictionary.java
@@ -138,7 +138,7 @@ public class ImportDictionary {
     /**
      * Returns a list of all fields in this record.
      * <p>
-     * Note that this is not neccessarily in the expected order. Use the <tt>mapping function</tt> to specify the order.
+     * Note that this is not necessarily in the expected order. Use the <tt>mapping function</tt> to specify the order.
      *
      * @return the fields in this dictionary
      */

--- a/src/main/java/sirius/biz/importer/format/ImportDictionary.java
+++ b/src/main/java/sirius/biz/importer/format/ImportDictionary.java
@@ -61,6 +61,7 @@ public class ImportDictionary {
 
     private final Map<String, FieldDefinition> fields = new LinkedHashMap<>();
     private final Map<String, String> aliases = new LinkedHashMap<>();
+    private final Set<String> fieldLabels = new HashSet<>();
     private List<String> mappingFunction;
     private final List<Function<String, FieldDefinition>> computedFieldLookups = new ArrayList<>();
     private boolean hasIdentityMapping;
@@ -83,6 +84,8 @@ public class ImportDictionary {
                                                              field.getName()));
         }
 
+        ensureFieldLabelsUnique(field);
+
         this.fields.put(field.getName(), field);
 
         Set<String> aliasDuplicatesToRemove = new HashSet<>();
@@ -93,6 +96,14 @@ public class ImportDictionary {
         aliasDuplicatesToRemove.forEach(field::removeAlias);
 
         return this;
+    }
+
+    private void ensureFieldLabelsUnique(FieldDefinition field) {
+        // if the label is already present and would no longer be unique, qualify the label including the field name
+        if (fieldLabels.contains(field.getLabel())) {
+            field.withLabel(field.getLabel() + "_" + field.getName());
+        }
+        fieldLabels.add(field.getLabel());
     }
 
     private void addCheckedAlias(FieldDefinition field, String alias, Consumer<String> duplicateConsumer) {


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
Sometimes we have enhanced dictionaries where labels with the same name will be added and always an exception due to a doubled alias will be thrown. With this approach we suffix the labels with the name to ensure uniqueness. Example: WEIGHT and NET_WEIGHT both are translated with "Gewicht" and added to the same import-dictionary will result in "Gewicht" and "Gewicht_NET_WEIGHT" now. (see Screenshots)

- fixes: SE-13234
<img width="1105" alt="Bildschirmfoto 2024-02-08 um 11 35 41" src="https://github.com/scireum/sirius-biz/assets/55080004/673ee5fa-da48-4de2-a8a9-af2848346e0e">

<img width="571" alt="Bildschirmfoto 2024-02-08 um 11 35 08" src="https://github.com/scireum/sirius-biz/assets/55080004/f6b3a85a-73b2-4c18-aa7d-b030e800c823">


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-](https://scireum.myjetbrains.com/youtrack/issue/SIRI-)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
