### PR TITLE
Properly marks field as nullable

### DIFF
--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntry.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntry.java
@@ -94,6 +94,7 @@ public class KnowledgeBaseEntry extends SearchableEntity {
      * Contains a short and concise description of this article.
      */
     public static final Mapping DESCRIPTION = Mapping.named("description");
+    @NullAllowed
     @SearchContent
     private String description;
 


### PR DESCRIPTION
### Description
Before https://github.com/scireum/sirius-db/pull/647 the framework did not enforce this on Elasticentities. Now we must annotate the fields properly. 

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-939](https://scireum.myjetbrains.com/youtrack/issue/SIRI-939)
- This PR is related to PR: https://github.com/scireum/sirius-db/pull/647

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
