### PR TITLE
Mark blob lowercased fields with sirius db annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>dev-42.5.0</sirius.kernel>
         <sirius.web>dev-78.3.0</sirius.web>
-        <sirius.db>dev-57.0.1</sirius.db>
+        <sirius.db>dev-57.1.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -24,6 +24,7 @@ import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.ComplexDelete;
 import sirius.db.mixing.annotations.Index;
 import sirius.db.mixing.annotations.Length;
+import sirius.db.mixing.annotations.LowerCase;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.annotations.TranslationSource;
@@ -118,6 +119,7 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
      */
     public static final Mapping NORMALIZED_FILENAME = Mapping.named("normalizedFilename");
     @NullAllowed
+    @LowerCase
     @Length(255)
     private String normalizedFilename;
 
@@ -128,6 +130,7 @@ public class SQLBlob extends SQLEntity implements Blob, OptimisticCreate {
      */
     public static final Mapping FILE_EXTENSION = Mapping.named("fileExtension");
     @NullAllowed
+    @LowerCase
     @Length(255)
     private String fileExtension;
 

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -21,6 +21,7 @@ import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.ComplexDelete;
 import sirius.db.mixing.annotations.Index;
+import sirius.db.mixing.annotations.LowerCase;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.annotations.TranslationSource;
@@ -130,6 +131,7 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
      */
     public static final Mapping NORMALIZED_FILENAME = Mapping.named("normalizedFilename");
     @NullAllowed
+    @LowerCase
     private String normalizedFilename;
 
     /**
@@ -139,6 +141,7 @@ public class MongoBlob extends MongoEntity implements Blob, OptimisticCreate {
      */
     public static final Mapping FILE_EXTENSION = Mapping.named("fileExtension");
     @NullAllowed
+    @LowerCase
     private String fileExtension;
 
     /**


### PR DESCRIPTION
### Description
Mark blob lowercased fields with sirius db annotation. The actual lowercasing cannot be removed, as it gets called within some additional logic and from other places

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-951](https://scireum.myjetbrains.com/youtrack/issue/SIRI-951)


### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
