### PR TITLE
Permits to call methods via noodle scripts

### DIFF
--- a/src/main/java/sirius/biz/importer/BeforeCreateOrUpdateEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeCreateOrUpdateEvent.java
@@ -11,6 +11,7 @@ package sirius.biz.importer;
 import sirius.biz.scripting.TypedScriptableEvent;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.Entity;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 /**
  * Triggered within {@link ImportHandler#createOrUpdateNow(BaseEntity)} (or the batch equivalent) in order to update an
@@ -33,6 +34,7 @@ public class BeforeCreateOrUpdateEvent<E extends Entity> extends TypedScriptable
         this.entity = entity;
     }
 
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public E getEntity() {
         return entity;
     }
@@ -54,6 +56,7 @@ public class BeforeCreateOrUpdateEvent<E extends Entity> extends TypedScriptable
         return (Class<E>) entity.getClass();
     }
 
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public ImporterContext getImporterContext() {
         return importerContext;
     }


### PR DESCRIPTION
### Description

- BeforeCreateOrUpdateEvent.getEntity()
- BeforeCreateOrUpdateEvent.getImporterContext()

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-953](https://scireum.myjetbrains.com/youtrack/issue/SIRI-953)

### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
