### PR TITLE
Concatenates all error messages of an incident

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <url>https://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-42.8.0</sirius.kernel>
+        <sirius.kernel>dev-42.9.0</sirius.kernel>
         <sirius.web>dev-78.8.0</sirius.web>
         <sirius.db>dev-57.3.0</sirius.db>
     </properties>

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -175,7 +175,7 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
     private int calcCharactersPerMessage(Throwable throwable) {
         try {
             return maxMessageLength / Throwables.getCausalChain(throwable).size();
-        } catch (IllegalArgumentException _) {
+        } catch (IllegalArgumentException ignored) {
             return maxMessageLength;
         }
     }

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -129,8 +129,8 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
                 storedIncident.getMdc().put(tuple.getFirst(), tuple.getSecond());
             }
             storedIncident.setUser(UserContext.getCurrentUser().getProtocolUsername());
-            storedIncident.setMessage(NLS.toUserString(buildErrorMessages(incident.getException())));
-            storedIncident.setStack(NLS.toUserString(Exceptions.buildStackTraceWithoutErrorMessage(incident.getException())));
+            storedIncident.setMessage(buildErrorMessages(incident.getException()));
+            storedIncident.setStack(Exceptions.buildStackTraceWithoutErrorMessage(incident.getException()));
             storedIncident.setCategory(incident.getCategory());
             storedIncident.setLastOccurrence(LocalDateTime.now());
 

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -24,7 +24,6 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Incident;
 import sirius.kernel.health.LogMessage;
 import sirius.kernel.health.LogTap;
-import sirius.kernel.nls.NLS;
 import sirius.web.mails.MailLog;
 import sirius.web.security.UserContext;
 
@@ -42,6 +41,8 @@ import java.util.logging.Level;
 public class Protocols implements LogTap, ExceptionHandler, MailLog {
 
     private static final int DISABLE_ON_ERROR_PERIOD_MILLIS = 1000 * 60;
+
+    private static final int NUMBER_OF_CHARS_TO_PRESERVE_AT_THE_END_OF_AN_ERROR_MESSAGE = 1000;
 
     /**
      * Names the framework which must be enabled to activate all protocol features.
@@ -167,7 +168,8 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
     }
 
     private String truncateErrorMessage(String errorMessage, int length) {
-        return Strings.limit(errorMessage, length, true, true, 1000);
+        int charsToPreserveFromStart = Math.max(0, length - NUMBER_OF_CHARS_TO_PRESERVE_AT_THE_END_OF_AN_ERROR_MESSAGE);
+        return Strings.truncateMiddle(errorMessage, charsToPreserveFromStart, NUMBER_OF_CHARS_TO_PRESERVE_AT_THE_END_OF_AN_ERROR_MESSAGE);
     }
 
     private int calcCharactersPerMessage(Throwable throwable) {

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -154,8 +154,8 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
             // The first element of the causal chain is always the throwable followed by its cause hierarchy.
             // Therefore, the first element is skipped.
             Throwables.getCausalChain(throwable).stream().skip(1).forEach(cause -> {
-                stringBuilder.append("Caused by: ").append(cause.getClass().getName()).append(":").append("\n");
-                stringBuilder.append(truncateErrorMessage(cause.getMessage(), numberOfCharactersPerMessage)).append("\n");
+                stringBuilder.append("\n")append("Caused by: ").append(cause.getClass().getName()).append(":").append("\n");
+                stringBuilder.append(truncateErrorMessage(cause.getMessage(), numberOfCharactersPerMessage)).append("\n\n");
             });
         } catch (IllegalArgumentException exception) {
             // This happens if the causal chain has a circular reference.

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -154,7 +154,7 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
             // The first element of the causal chain is always the throwable followed by its cause hierarchy.
             // Therefore, the first element is skipped.
             Throwables.getCausalChain(throwable).stream().skip(1).forEach(cause -> {
-                stringBuilder.append("\n")append("Caused by: ").append(cause.getClass().getName()).append(":").append("\n");
+                stringBuilder.append("\n").append("Caused by: ").append(cause.getClass().getName()).append(":").append("\n");
                 stringBuilder.append(truncateErrorMessage(cause.getMessage(), numberOfCharactersPerMessage)).append("\n\n");
             });
         } catch (IllegalArgumentException exception) {

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -82,7 +82,7 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
     private AtomicLong disabledUntil;
 
     /**
-     * In case the ES cluster is unreachable or we can for some reason not log errors or log messages,
+     * In case the ES cluster is unreachable, or we can for some reason not log errors or log messages,
      * we disable the facility for one minute so that the local syslogs aren't jammed with errors.
      */
     private void disableForOneMinute() {


### PR DESCRIPTION
Since we removed the error messages from the stack trace we are moving the error messages of the incident to its designated field.

The added method makes sure that we do not exceed the total maxMessageLength by splitting the available characters between all messages.

Example:
![Bildschirmfoto 2024-05-16 um 15 19 48](https://github.com/scireum/sirius-biz/assets/106659278/035508b0-c25e-4a0f-af41-fcae641db862)
...
![Bildschirmfoto 2024-05-16 um 15 20 04](https://github.com/scireum/sirius-biz/assets/106659278/8075149d-07dc-4571-85a0-85919a0dd8a3)
...
![Bildschirmfoto 2024-05-16 um 15 20 21](https://github.com/scireum/sirius-biz/assets/106659278/2f487923-d9d6-4a97-833f-e13c42fb873b)

and the corresponding stack trace:
![Bildschirmfoto 2024-05-16 um 15 20 45](https://github.com/scireum/sirius-biz/assets/106659278/0ca3ac21-0868-4b08-801b-541d1a69d1e3)

-> This way we can make sure that we have only a limited amount of chars saved in the es entity and have a meaningfull and easy to understand stacktrace

### Requires

- https://github.com/scireum/sirius-kernel/pull/525
- https://github.com/scireum/sirius-kernel/pull/526

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-960](https://scireum.myjetbrains.com/youtrack/issue/SIRI-960)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
