### PR TITLE
Query Tool: Marks fields that are actually empty in DB

### DIFF
--- a/src/main/resources/default/templates/biz/model/query-results.html.pasta
+++ b/src/main/resources/default/templates/biz/model/query-results.html.pasta
@@ -121,6 +121,11 @@
                                             </i:if>
                                         </i:else>
                                     </i:if>
+                                    <i:if test="property.getValue(entity) != null && !type.isFetched(entity, property)">
+                                        <t:tag color="red" class="ml-2 ms-2">
+                                            Empty in DB
+                                        </t:tag>
+                                    </i:if>
                                 </td>
                             </tr>
                         </i:for>


### PR DESCRIPTION
### Description

This makes it actually possible to distinguish between values that are read from DB and values that are filled via the default value in the Java-Entity because the field is empty in the DB.

**Example:**

![image](https://github.com/scireum/sirius-biz/assets/2427877/84162c1c-cbd3-4ac8-ba7e-14c65410dc0b)

This field is actually not filled with the current date and time, but rather it is empty in the Database.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-935](https://scireum.myjetbrains.com/youtrack/issue/SIRI-935)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
