### PR TITLE
Limits the maximum length of a error message to 16k

### DIFF
--- a/src/main/java/sirius/biz/protocol/StoredIncident.java
+++ b/src/main/java/sirius/biz/protocol/StoredIncident.java
@@ -29,7 +29,7 @@ public class StoredIncident extends SearchableEntity {
     /**
      * Defines the maximum length of the message.
      */
-    private static final int MAX_MESSAGE_LENGTH = 16384;
+    private static final int MAX_MESSAGE_LENGTH = 16_000;
 
     /**
      * Contains the error message.

--- a/src/main/java/sirius/biz/protocol/StoredIncident.java
+++ b/src/main/java/sirius/biz/protocol/StoredIncident.java
@@ -13,7 +13,9 @@ import sirius.biz.elastic.SearchableEntity;
 import sirius.db.es.annotations.ESOption;
 import sirius.db.es.annotations.IndexMode;
 import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.BeforeSave;
 import sirius.db.mixing.types.StringMap;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Framework;
 
 import java.time.LocalDateTime;
@@ -23,6 +25,11 @@ import java.time.LocalDateTime;
  */
 @Framework(Protocols.FRAMEWORK_PROTOCOLS)
 public class StoredIncident extends SearchableEntity {
+
+    /**
+     * Defines the maximum length of the message.
+     */
+    private static final int MAX_MESSAGE_LENGTH = 16384;
 
     /**
      * Contains the error message.
@@ -93,6 +100,17 @@ public class StoredIncident extends SearchableEntity {
     public static final Mapping USER = Mapping.named("user");
     @SearchContent
     private String user;
+
+    /**
+     * Truncates the message if it exceeds the maximum length.
+     */
+    @BeforeSave
+    protected void truncateMessage() {
+        if (message.length() > MAX_MESSAGE_LENGTH) {
+            message = Strings.limit(message, MAX_MESSAGE_LENGTH, true);
+            message += "\nThe error message was too long and has been truncated.";
+        }
+    }
 
     public String getMessage() {
         return message;


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-960](https://scireum.myjetbrains.com/youtrack/issue/SIRI-960)


### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

