### PR TITLE
DH-240: Fix the SelectStringParameter.getValues() method. 

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/SelectStringParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/SelectStringParameter.java
@@ -82,10 +82,11 @@ public class SelectStringParameter extends SelectParameter<String, SelectStringP
      */
     @Override
     public List<Tuple<String, String>> getValues() {
-        return fetchEntriesMap().keySet()
-                                .stream()
-                                .map(entry -> Tuple.create(entry, NLS.smartGet(fetchEntriesMap().get(entry))))
-                                .toList();
+        Map<String, String> entriesMap = fetchEntriesMap();
+        return entriesMap.keySet()
+                         .stream()
+                         .map(entry -> Tuple.create(entry, NLS.smartGet(entriesMap.get(entry))))
+                         .toList();
     }
 
     @Override

--- a/src/main/java/sirius/biz/jobs/params/SelectStringParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/SelectStringParameter.java
@@ -82,11 +82,10 @@ public class SelectStringParameter extends SelectParameter<String, SelectStringP
      */
     @Override
     public List<Tuple<String, String>> getValues() {
-        Map<String, String> entriesMap = fetchEntriesMap();
-        return entriesMap.keySet()
-                         .stream()
-                         .map(entry -> Tuple.create(entry, NLS.smartGet(entriesMap.get(entry))))
-                         .toList();
+        return fetchEntriesMap().entrySet()
+                                .stream()
+                                .map(entry -> Tuple.create(entry.getKey(), NLS.smartGet(entry.getValue())))
+                                .toList();
     }
 
     @Override


### PR DESCRIPTION
### Description
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
Modifies the SelectStringParameter.getValues() method to use fetchEntriesMap() only one single time.

### Additional Notes

- This PR fixes or works on following ticket(s): [DH-240](https://scireum.myjetbrains.com/youtrack/issue/DH-240)
<!-- - This PR is related to PR: URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
