### PR TITLE
S3 Storage stream: Ignores SocketException

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -552,10 +552,10 @@ public abstract class ObjectStorageSpace {
     }
 
     private void handleDeliveryError(Response response, String objectId, Exception exception) {
-        if (canIgnoreException(exception, ClosedChannelException.class)
-            || canIgnoreException(exception,
-                                  ConnectionClosedException.class)
-            || canIgnoreException(exception, SocketException.class)) {
+        if (isExceptionOf(exception, ClosedChannelException.class)
+            || isExceptionOf(exception,
+                             ConnectionClosedException.class)
+            || isExceptionOf(exception, SocketException.class)) {
             // If the user unexpectedly closes the connection, we do not need to log an error...
             Exceptions.ignore(exception);
             return;
@@ -575,7 +575,7 @@ public abstract class ObjectStorageSpace {
                         .handle();
     }
 
-    private boolean canIgnoreException(Exception exception, Class<? extends Exception> clazz) {
+    private boolean isExceptionOf(Exception exception, Class<? extends Exception> clazz) {
         return clazz.isInstance(exception) || clazz.isInstance(exception.getCause());
     }
 


### PR DESCRIPTION
### Description

Kinda rare, since a ClosedChannelException is usually the exception by disconnection, but research in out haproxy logs shows client-disconnects when this exception is thrown.

### Additional Notes

- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/1928

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
