### PR TITLE
Makes scheduled entries directly executable from overview page

### DIFF
--- a/src/main/java/sirius/biz/jobs/scheduler/JobSchedulerLoop.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/JobSchedulerLoop.java
@@ -9,20 +9,13 @@
 package sirius.biz.jobs.scheduler;
 
 import sirius.biz.jobs.Jobs;
-import sirius.biz.process.ProcessContext;
-import sirius.biz.process.ProcessLink;
-import sirius.biz.process.Processes;
-import sirius.biz.process.logs.ProcessLog;
 import sirius.kernel.async.BackgroundLoop;
 import sirius.kernel.di.PartCollection;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
-import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
-import sirius.web.security.UserContext;
-import sirius.web.security.UserInfo;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,7 +31,7 @@ public class JobSchedulerLoop extends BackgroundLoop {
     private Jobs jobs;
 
     @Part
-    private Processes processes;
+    private ScheduledEntryExecution entryExecution;
 
     @Parts(SchedulerEntryProvider.class)
     private PartCollection<SchedulerEntryProvider<?>> providers;
@@ -77,7 +70,7 @@ public class JobSchedulerLoop extends BackgroundLoop {
             try {
                 if (entry.getSchedulerData().shouldRun(now)) {
                     entry = provider.fetchFullInformation(entry);
-                    executeJob(provider, entry, now);
+                    entryExecution.executeJob(provider, entry, now);
                     startedJobs++;
                 }
             } catch (Exception exception) {
@@ -93,67 +86,5 @@ public class JobSchedulerLoop extends BackgroundLoop {
         }
 
         return startedJobs;
-    }
-
-    private <J extends SchedulerEntry> void executeJob(SchedulerEntryProvider<J> provider, J entry, LocalDateTime now) {
-        try {
-            UserInfo user = UserContext.get().getUserManager().findUserByUserId(entry.getSchedulerData().getUserId());
-            UserContext.get().runAs(user, () -> executeJobAsUser(provider, entry, now));
-        } catch (Exception exception) {
-            Exceptions.handle()
-                      .to(Log.BACKGROUND)
-                      .error(exception)
-                      .withSystemErrorMessage("An error occurred while starting a scheduled task of %s: %s - %s (%s)",
-                                              provider.getClass().getSimpleName(),
-                                              entry)
-                      .handle();
-        }
-    }
-
-    private <J extends SchedulerEntry> void executeJobAsUser(SchedulerEntryProvider<J> provider,
-                                                             J entry,
-                                                             LocalDateTime now) {
-        processes.executeInStandbyProcessForCurrentTenant("biz-scheduler",
-                                                          () -> "Job Scheduler",
-                                                          ctx -> executeJobInProcess(provider, entry, now, ctx));
-    }
-
-    private <J extends SchedulerEntry> void executeJobInProcess(SchedulerEntryProvider<J> provider,
-                                                                J entry,
-                                                                LocalDateTime now,
-                                                                ProcessContext ctx) {
-        if (ctx.isDebugging()) {
-            ctx.debug(ProcessLog.info()
-                                .withFormattedMessage("Starting scheduled job %s (%s) for user %s.",
-                                                      entry,
-                                                      entry.getJobConfigData().getJobName(),
-                                                      UserContext.getCurrentUser().getUserName()));
-        }
-
-        try {
-            String processId = entry.getJobConfigData()
-                                    .getJobFactory()
-                                    .startInBackground(entry.getJobConfigData()::fetchParameter);
-
-            if (processId != null) {
-                processes.log(processId,
-                              ProcessLog.info()
-                                        .withNLSKey("JobSchedulerLoop.scheduledExecutionInfo")
-                                        .withContext("entry", entry.toString()));
-                processes.addLink(processId,
-                                  new ProcessLink().withLabel("$JobSchedulerLoop.jobLink")
-                                                   .withUri("/jobs/scheduler/entry/" + entry.getIdAsString()));
-                processes.addReference(processId, entry.getUniqueName());
-            }
-
-            provider.markExecuted(entry, now);
-        } catch (HandledException exception) {
-            ctx.log(ProcessLog.error()
-                              .withFormattedMessage("Failed to start scheduled job %s (%s) for user %s: %s",
-                                                    entry,
-                                                    entry.getJobConfigData().getJobName(),
-                                                    UserContext.getCurrentUser().getUserName(),
-                                                    exception.getMessage()));
-        }
     }
 }

--- a/src/main/java/sirius/biz/jobs/scheduler/ScheduledEntryExecution.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/ScheduledEntryExecution.java
@@ -1,0 +1,104 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.scheduler;
+
+import sirius.biz.jobs.Jobs;
+import sirius.biz.process.ProcessContext;
+import sirius.biz.process.ProcessLink;
+import sirius.biz.process.Processes;
+import sirius.biz.process.logs.ProcessLog;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.HandledException;
+import sirius.kernel.health.Log;
+import sirius.web.security.UserContext;
+import sirius.web.security.UserInfo;
+
+import java.time.LocalDateTime;
+
+/**
+ * Provides the logic to execute a scheduled entry with the appropriate settings.
+ */
+@Register(framework = Jobs.FRAMEWORK_JOBS, classes = ScheduledEntryExecution.class)
+public class ScheduledEntryExecution {
+
+    @Part
+    private Processes processes;
+
+    /**
+     * Executes the provided scheduled entry immediately using the given provider.
+     *
+     * @param provider The provider which manages data persistence for the given entry
+     * @param entry    the entry to execute
+     * @param now      the current time to be used for marking the job execution
+     * @param <J>      the type of the entry to execute
+     */
+    public <J extends SchedulerEntry> void executeJob(SchedulerEntryProvider<J> provider, J entry, LocalDateTime now) {
+        try {
+            UserInfo user = UserContext.get().getUserManager().findUserByUserId(entry.getSchedulerData().getUserId());
+            UserContext.get().runAs(user, () -> executeJobAsUser(provider, entry, now));
+        } catch (Exception exception) {
+            Exceptions.handle()
+                      .to(Log.BACKGROUND)
+                      .error(exception)
+                      .withSystemErrorMessage("An error occurred while starting a scheduled task of %s: %s - %s (%s)",
+                                              provider.getClass().getSimpleName(),
+                                              entry)
+                      .handle();
+        }
+    }
+
+    private <J extends SchedulerEntry> void executeJobAsUser(SchedulerEntryProvider<J> provider,
+                                                             J entry,
+                                                             LocalDateTime now) {
+        processes.executeInStandbyProcessForCurrentTenant("biz-scheduler",
+                                                          () -> "Job Scheduler",
+                                                          ctx -> executeJobInProcess(provider, entry, now, ctx));
+    }
+
+    private <J extends SchedulerEntry> void executeJobInProcess(SchedulerEntryProvider<J> provider,
+                                                                J entry,
+                                                                LocalDateTime now,
+                                                                ProcessContext ctx) {
+        if (ctx.isDebugging()) {
+            ctx.debug(ProcessLog.info()
+                                .withFormattedMessage("Starting scheduled job %s (%s) for user %s.",
+                                                      entry,
+                                                      entry.getJobConfigData().getJobName(),
+                                                      UserContext.getCurrentUser().getUserName()));
+        }
+
+        try {
+            String processId = entry.getJobConfigData()
+                                    .getJobFactory()
+                                    .startInBackground(entry.getJobConfigData()::fetchParameter);
+
+            if (processId != null) {
+                processes.log(processId,
+                              ProcessLog.info()
+                                        .withNLSKey("JobSchedulerLoop.scheduledExecutionInfo")
+                                        .withContext("entry", entry.toString()));
+                processes.addLink(processId,
+                                  new ProcessLink().withLabel("$JobSchedulerLoop.jobLink")
+                                                   .withUri("/jobs/scheduler/entry/" + entry.getIdAsString()));
+                processes.addReference(processId, entry.getUniqueName());
+            }
+
+            provider.markExecuted(entry, now);
+        } catch (HandledException exception) {
+            ctx.log(ProcessLog.error()
+                              .withFormattedMessage("Failed to start scheduled job %s (%s) for user %s: %s",
+                                                    entry,
+                                                    entry.getJobConfigData().getJobName(),
+                                                    UserContext.getCurrentUser().getUserName(),
+                                                    exception.getMessage()));
+        }
+    }
+}

--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerController.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerController.java
@@ -11,19 +11,16 @@ package sirius.biz.jobs.scheduler;
 import sirius.biz.jobs.JobConfigData;
 import sirius.biz.jobs.JobFactory;
 import sirius.biz.jobs.Jobs;
-import sirius.biz.process.Process;
 import sirius.biz.process.Processes;
 import sirius.biz.web.BasePageHelper;
 import sirius.biz.web.BizController;
 import sirius.biz.web.TenantAware;
-import sirius.db.es.ElasticQuery;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.query.QueryField;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.PartCollection;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
-import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 import sirius.web.controller.AutocompleteHelper;
 import sirius.web.controller.Routed;
@@ -138,18 +135,10 @@ public abstract class SchedulerController<J extends BaseEntity<?> & SchedulerEnt
         }
 
         executeInBelongingProvider(entry);
