### PR TITLE
SonarQube - Increase safeness of regexes by making quantifiers possessive/reluctant

### DIFF
--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseMessageExpander.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseMessageExpander.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 public class KnowledgeBaseMessageExpander implements MessageExpander {
 
     private static final Pattern LOCKED_KBA_PATTERN =
-            Pattern.compile("\\[(.*?)kba:([a-zA-Z0-9]+)(#[a-zA-Z0-9-_]+)?(.*)]");
+            Pattern.compile("\\[(.*?)kba:([a-zA-Z0-9]+)(#[a-zA-Z0-9-_]+)?(.*?)]");
     private static final Pattern KBA_PATTERN = Pattern.compile("kba:([a-zA-Z0-9]+)(#[a-zA-Z0-9-_]+)?");
 
     private static final String EXPANDED_LINK_TEMPLATE = """


### PR DESCRIPTION
### Description

SonarQube warns about these regex patterns being a potential risk of a DoS attack because of the default greedy behaviour of the included quantifiers. This can cause performance problems because of so called catastrophic backtracking situations. By switching problematic quantifiers
   to being possessive or reluctant these problems can no longer occur.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-9946](https://scireum.myjetbrains.com/youtrack/issue/OX-9946)
