### PR TITLE
Detaches tenant scripting from sandbox

### DIFF
--- a/src/main/java/sirius/biz/scripting/mongo/MongoCustomEventDispatcherRepository.java
+++ b/src/main/java/sirius/biz/scripting/mongo/MongoCustomEventDispatcherRepository.java
@@ -86,7 +86,7 @@ public class MongoCustomEventDispatcherRepository implements ScriptableEventDisp
             }
 
             CompilationContext compilationContext =
-                    new CompilationContext(SourceCodeInfo.forInlineCode(script.getScript(), SandboxMode.WARN_ONLY));
+                    new CompilationContext(SourceCodeInfo.forInlineCode(script.getScript(), SandboxMode.DISABLED));
 
             compilationContext.getVariableScoper()
                               .defineVariable(Position.UNKNOWN,

--- a/src/main/java/sirius/biz/scripting/mongo/MongoCustomScriptController.java
+++ b/src/main/java/sirius/biz/scripting/mongo/MongoCustomScriptController.java
@@ -93,7 +93,7 @@ public class MongoCustomScriptController extends BizController {
         if (webContext.isSafePOST()) {
             String script = webContext.get(PARAM_SCRIPT).asString();
             CompilationContext compilationContext =
-                    new CompilationContext(SourceCodeInfo.forInlineCode(script, SandboxMode.WARN_ONLY));
+                    new CompilationContext(SourceCodeInfo.forInlineCode(script, SandboxMode.DISABLED));
             compilationContext.getVariableScoper()
                               .defineVariable(Position.UNKNOWN,
                                               MongoCustomEventDispatcherRepository.SCRIPT_PARAMETER_REGISTRY,


### PR DESCRIPTION
### Description

Since the creation of tenant-scripts are not open for end-customer, we detach them from sandboxed environments until we decide to open that functionality, where the whole sandboxing must be reviewed.

Reason being that many events are now not useful, if we cannot access methods from obtained objects. For example: the `AfterLoadEvent.getEntity()` will successfully return the entity being loaded, but from there no method can be called but a few such as `getIdAsString()`.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11008](https://scireum.myjetbrains.com/youtrack/issue/OX-11008)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
