### PR TITLE
SIRI-942 revamp saving of code-list-entries

### DIFF
--- a/src/main/java/sirius/biz/codelists/CodeListController.java
+++ b/src/main/java/sirius/biz/codelists/CodeListController.java
@@ -121,17 +121,16 @@ public abstract class CodeListController<I extends Serializable, L extends BaseE
      *
      * @param webContext the current request
      * @param codeListId the code list of the entry
+     * @param entryId    the id of the entry or new if a new entry should be created
      */
     @LoginRequired
     @Permission(PERMISSION_MANAGE_CODELISTS)
-    @Routed("/code-list/:1/entry")
-    public void codeListEntry(WebContext webContext, String codeListId) {
+    @Routed("/code-list/:1/entry/:2")
+    public void codeListEntry(WebContext webContext, String codeListId, String entryId) {
         L codeList = findForTenant(codeLists.getListType(), codeListId);
         assertNotNew(codeList);
 
-        String code =
-                webContext.get(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.CODE).toString()).asString();
-        E codeListEntry = findOrCreateEntry(codeList, code);
+        E codeListEntry = find(codeLists.getEntryType(), entryId);
         setOrVerify(codeListEntry, codeListEntry.getCodeList(), codeList);
 
         boolean requestHandled =
@@ -142,8 +141,6 @@ public abstract class CodeListController<I extends Serializable, L extends BaseE
                       .template("/templates/biz/codelists/code-list-entry.html.pasta", codeList, codeListEntry);
         }
     }
