### PR TITLE
Do not collect the dispatcher parameter when no scripts exist

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/ImportBatchProcessFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/ImportBatchProcessFactory.java
@@ -87,7 +87,7 @@ public abstract class ImportBatchProcessFactory extends BatchProcessJobFactory {
 
     @Override
     protected void collectParameters(Consumer<Parameter<?>> parameterCollector) {
-        if (enableScriptableEvents()) {
+        if (enableScriptableEvents() && !scriptableEvents.fetchDispatchersForCurrentTenant().isEmpty()) {
             parameterCollector.accept(createDispatcherParameter());
         }
     }


### PR DESCRIPTION
### Description

The parameter is required and should only be present if we have available scripts.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10898](https://scireum.myjetbrains.com/youtrack/issue/OX-10898)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
