### PR TITLE
Improves the tenant select check

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantController.java
+++ b/src/main/java/sirius/biz/tenants/TenantController.java
@@ -417,6 +417,13 @@ public abstract class TenantController<I extends Serializable, T extends BaseEnt
             return;
         }
 
+        if (Strings.areEqual(getUser().getTenantId(), tenantId)) {
+            // The tenant of the current user we are spying is the same as the one we want to switch to,
+            // so we simply navigate to the target URL.
+            webContext.respondWith().redirectTemporarily(redirectTarget);
+            return;
+        }
+
         assertPermission(TenantUserManager.PERMISSION_SELECT_TENANT);
 
         Optional<T> tenant = resolveAccessibleTenant(tenantId, determineCurrentTenant(webContext));


### PR DESCRIPTION
When spying over a user WITHOUT the permission to select tenants and navigating to a URL of the same tenant being spied, we would get a permission failed check.

Note that a logged-in user can navigate to URLs of its own tenant, so we just extend that when spying on a foreign user.