### PR TITLE
Changes query behavior for /fs to from 'prefix' to 'contains'

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -804,8 +804,8 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
 
         SQLPageHelper<SQLBlob> pageHelper = SQLPageHelper.withQuery(blobsQuery)
                                                          .withContext(webContext)
-                                                         .withSearchFields(QueryField.startsWith(SQLBlob.NORMALIZED_FILENAME),
-                                                                           QueryField.startsWith(SQLBlob.FILE_EXTENSION));
+                                                         .withSearchFields(QueryField.contains(SQLBlob.NORMALIZED_FILENAME),
+                                                                           QueryField.contains(SQLBlob.FILE_EXTENSION));
 
         pageHelper.addQueryFacet(SQLBlob.FILE_EXTENSION.getName(),
                                  NLS.get("Blob.fileExtension"),

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -712,8 +712,8 @@ public class MongoBlobStorageSpace extends BasicBlobStorageSpace<MongoBlob, Mong
 
         MongoPageHelper<MongoBlob> pageHelper = MongoPageHelper.withQuery(blobsQuery)
                                                                .withContext(webContext)
-                                                               .withSearchFields(QueryField.startsWith(MongoBlob.NORMALIZED_FILENAME),
-                                                                                 QueryField.startsWith(MongoBlob.FILE_EXTENSION));
+                                                               .withSearchFields(QueryField.contains(MongoBlob.NORMALIZED_FILENAME),
+                                                                                 QueryField.contains(MongoBlob.FILE_EXTENSION));
 
         pageHelper.addTermAggregation(MongoBlob.FILE_EXTENSION);
         pageHelper.addTimeAggregation(MongoBlob.LAST_MODIFIED,


### PR DESCRIPTION
### Description
Changes query behavior for /fs to contains
- the assumption is that this will make sense in many use cases e.g. filename = "theSpecialFilename.txt" will be found when searching for "special"
- as a side effect, this will workaround the problem that the prefix query for sql will not find exact matches if the filename contains uppercase characters


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-951](https://scireum.myjetbrains.com/youtrack/issue/SIRI-951)

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
