### PR TITLE
fix rare case of sanitizing file names with illegal characters

### DIFF
--- a/src/main/java/sirius/biz/storage/util/StorageUtils.java
+++ b/src/main/java/sirius/biz/storage/util/StorageUtils.java
@@ -238,7 +238,7 @@ public class StorageUtils {
         if (Strings.isEmpty(name)) {
             return true;
         }
-        return SANITIZE_ILLEGAL_FILE_CHARS.split(name).length > 1 || SANITIZE_SLASHES.split(name).length > 1;
+        return SANITIZE_ILLEGAL_FILE_CHARS.matcher(name).find() || SANITIZE_SLASHES.matcher(name).find();
     }
 
     /**


### PR DESCRIPTION
in case of only illegal characters or e.g. single / \ | %,... we allowed the renaming and it could crash the file system

- fixes: SE-13427

### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13427](https://scireum.myjetbrains.com/youtrack/issue/SE-13427)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
