### PR TITLE
Avoids cursor exception processing analytic computers

### DIFF
--- a/src/main/java/sirius/biz/analytics/scheduler/BaseEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/BaseEntityBatchEmitter.java
@@ -131,6 +131,6 @@ public abstract class BaseEntityBatchEmitter<I, C extends Constraint, B extends 
             queryExtender.accept(query);
         }
 
-        ((Query<?, E, C>) query).iterateAll(entityConsumer);
+        ((Query<?, E, C>) query).streamBlockwise().forEach(entityConsumer);
     }
 }


### PR DESCRIPTION
By using streamBlockwise instead of interateAll.

Although batches are emitted to only 250 entities by default (can be overwritten), for each entity, all relevant computers are called, causing the cursor to remain open for quite a long time.

We've seen a MongoCursorNotFoundException at a productive MongoDB instance.

**BREAKING**: Note that mongo queries shall not provide sorting, which is incompatible with streamBlockwise.