### PR TITLE
ExtractArchiveJob: Handles unresolvable paths

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -184,7 +184,7 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
             return;
         }
 
-        String targetPath = getTargetPath(extractedFile, flattenDirectory);
+        String targetPath = computeTargetPath(extractedFile, flattenDirectory);
         VirtualFile targetFile = targetDirectory.resolve(targetPath);
         ArchiveExtractor.UpdateResult result = extractor.updateFile(extractedFile, targetFile, overrideMode);
         switch (result) {
@@ -197,7 +197,7 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
         log(process, extractedFile, targetFile, result.name());
     }
 
-    private String getTargetPath(ExtractedFile extractedFile, boolean flattenDirectory) {
+    private String computeTargetPath(ExtractedFile extractedFile, boolean flattenDirectory) {
         String targetPath = extractedFile.getFilePath();
         if (flattenDirectory) {
             return Files.getFilenameAndExtension(targetPath);

--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -185,7 +185,15 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
         }
 
         String targetPath = computeTargetPath(extractedFile, flattenDirectory);
-        VirtualFile targetFile = targetDirectory.resolve(targetPath);
+        VirtualFile targetFile = fetchTargetFile(targetDirectory, targetPath);
+        if (targetFile == null) {
+            process.log(ProcessLog.warn()
+                                  .withNLSKey("ExtractArchiveJob.emptyFile")
+                                  .withContext("filename", extractedFile.getFilePath()));
+            process.addTiming(FILE_SKIPPED_COUNTER, watch.elapsedMillis());
+            return;
+        }
+
         ArchiveExtractor.UpdateResult result = extractor.updateFile(extractedFile, targetFile, overrideMode);
         switch (result) {
             case CREATED -> process.addTiming("ExtractArchiveJob.fileCreated", watch.elapsedMillis());
@@ -195,6 +203,15 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
         }
 
         log(process, extractedFile, targetFile, result.name());
+    }
+
+    private VirtualFile fetchTargetFile(VirtualFile targetDirectory, String targetPath) {
+        try {
+            return targetDirectory.resolve(targetPath);
+        } catch (IllegalArgumentException _) {
+            // The path cannot be resolved into a sanitized target path
+            return null;
+        }
     }
 
     private String computeTargetPath(ExtractedFile extractedFile, boolean flattenDirectory) {


### PR DESCRIPTION
### Description

Previously an IllegalArgumentException aborted the unarchive process if a path cannot be converted to a sanitized target path.

Now we log it and keep going.

### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
