### PR TITLE
Open Search - Ensure select link in user and tenant search results works

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/TenantSearchProvider.java
@@ -70,10 +70,9 @@ public abstract class TenantSearchProvider<I extends Serializable, T extends Bas
             if (currentUser.hasPermission(TenantUserManager.PERMISSION_SELECT_TENANT)) {
                 openSearchResult.withTemplateFromCode("""
                                                               <i:arg name="tenant" type="sirius.biz.tenants.Tenant"/>
-
                                                               @tenant.getTenantData().getAddress().getZip() @tenant.getTenantData().getAddress().getCity()
                                                               <br>
-                                                              <a href=/tenants/select/@tenant.getIdAsString()" class="card-link">@i18n("TenantController.select")</a>
+                                                              <a href="/tenants/select/@tenant.getIdAsString()" class="card-link">@i18n("TenantController.select")</a>
                                                               """, tenant);
             }
             resultCollector.accept(openSearchResult);

--- a/src/main/java/sirius/biz/tenants/UserAccountSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountSearchProvider.java
@@ -98,10 +98,9 @@ public abstract class UserAccountSearchProvider<I extends Serializable, T extend
             if (currentUser.hasPermission(TenantUserManager.PERMISSION_SELECT_USER_ACCOUNT)) {
                 openSearchResult.withTemplateFromCode("""
                                                               <i:arg name="user" type="sirius.biz.tenants.UserAccount"/>
-                                                                                                                            
                                                               @user (@user.getTenant().fetchValue().toString())
                                                               <br>
-                                                              <a href=/user-accounts/select/@user.getIdAsString()" class="card-link">@i18n("TenantController.select")</a>
+                                                              <a href="/user-accounts/select/@user.getIdAsString()" class="card-link">@i18n("TenantController.select")</a>
                                                               """, userAccount);
             }
             resultCollector.accept(openSearchResult);


### PR DESCRIPTION
### Description

This was caused by missing opening quotes of the href attribute.
Without it the closing quotes were added to the ID of the select link, breaking its functionality.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-957](https://scireum.myjetbrains.com/youtrack/issue/SIRI-957)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
