### PR TITLE
SQLdirectory query lowercasing

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -31,6 +31,7 @@ import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
+import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
@@ -661,7 +662,7 @@ public class SQLBlobStorageSpace extends BasicBlobStorageSpace<SQLBlob, SQLDirec
            .eq(SQLDirectory.COMMITTED, true)
            .eq(SQLDirectory.DELETED, false)
            .where(OMA.FILTERS.like(SQLDirectory.NORMALIZED_DIRECTORY_NAME)
-                             .startsWith(prefixFilter)
+                             .startsWith(Value.of(prefixFilter).toLowerCase())
                              .ignoreEmpty()
                              .build())
            .limit(maxResults)

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
@@ -20,6 +20,7 @@ import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.Index;
 import sirius.db.mixing.annotations.Length;
+import sirius.db.mixing.annotations.LowerCase;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.types.BaseEntityRef;
@@ -76,6 +77,7 @@ public class SQLDirectory extends SQLEntity implements Directory, OptimisticCrea
      */
     public static final Mapping NORMALIZED_DIRECTORY_NAME = Mapping.named("normalizedDirectoryName");
     @Length(255)
+    @LowerCase
     @NullAllowed
     private String normalizedDirectoryName;
 
@@ -131,7 +133,7 @@ public class SQLDirectory extends SQLEntity implements Directory, OptimisticCrea
         if (Strings.isFilled(directoryName)) {
             this.directoryName = storageUtils.sanitizePath(directoryName);
             if (Strings.isFilled(directoryName)) {
-                this.normalizedDirectoryName = directoryName.toLowerCase();
+                this.normalizedDirectoryName = directoryName;
             } else {
                 this.directoryName = null;
                 this.normalizedDirectoryName = null;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
@@ -17,6 +17,7 @@ import sirius.biz.web.BasePageHelper;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.annotations.Index;
+import sirius.db.mixing.annotations.LowerCase;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.types.BaseEntityRef;
@@ -78,6 +79,7 @@ public class MongoDirectory extends MongoEntity implements Directory, Optimistic
      */
     public static final Mapping NORMALIZED_DIRECTORY_NAME = Mapping.named("normalizedDirectoryName");
     @NullAllowed
+    @LowerCase
     private String normalizedDirectoryName;
 
     /**
@@ -131,7 +133,7 @@ public class MongoDirectory extends MongoEntity implements Directory, Optimistic
         if (Strings.isFilled(directoryName)) {
             this.directoryName = storageUtils.sanitizePath(directoryName);
             if (Strings.isFilled(directoryName)) {
-                this.normalizedDirectoryName = directoryName.toLowerCase();
+                this.normalizedDirectoryName = directoryName;
             } else {
                 this.directoryName = null;
                 this.normalizedDirectoryName = null;


### PR DESCRIPTION
### Description
When querying for the lowercased filename field of an directory, query terms containing upper case characters make no sense and will be lower cased. 

Note: For MongoDB no changes are required, as it already works due to case insensitive prefix queries. 

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-951](https://scireum.myjetbrains.com/youtrack/issue/SIRI-951)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/1968

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