-
-    protected abstract E findOrCreateEntry(L codeList, String code);
 
     /**
      * Deletes a code list.

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListController.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListController.java
@@ -16,7 +16,6 @@ import sirius.biz.codelists.CodeListEntryData;
 import sirius.biz.web.BasePageHelper;
 import sirius.biz.web.SQLPageHelper;
 import sirius.db.mixing.query.QueryField;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 
 import javax.annotation.Nonnull;
@@ -55,24 +54,5 @@ public class SQLCodeListController extends CodeListController<Long, SQLCodeList,
                                     QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.VALUE)),
                                     QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.ADDITIONAL_VALUE)),
                                     QueryField.contains(CodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.DESCRIPTION)));
-    }
-
-    @Override
-    protected SQLCodeListEntry findOrCreateEntry(SQLCodeList codeList, String code) {
-        if (Strings.isEmpty(code)) {
-            return new SQLCodeListEntry();
-        }
-
-        SQLCodeListEntry cle = oma.select(SQLCodeListEntry.class)
-                                  .eq(SQLCodeListEntry.CODE_LIST, codeList)
-                                  .eq(SQLCodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.CODE), code)
-                                  .queryFirst();
-        if (cle == null) {
-            cle = new SQLCodeListEntry();
-            cle.getCodeList().setValue(codeList);
-            cle.getCodeListEntryData().setCode(code);
-        }
-
-        return cle;
     }
 }

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListController.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListController.java
@@ -15,7 +15,6 @@ import sirius.biz.mongo.PrefixSearchableEntity;
 import sirius.biz.web.BasePageHelper;
 import sirius.biz.web.MongoPageHelper;
 import sirius.db.mixing.query.QueryField;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 
 import javax.annotation.Nonnull;
@@ -49,24 +48,5 @@ public class MongoCodeListController extends CodeListController<String, MongoCod
     @Override
     protected void applyCodeListEntrySearchFields(@Nonnull BasePageHelper<MongoCodeListEntry, ?, ?, ?> pageHelper) {
         pageHelper.withSearchFields(QueryField.startsWith(PrefixSearchableEntity.SEARCH_PREFIXES));
-    }
-
-    @Override
-    protected MongoCodeListEntry findOrCreateEntry(MongoCodeList codeList, String code) {
-        if (Strings.isEmpty(code)) {
-            return new MongoCodeListEntry();
-        }
-
-        MongoCodeListEntry cle = mango.select(MongoCodeListEntry.class)
-                                      .eq(MongoCodeListEntry.CODE_LIST, codeList)
-                                      .eq(MongoCodeListEntry.CODE_LIST_ENTRY_DATA.inner(CodeListEntryData.CODE), code)
-                                      .queryFirst();
-        if (cle == null) {
-            cle = new MongoCodeListEntry();
-            cle.getCodeList().setValue(codeList);
-            cle.getCodeListEntryData().setCode(code);
-        }
-
-        return cle;
     }
 }

--- a/src/main/resources/default/taglib/t/multiLanguageTextField.html.pasta
+++ b/src/main/resources/default/taglib/t/multiLanguageTextField.html.pasta
@@ -26,7 +26,7 @@
 
 <i:if test="value.isEnabled()">
     <div id="@wrapperId"
-         class="form-group mb-3 0@UserContext.get().signalFieldError(name) @class">
+         class="form-group mb-3 @UserContext.get().signalFieldError(name) @class">
         <i:if test="isFilled(label) || forceLabel">
             <label class="form-label"><span>@label</span></label>
         </i:if>

--- a/src/main/resources/default/templates/biz/codelists/code-list-entries.html.pasta
+++ b/src/main/resources/default/templates/biz/codelists/code-list-entries.html.pasta
@@ -3,7 +3,7 @@
 
 <i:invoke template="/templates/biz/codelists/code-list.html.pasta" codeList="codeList" page="entries">
     <t:searchHeader page="entries" baseUrl="@apply('/code-list/%s', codeList.getIdAsString())">
-        <t:createButton url="@apply('/code-list/%s/entry', codeList.getIdAsString())"/>
+        <t:createButton url="@apply('/code-list/%s/entry/new', codeList.getIdAsString())"/>
     </t:searchHeader>
 
     <t:emptyCheck data="entries">
@@ -30,7 +30,7 @@
                     <i:for type="sirius.biz.codelists.CodeListEntry" var="entry" items="entries.getItems()">
                         <tr>
                             <td>
-                                <a href="/code-list/@codeList.getIdAsString()/entry?codeListEntryData_code=@urlEncode(entry.getCodeListEntryData().getCode())">
+                                <a href="/code-list/@codeList.getIdAsString()/entry/@entry.getIdAsString()">
                                     @entry.getCodeListEntryData().getCode()
                                 </a><br>
                                 <small class="text-muted">@entry.getCodeListEntryData().getPriority()</small>

--- a/src/main/resources/default/templates/biz/codelists/code-list-entry.html.pasta
+++ b/src/main/resources/default/templates/biz/codelists/code-list-entry.html.pasta
@@ -10,11 +10,12 @@
             <a href="/code-list/@codeList.getIdAsString()">@codeList.getCodeListData().toString()</a>
         </li>
         <li>
-            <a href="/code-list/@codeList.getIdAsString()/entry">@entry.getCodeListEntryData()</a>
+            <a href="/code-list/@codeList.getIdAsString()/entry/@entry.getIdAsString()">@entry.getCodeListEntryData()</a>
         </li>
     </i:block>
 
-    <t:pageHeader title="@codeList.getCodeListData().getName() + ' - ' + entry.getCodeListEntryData().toString()">
+    <t:pageHeader
+            title="@codeList.getCodeListData().getName() + ' - ' + (entry.isNew() ? i18n('CodeListEntry.new') : entry.getCodeListEntryData().toString())">
         <i:block name="additionalActions">
             <i:if test="!entry.isNew()">
                 <t:dropdownDeleteItem
@@ -23,7 +24,7 @@
         </i:block>
     </t:pageHeader>
 
-    <t:editForm url="@apply('/code-list/%s/entry', codeList.getIdAsString())">
+    <t:editForm url="@apply('/code-list/%s/entry/%s', codeList.getIdAsString(), entry.getIdAsString())">
         <div class="row">
             <t:textfield name="codeListEntryData_code"
                          value="@entry.getCodeListEntryData().getCode()"


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
Due to changes of Bootstrap5 we set the code to disabled to have correct css. disabled field won't be sent in the request, so we change the route and include the id in the route. This also unifies the behaviour to many other routes, where /entity/new is the route to create a new entity and /entity/:1 will show the editor as well for entry with given id.

BREAKING - Changed behaviour: - if you create a new code-list-entry with an existing code we now no more edit the existing one (which was also kindly unintuitive until now) and will throw an error instead..

Occurrences of route-calling of `/code-list/:1/entry` must be changed to `/code-list/:1/entry/:2`

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-942](https://scireum.myjetbrains.com/youtrack/issue/SIRI-942)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
