### PR TITLE
Allow scripting events to fully skip entities

### DIFF
--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -85,7 +85,7 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
     /**
      * Defines a context key used to skip loading entities aborted via {@linkplain sirius.biz.scripting.ScriptableEvent script}
      */
-    protected static final String SCRIPT_ABORTED = "_SCRIPT_ABORTED_";
+    public static final String SCRIPT_ABORTED = "_SCRIPT_ABORTED_";
 
     /**
      * Creates a new instance for the given type of entities and import context.

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -83,6 +83,11 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
     private final Extension aliases;
 
     /**
+     * Defines a context key used to skip loading entities aborted via {@linkplain sirius.biz.scripting.ScriptableEvent script}
+     */
+    protected static final String SCRIPT_ABORTED = "_SCRIPT_ABORTED_";
+
+    /**
      * Creates a new instance for the given type of entities and import context.
      *
      * @param clazz   the type of entities being handled

--- a/src/main/java/sirius/biz/importer/ImportHandler.java
+++ b/src/main/java/sirius/biz/importer/ImportHandler.java
@@ -47,7 +47,8 @@ public interface ImportHandler<E extends BaseEntity<?>> {
      *
      * @param data   used to fill the newly created entity
      * @param entity the entity to be filled
-     * @return a new and not yet persisted entity filled with value from <tt>data</tt>
+     * @return a new and not yet persisted entity filled with value from <tt>data</tt> or <tt>null</tt> if the
+     * operation was aborted by an {@linkplain sirius.biz.scripting.ScriptableEvent event}
      */
     E load(Context data, E entity);
 