-
-        webContext.respondWith().redirectToGet("/ps/" + fetchLatestProcess(entry).getIdAsString());
-    }
-
-    private Process fetchLatestProcess(J entry) {
-        ElasticQuery<Process> query = processes.queryProcessesForCurrentUser();
-        query.eqIgnoreNull(Process.REFERENCES, entry.getUniqueName());
-        query.orderDesc(Process.STARTED);
-        return query.first()
-                    .orElseThrow(() -> Exceptions.createHandled()
-                                                 .withNLSKey("SchedulerController.noProcessFound")
-                                                 .handle());
+        String entryProcessesUrl = Strings.apply("/ps?reference=%s&reference-label=%s",
+                                                 entry.getUniqueName(),
+                                                 Strings.urlEncode(entry.toString()));
+        webContext.respondWith().redirectToGet(entryProcessesUrl);
     }
 
     private void executeInBelongingProvider(J entry) {

--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerController.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerController.java
@@ -127,8 +127,8 @@ public abstract class SchedulerController<J extends BaseEntity<?> & SchedulerEnt
      * @param webContext the current request
      * @param entryId    the id of the entry to display or <tt>new</tt> to create a new one
      */
-    @Permission(PERMISSION_MANAGE_SCHEDULER)
-    @Routed("/jobs/scheduler/execute-entry/:1")
+    @Permission(Jobs.PERMISSION_EXECUTE_JOBS)
+    @Routed("/jobs/scheduler/:1/execute")
     public void executeSchedulerEntry(WebContext webContext, String entryId) {
         J entry = findForTenant(getEntryType(), entryId);
 

--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerController.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerController.java
@@ -93,8 +93,8 @@ public abstract class SchedulerController<J extends BaseEntity<?> & SchedulerEnt
     /**
      * Renders a details page for the given scheduler entry.
      *
-     * @param webContext     the current request
-     * @param entryId the id of the entry to display or <tt>new</tt> to create a new one
+     * @param webContext the current request
+     * @param entryId    the id of the entry to display or <tt>new</tt> to create a new one
      */
     @Permission(PERMISSION_MANAGE_SCHEDULER)
     @Routed("/jobs/scheduler/entry/:1")
@@ -109,10 +109,11 @@ public abstract class SchedulerController<J extends BaseEntity<?> & SchedulerEnt
             return;
         }
 
-        boolean requestHandled = prepareSave(webContext).withAfterSaveURI("/jobs/scheduler").withPreSaveHandler(isNew -> {
-            loadUser(webContext, entry);
-            entry.getJobConfigData().loadFromContext(webContext);
-        }).saveEntity(entry);
+        boolean requestHandled =
+                prepareSave(webContext).withAfterSaveURI("/jobs/scheduler").withPreSaveHandler(isNew -> {
+                    loadUser(webContext, entry);
+                    entry.getJobConfigData().loadFromContext(webContext);
+                }).saveEntity(entry);
 
         if (!requestHandled) {
             validate(entry);
@@ -171,7 +172,8 @@ public abstract class SchedulerController<J extends BaseEntity<?> & SchedulerEnt
         UserInfo user = UserContext.get()
                                    .getUserManager()
                                    .findUserByUserId(webContext.get(SchedulerEntry.SCHEDULER_DATA.inner(SchedulerData.USER_ID)
-                                                                                          .toString()).asString());
+                                                                                                 .toString())
+                                                               .asString());
 
         // Ensure that an active and accessible user was selected...
         if (user == null || !Strings.areEqual(UserContext.getCurrentUser().getTenantId(), user.getTenantId())) {
@@ -214,8 +216,8 @@ public abstract class SchedulerController<J extends BaseEntity<?> & SchedulerEnt
     /**
      * Deletes the given scheduler entry.
      *
-     * @param webContext     the curren request
-     * @param entryId the id of the entry to delete
+     * @param webContext the curren request
+     * @param entryId    the id of the entry to delete
      */
     @Permission(PERMISSION_MANAGE_SCHEDULER)
     @Routed("/jobs/scheduler/entry/:1/delete")

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -929,6 +929,7 @@ SchedulerEntry.invalidPatternInField = Ungültiger Wert im Feld ${field}: ${msg}
 SchedulerEntry.lastExecution = Letzte Ausführung
 SchedulerEntry.minute = Minute
 SchedulerEntry.month = Monat
+SchedulerEntry.executeNow = Jetzt ausführen
 SchedulerEntry.numberOfExecutions = Anzahl Ausführungen
 SchedulerEntry.performedExecutions = Ausführungen
 SchedulerEntry.plural = Geplante Ausführungen

--- a/src/main/resources/default/templates/biz/jobs/scheduler/entries.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/scheduler/entries.html.pasta
@@ -34,6 +34,10 @@
                                 url="@apply('/ps?reference=%s&reference-label=%s', entry.getUniqueName(), urlEncode(entry.toString()))"
                                 icon="fa-solid fa-list"
                                 labelKey="SchedulerEntry.performedExecutions"/>
+                        <t:dropdownItem
+                                url="@apply('/jobs/scheduler/execute-entry/%s', entry.getIdAsString())"
+                                icon="fa-solid fa-play"
+                                labelKey="SchedulerEntry.executeNow"/>
                         <t:dropdownDeleteItem
                                 url="@apply('/jobs/scheduler/entry/%s/delete', entry.getIdAsString())"/>
                     </i:block>

--- a/src/main/resources/default/templates/biz/jobs/scheduler/entries.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/scheduler/entries.html.pasta
@@ -35,7 +35,7 @@
                                 icon="fa-solid fa-list"
                                 labelKey="SchedulerEntry.performedExecutions"/>
                         <t:dropdownItem
-                                url="@apply('/jobs/scheduler/execute-entry/%s', entry.getIdAsString())"
+                                url="@apply('/jobs/scheduler/%s/execute', entry.getIdAsString())"
                                 icon="fa-solid fa-play"
                                 labelKey="SchedulerEntry.executeNow"/>
                         <t:dropdownDeleteItem


### PR DESCRIPTION
### Description
This PR introduces a button on the scheduled entries overview page, that allows to directly execute a selected scheduled entry.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-941](https://scireum.myjetbrains.com/youtrack/issue/SIRI-941)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
