### PR TITLE
Add some additional sandbox annotations for blob refs

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobHardRef.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobHardRef.java
@@ -101,6 +101,7 @@ public class BlobHardRef {
      * @return the formatted (human-readable) file size of the referenced blob or an empty string, if the reference
      * is empty
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String fetchFormattedSize() {
         return fetchBlob().map(Blob::getSize).map(NLS::formatSize).orElse("");
     }

--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRef.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRef.java
@@ -11,6 +11,7 @@ package sirius.biz.storage.layer2;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.types.BaseEntityRef;
 import sirius.kernel.commons.Strings;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nullable;
 import java.util.regex.Pattern;
@@ -89,6 +90,7 @@ public class BlobSoftRef extends BlobHardRef {
      *
      * @return <tt>true</tt> if a URL was stored, <tt>false</tt> if an object key or nothing yet is stored
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isURL() {
         return supportsURL && Strings.isFilled(key) && URL_PATTERN.matcher(key).find();
     }


### PR DESCRIPTION
### Description

This allows some more methods of BlobSoftRef and BlobHardRef in the noodle sandbox.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13581](https://scireum.myjetbrains.com/youtrack/issue/SE-13581)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