@@ -177,7 +178,7 @@ public interface ImportHandler<E extends BaseEntity<?>> {
      * Either persists or updates the given entity.
      *
      * @param entity the entity to update or persist.
-     * @return the updated or persisted entity
+     * @return the updated or persisted entity or <tt>null</tt> if the operation was aborted by an {@linkplain sirius.biz.scripting.ScriptableEvent event}
      */
     E createOrUpdateNow(E entity);
 

--- a/src/main/java/sirius/biz/importer/ImportHandler.java
+++ b/src/main/java/sirius/biz/importer/ImportHandler.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
  * available to the dependency injection framework using {@link sirius.kernel.di.std.Register}.
  * <p>
  * Which import handle is actually used for a type is determined by {@link ImporterContext#findHandler(Class)}. As the
- * factories are priorized, an existing handler can be overwritten by providing a customization which supplies a
+ * factories are prioritized, an existing handler can be overwritten by providing a customization which supplies a
  * factory with a lower {@link ImportHandlerFactory#getPriority() priority} for the same entity type.
  * <p>
  * An example which provides basic support for all sql based entities can be found in {@link SQLEntityImportHandler}.
@@ -161,7 +161,7 @@ public interface ImportHandler<E extends BaseEntity<?>> {
     /**
      * Permits to enforce some constraints before persisting an entity.
      * <p>
-     * This is autoamtically invoked by {@link #createOrUpdateNow(BaseEntity)} and all other save methods. It is however
+     * This is automatically invoked by {@link #createOrUpdateNow(BaseEntity)} and other save methods. It is however
      * made public as some jobs only verify the consistency of data without persisting anything.
      * <p>
      * This method should only rarely be overwritten as most checks should be either be performed during a load
@@ -191,7 +191,7 @@ public interface ImportHandler<E extends BaseEntity<?>> {
     /**
      * Either persists or updates the given entity - using a batch update if possible.
      * <p>
-     * If the entity doesn't exist yet, it will be immediatelly created. If it doesn exist,
+     * If the entity doesn't exist yet, it will be immediately created. If it doesn't exist,
      * it will be updated in the next batch execution. This can be used to ensure that entities
      * referenced by others are available but also that updates of non-critical fields are efficiently
      * executed as a JDBC batch.

--- a/src/main/java/sirius/biz/importer/Importer.java
+++ b/src/main/java/sirius/biz/importer/Importer.java
@@ -223,6 +223,9 @@ public class Importer implements Closeable {
      */
     @SuppressWarnings("unchecked")
     public <E extends BaseEntity<?>> E createOrUpdateNow(E entity) {
+        if (entity == null) {
+            return null;
+        }
         return context.findHandler((Class<E>) entity.getClass()).createOrUpdateNow(entity);
     }
 
@@ -244,6 +247,9 @@ public class Importer implements Closeable {
      */
     @SuppressWarnings("unchecked")
     public <E extends BaseEntity<?>> void createOrUpdateInBatch(E entity) {
+        if (entity == null) {
+            return;
+        }
         context.findHandler((Class<E>) entity.getClass()).createOrUpdateInBatch(entity);
     }
 

--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -48,7 +48,11 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
     @Override
     public E load(Context data, E entity) {
         if (context.getEventDispatcher().isActive()) {
-            context.getEventDispatcher().handleEvent(new BeforeLoadEvent<E>(entity, data, context));
+            BeforeLoadEvent<E> beforeLoadEvent = new BeforeLoadEvent<>(entity, data, context);
+            context.getEventDispatcher().handleEvent(beforeLoadEvent);
+            if (beforeLoadEvent.isAborted()) {
+                return null;
+            }
         }
 
         E result = load(data, entity, mappingsToLoad);

--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -144,7 +144,12 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
     public E createOrUpdateNow(E entity) {
         try {
             if (context.getEventDispatcher().isActive()) {
-                context.getEventDispatcher().handleEvent(new BeforeCreateOrUpdateEvent<E>(entity, context));
+                BeforeCreateOrUpdateEvent<E> beforeCreateOrUpdateEvent =
+                        new BeforeCreateOrUpdateEvent<>(entity, context);
+                context.getEventDispatcher().handleEvent(beforeCreateOrUpdateEvent);
+                if (beforeCreateOrUpdateEvent.isAborted()) {
+                    return null;
+                }
             }
 
             enforcePreSaveConstraints(entity);

--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -47,10 +47,15 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
 
     @Override
     public E load(Context data, E entity) {
+        if (data.containsKey(SCRIPT_ABORTED)) {
+            return null;
+        }
+
         if (context.getEventDispatcher().isActive()) {
             BeforeLoadEvent<E> beforeLoadEvent = new BeforeLoadEvent<>(entity, data, context);
             context.getEventDispatcher().handleEvent(beforeLoadEvent);
             if (beforeLoadEvent.isAborted()) {
+                data.put(SCRIPT_ABORTED, true);
                 return null;
             }
         }
@@ -61,6 +66,7 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
             AfterLoadEvent<E> afterLoadEvent = new AfterLoadEvent<>(result, data, context);
             context.getEventDispatcher().handleEvent(afterLoadEvent);
             if (afterLoadEvent.isAborted()) {
+                data.put(SCRIPT_ABORTED, true);
                 return null;
             }
         }
@@ -96,6 +102,7 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
             BeforeFindEvent<E> beforeFindEvent = new BeforeFindEvent<>((Class<E>) descriptor.getType(), data, context);
             context.getEventDispatcher().handleEvent(beforeFindEvent);
             if (beforeFindEvent.isAborted()) {
+                data.put(SCRIPT_ABORTED, true);
                 return Optional.empty();
             }
         }

--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -58,7 +58,11 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
         E result = load(data, entity, mappingsToLoad);
 
         if (context.getEventDispatcher().isActive()) {
-            context.getEventDispatcher().handleEvent(new AfterLoadEvent<E>(result, data, context));
+            AfterLoadEvent<E> afterLoadEvent = new AfterLoadEvent<>(result, data, context);
+            context.getEventDispatcher().handleEvent(afterLoadEvent);
+            if (afterLoadEvent.isAborted()) {
+                return null;
+            }
         }
 
         return result;

--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -85,8 +85,11 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
     @Override
     public final Optional<E> tryFind(Context data) {
         if (context.getEventDispatcher().isActive()) {
-            context.getEventDispatcher()
-                   .handleEvent(new BeforeFindEvent<E>((Class<E>) descriptor.getType(), data, context));
+            BeforeFindEvent<E> beforeFindEvent = new BeforeFindEvent<>((Class<E>) descriptor.getType(), data, context);
+            context.getEventDispatcher().handleEvent(beforeFindEvent);
+            if (beforeFindEvent.isAborted()) {
+                return Optional.empty();
+            }
         }
 
         return findByExample(data);

--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -142,6 +142,10 @@ public abstract class MongoEntityImportHandler<E extends MongoEntity> extends Ba
 
     @Override
     public E createOrUpdateNow(E entity) {
+        if (entity == null) {
+            return null;
+        }
+
         try {
             if (context.getEventDispatcher().isActive()) {
                 BeforeCreateOrUpdateEvent<E> beforeCreateOrUpdateEvent =

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -150,10 +150,15 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
 
     @Override
     public E load(Context data, E entity) {
+        if (data.containsKey(SCRIPT_ABORTED)) {
+            return null;
+        }
+
         if (context.getEventDispatcher().isActive()) {
             BeforeLoadEvent<E> beforeLoadEvent = new BeforeLoadEvent<>(entity, data, context);
             context.getEventDispatcher().handleEvent(beforeLoadEvent);
             if (beforeLoadEvent.isAborted()) {
+                data.put(SCRIPT_ABORTED, true);
                 return null;
             }
         }
@@ -164,6 +169,7 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
             AfterLoadEvent<E> afterLoadEvent = new AfterLoadEvent<>(result, data, context);
             context.getEventDispatcher().handleEvent(afterLoadEvent);
             if (afterLoadEvent.isAborted()) {
+                data.put(SCRIPT_ABORTED, true);
                 return null;
             }
         }
@@ -178,6 +184,7 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
             BeforeFindEvent<E> beforeFindEvent = new BeforeFindEvent<>((Class<E>) descriptor.getType(), data, context);
             context.getEventDispatcher().handleEvent(beforeFindEvent);
             if (beforeFindEvent.isAborted()) {
+                data.put(SCRIPT_ABORTED, true);
                 return Optional.empty();
             }
         }

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -256,6 +256,10 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
      * @return the updated or created entity or, if batch updates are active, the given entity
      */
     protected E createOrUpdate(E entity, boolean batch) {
+        if (entity == null) {
+            return null;
+        }
+
         try {
             if (context.getEventDispatcher().isActive()) {
                 BeforeCreateOrUpdateEvent<E> beforeCreateOrUpdateEvent =

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -161,7 +161,11 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
         E result = load(data, entity, mappingsToLoad);
 
         if (context.getEventDispatcher().isActive()) {
-            context.getEventDispatcher().handleEvent(new AfterLoadEvent<E>(result, data, context));
+            AfterLoadEvent<E> afterLoadEvent = new AfterLoadEvent<>(result, data, context);
+            context.getEventDispatcher().handleEvent(afterLoadEvent);
+            if (afterLoadEvent.isAborted()) {
+                return null;
+            }
         }
 
         return result;

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -167,8 +167,11 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
     @Override
     public Optional<E> tryFind(Context data) {
         if (context.getEventDispatcher().isActive()) {
-            context.getEventDispatcher()
-                   .handleEvent(new BeforeFindEvent<E>((Class<E>) descriptor.getType(), data, context));
+            BeforeFindEvent<E> beforeFindEvent = new BeforeFindEvent<>((Class<E>) descriptor.getType(), data, context);
+            context.getEventDispatcher().handleEvent(beforeFindEvent);
+            if (beforeFindEvent.isAborted()) {
+                return Optional.empty();
+            }
         }
 
         E example = loadForFind(data);

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -258,7 +258,12 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
     protected E createOrUpdate(E entity, boolean batch) {
         try {
             if (context.getEventDispatcher().isActive()) {
-                context.getEventDispatcher().handleEvent(new BeforeCreateOrUpdateEvent<E>(entity, context));
+                BeforeCreateOrUpdateEvent<E> beforeCreateOrUpdateEvent =
+                        new BeforeCreateOrUpdateEvent<>(entity, context);
+                context.getEventDispatcher().handleEvent(beforeCreateOrUpdateEvent);
+                if (beforeCreateOrUpdateEvent.isAborted()) {
+                    return null;
+                }
             }
 
             enforcePreSaveConstraints(entity);

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -151,7 +151,11 @@ public abstract class SQLEntityImportHandler<E extends SQLEntity> extends BaseIm
     @Override
     public E load(Context data, E entity) {
         if (context.getEventDispatcher().isActive()) {
-            context.getEventDispatcher().handleEvent(new BeforeLoadEvent<E>(entity, data, context));
+            BeforeLoadEvent<E> beforeLoadEvent = new BeforeLoadEvent<>(entity, data, context);
+            context.getEventDispatcher().handleEvent(beforeLoadEvent);
+            if (beforeLoadEvent.isAborted()) {
+                return null;
+            }
         }
 
         E result = load(data, entity, mappingsToLoad);

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
@@ -43,7 +43,7 @@ public class EntityImportJob<E extends BaseEntity<?>> extends DictionaryBasedImp
      */
     public static final Parameter<ImportMode> IMPORT_MODE_PARAMETER =
             new EnumParameter<>("importMode", "$EntityImportJobFactory.importMode", ImportMode.class).withDefault(
-                    ImportMode.NEW_AND_UPDATES)
+                                                                                                             ImportMode.NEW_AND_UPDATES)
                                                                                                      .markRequired()
                                                                                                      .withDescription(
                                                                                                              "$EntityImportJobFactory.importMode.help")
@@ -105,12 +105,12 @@ public class EntityImportJob<E extends BaseEntity<?>> extends DictionaryBasedImp
         }
 
         E entity = findAndLoad(context);
-        ErrorContext.get().performImport(entity::toString, () -> {
-            if (shouldSkip(entity)) {
-                process.incCounter("EntityImportJob.rowIgnored");
-                return;
-            }
+        if (shouldSkip(entity)) {
+            process.incCounter("EntityImportJob.rowIgnored");
+            return;
+        }
 
+        ErrorContext.get().performImport(entity::toString, () -> {
             fillAndVerify(entity, context);
             boolean isNew = entity.isNew();
 
@@ -152,7 +152,15 @@ public class EntityImportJob<E extends BaseEntity<?>> extends DictionaryBasedImp
     }
 
     protected boolean shouldSkip(E entity) {
-        return mode == ImportMode.NEW_ONLY && !entity.isNew() || (mode == ImportMode.UPDATE_ONLY && entity.isNew());
+        if (entity == null) {
+            return true;
+        }
+
+        if (mode == ImportMode.NEW_ONLY && !entity.isNew()) {
+            return true;
+        }
+
+        return mode == ImportMode.UPDATE_ONLY && entity.isNew();
     }
 
     /**

--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJob.java
@@ -194,6 +194,11 @@ public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransacti
         }
 
         E entity = findAndLoad(context);
+        if (shouldSkip(entity)) {
+            process.incCounter(NLS.get("EntityImportJob.rowIgnored"));
+            return;
+        }
+
         if (mode == SyncMode.DELETE_EXISTING) {
             if (!entity.isNew()) {
                 importer.deleteNow(entity);
@@ -206,11 +211,6 @@ public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransacti
 
     protected void createOrUpdateEntity(E entity, Context context, Watch watch) {
         try {
-            if (shouldSkip(entity)) {
-                process.incCounter(NLS.get("EntityImportJob.rowIgnored"));
-                return;
-            }
-
             fillAndVerify(entity, context);
             boolean isNew = entity.isNew();
 
@@ -249,7 +249,16 @@ public class RelationalEntityImportJob<E extends BaseEntity<?> & ImportTransacti
      * @return <tt>true</tt> if further processing should be skipped, <tt>false</tt> if the entity should be persisted
      */
     protected boolean shouldSkip(E entity) {
-        return mode == SyncMode.NEW_ONLY && !entity.isNew() || (mode == SyncMode.UPDATE_ONLY && entity.isNew());
+        if (entity == null) {
+            return true;
+        }
+        if (mode == SyncMode.NEW_ONLY && !entity.isNew()) {
+            return true;
+        }
+        if (mode == SyncMode.UPDATE_ONLY && entity.isNew()) {
+            return true;
+        }
+        return mode != SyncMode.DELETE_EXISTING;
     }
 
     /**

--- a/src/main/java/sirius/biz/scripting/ScriptableEvent.java
+++ b/src/main/java/sirius/biz/scripting/ScriptableEvent.java
@@ -28,6 +28,13 @@ public abstract class ScriptableEvent {
     protected boolean failed;
 
     /**
+     * Stores if an event handler marked the event as aborted.
+     * <p>
+     * This can be parsed by event callers to evaluate if an operation should be stopped.
+     */
+    private boolean aborted;
+
+    /**
      * Stores the exception which occurred while invoking an event handler.
      */
     protected HandledException error;
@@ -50,6 +57,24 @@ public abstract class ScriptableEvent {
      */
     public boolean isFailed() {
         return failed;
+    }
+
+    /**
+     * Determines if the event was marked as aborted.
+     * <p>
+     * This can be parsed by event callers to evaluate if an operation should be stopped.
+     *
+     * @return <tt>true</tt> if the event is marked as aborted, <tt>false</tt> otherwise
+     */
+    public boolean isAborted() {
+        return aborted;
+    }
+
+    /**
+     * Marks the event as aborted.
+     */
+    public void abort() {
+        this.aborted = true;
     }
 
     /**

--- a/src/main/java/sirius/biz/scripting/ScriptableEvent.java
+++ b/src/main/java/sirius/biz/scripting/ScriptableEvent.java
@@ -9,6 +9,7 @@
 package sirius.biz.scripting;
 
 import sirius.kernel.health.HandledException;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import java.util.Optional;
 
@@ -73,6 +74,7 @@ public abstract class ScriptableEvent {
     /**
      * Marks the event as aborted.
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public void abort() {
         this.aborted = true;
     }

--- a/src/main/java/sirius/biz/scripting/TypedScriptableEvent.java
+++ b/src/main/java/sirius/biz/scripting/TypedScriptableEvent.java
@@ -21,7 +21,7 @@ import sirius.pasta.noodle.sandbox.NoodleSandbox;
 public abstract class TypedScriptableEvent<T> extends ScriptableEvent {
 
     /**
-     * The of objects for which this event occurred.
+     * The type of object for which this event occurred.
      *
      * @return the type of object for which this event occurred
      */


### PR DESCRIPTION
### Description

Until now we were able to manipulate the context and/or entity being processed, but we did not have a way to fully skip an entity.

Now, events can call an `.abort()` method to abort the operations further down the line, example:
```js
registry.registerTypedHandler(sirius.biz.importer.BeforeFindEvent.class, Attachment.class, |event| {
    let context = event.getContext();
    if (context.getValue("type").equals("INSTALLATION_MANUAL")) {
        event.abort();
        log(event.getErrorContext().enhanceMessage("Skipped Installation Manual " + context.get("filePath")));
    }
});
```

- calling it in a BeforeFindEvent skips the entire lookup, load and upsert.
- calling it in a BeforeLoadEvent skips the load and upsert.
- calling it in an AfterLoadEvent or BeforeCreateOrUpdateEvent skips the upsert.

**This should be a non-breaking change**. Only highly customized jobs, which either override the mechanisms of finding, loading and creating entities and on system which have scripting enabled and plan to use this abort mechanism must be checked for potential NPEs if entities are used unchecked.

For reference, see the 2 generic Dictionary-Based import jobs (EntityImportJob, RelationalEntityImportJob) updated in this PR.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-953](https://scireum.myjetbrains.com/youtrack/issue/SIRI-953)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
