### PR TITLE
SAML: Redirect Fix

### DIFF
--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -104,7 +104,7 @@
             }
 
             try {
-                window.localStorage.setItem('samlPostLoginUri', '@originalUrl');
+                window.localStorage.setItem('samlPostLoginUri', '<i:raw>@originalUrl</i:raw>');
             } catch (e) {
                 console.log(e);
             }


### PR DESCRIPTION
### Description

In order to route back to the originally intended site after a SAML login, the login site stores the original URL in the local storage. This is done by passing the URL to the Pasta template and rendering the string as part of a respective JavaScript snippet. If a URL contains characters with significance in HTML such as `&`, though, the Pasta string renderer converts these to HTML entities unless everything is placed within `<i:raw>`.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-937](https://scireum.myjetbrains.com/youtrack/issue/SIRI-937)

### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
