### PR TITLE
Permits to only support login via hashed API tokens

### DIFF
--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1400,6 +1400,11 @@ security {
         # Disables API tokens by default, as these are constant and kept in clear-text and thus might impose a security
         # risk in generic setups. We still keep them around, mainly to support legacy systems.
         accept-api-tokens = false
+        # Disables hashed API tokens by default. These are a bit less security sensitive, as at least no cleartext value
+        # is sent over the wire. Still, the values remain as cleartext in the database and there is no real benefit over
+        # simply generating a long and secure password which is properly stored in the database. Still support can be
+        # enabled for legacy systems.
+        accept-hashed-api-tokens = false
         loginCookieTTL = 90 days
         default-language = "de"
         fallback-language = "en"


### PR DESCRIPTION
API tokens have already been deprecated for some time. Still some legacy systems need to support this approach. However, some systems now at least only rely in hashed tokens, which are way more secure as simply accepting a plaintext token which is also stored as plaintext in the DB.

Therefore, we now permit a more fine grained control over how kind of API tokens and authentication can be used.

Within the system config, next to "accept-api-tokens" one can also specify "accept-hashed-api-tokens". The former controls whether plaintext API keys can be used "just like a password" and the latter controls if a properly hashed version of the token is accepted. These two flags operate independently of each other.

NOTE: If "accept-api-tokens" was / is enabled, please review carefully, if now "accept-hashed-api-tokens" should be enabled, and also, if "accept-api-tokens" could be disabled after this change.

### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-](https://scireum.myjetbrains.com/youtrack/issue/SIRI-)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
