### PR TITLE
SIRI-965: remove double methods and move to sirius-web and use them

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>dev-42.9.0</sirius.kernel>
         <sirius.web>dev-79.2.0</sirius.web>
-        <sirius.db>dev-57.3.0</sirius.db>
+        <sirius.db>dev-57.5.0</sirius.db>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>dev-42.8.0</sirius.kernel>
-        <sirius.web>dev-78.8.0</sirius.web>
+        <sirius.web>dev-79.2.0</sirius.web>
         <sirius.db>dev-57.3.0</sirius.db>
     </properties>
 

--- a/src/main/resources/default/taglib/t/blobImageHardRefField.html.pasta
+++ b/src/main/resources/default/taglib/t/blobImageHardRefField.html.pasta
@@ -69,7 +69,7 @@
 
     const initialImage = _img.src;
     sirius.ready(function () {
-        if (isDisplayableImage(fileExtension)) {
+        if (sirius.isDisplayableImage(fileExtension)) {
             if (_img.src === '___defaultPreview' || '___previewVariant' === 'raw') {
                 return;
             }
@@ -81,7 +81,7 @@
             let _previewIconSpan = document.createElement('span');
             let _previewIcon = document.createElement('i');
             _previewIconSpan.appendChild(_previewIcon);
-            _previewIcon.className = '___iconClass' + ' ' + determineFileIcon(fileExtension);
+            _previewIcon.className = '___iconClass' + ' ' + sirius.determineFileIcon(fileExtension);
             _img.classList.add('d-none');
             _previewContainer.appendChild(_previewIconSpan);
         }
@@ -159,7 +159,7 @@
                 _img = outerDiv.querySelector('.img-preview img');
 
                 fileExtension = sirius.extractFileExtension(response.imageUrl).toLowerCase();
-                if (isDisplayableImage(fileExtension)) {
+                if (sirius.isDisplayableImage(fileExtension)) {
                     if ('___previewVariant' === 'raw') {
                         _img.src = response.imageUrl;
                     } else {
@@ -172,7 +172,7 @@
                     let _previewIconSpan = document.createElement('span');
                     let _previewIcon = document.createElement('i');
                     _previewIconSpan.appendChild(_previewIcon);
-                    _previewIcon.className = '___iconClass' + ' ' + determineFileIcon(fileExtension);
+                    _previewIcon.className = '___iconClass' + ' ' + sirius.determineFileIcon(fileExtension);
                     _previewContainer.appendChild(_previewIconSpan);
                     _img.classList.add('d-none');
                 }
@@ -200,36 +200,4 @@
             outerDiv.querySelector('#saveHint').classList.remove('d-none');
         }
     }
-
-    function isDisplayableImage(extension) {
-        return extension === '.jpg' || extension === '.jpeg' || extension === '.png';
-    }
-
-    function determineFileIcon(extension) {
-        if (extension === '.pdf') {
-            return 'fa-file-pdf';
-        }
-
-        if (extension === '.tif' || extension === '.tiff' || extension === '.bmp' || extension === '.svg') {
-            return 'fa-image';
-        }
-
-        if (extension === '.doc' || extension === '.docx') {
-            return 'fa-file-word';
-        }
-
-        if (extension === '.xls' || extension === '.xlsx') {
-            return 'fa-file-excel';
-        }
-
-        if (extension === '.ppt' || extension === '.pps' || extension === '.pptx' || extension === '.ppsx') {
-            return 'fa-file-powerpoint';
-        }
-
-        if (extension === '.zip' || extension === '.rar') {
-            return 'fa-file-zipper';
-        }
-
-        return 'fa-file';
-    };
 </script>

--- a/src/main/resources/default/taglib/t/blobImageSoftRefField.html.pasta
+++ b/src/main/resources/default/taglib/t/blobImageSoftRefField.html.pasta
@@ -86,7 +86,7 @@
 
                 const fileExtension = sirius.extractFileExtension(src).toLowerCase();
 
-                if (isDisplayableImage(fileExtension)) {
+                if (sirius.isDisplayableImage(fileExtension)) {
                     let _previewImage = document.createElement('img');
                     _previewImage.className = 'mh-100 mw-100';
 
@@ -102,7 +102,7 @@
                     }
                 } else {
                     let _previewIcon = document.createElement('i');
-                    _previewIcon.className = '___iconClass' + ' ' + determineFileIcon(fileExtension);
+                    _previewIcon.className = '___iconClass' + ' ' + sirius.determineFileIcon(fileExtension);
                     _previewContainer.appendChild(_previewIcon);
                 }
             }
@@ -170,37 +170,5 @@
             }
             return '/' + path.substring(0, path.lastIndexOf('/') + 1);
         }
-
-        function isDisplayableImage(extension) {
-            return extension === '.jpg' || extension === '.jpeg' || extension === '.png';
-        }
-
-        function determineFileIcon(extension) {
-            if (extension === '.pdf') {
-                return 'fa-file-pdf';
-            }
-
-            if (extension === '.tif' || extension === '.tiff' || extension === '.bmp' || extension === '.svg') {
-                return 'fa-image';
-            }
-
-            if (extension === '.doc' || extension === '.docx') {
-                return 'fa-file-word';
-            }
-
-            if (extension === '.xls' || extension === '.xlsx') {
-                return 'fa-file-excel';
-            }
-
-            if (extension === '.ppt' || extension === '.pps' || extension === '.pptx' || extension === '.ppsx') {
-                return 'fa-file-powerpoint';
-            }
-
-            if (extension === '.zip' || extension === '.rar') {
-                return 'fa-file-zipper';
-            }
-
-            return 'fa-file';
-        };
     }());
 </script>

--- a/src/test/kotlin/sirius/biz/pagehelper/ElasticPageHelperTest.kt
+++ b/src/test/kotlin/sirius/biz/pagehelper/ElasticPageHelperTest.kt
@@ -16,6 +16,7 @@ import sirius.biz.web.pagehelper.ElasticPageHelperEntity
 import sirius.db.es.Elastic
 import sirius.kernel.SiriusExtension
 import sirius.kernel.di.std.Part
+import sirius.web.http.QueryString
 import sirius.web.http.WebContext
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -34,7 +35,7 @@ class ElasticPageHelperTest {
         val webContext = WebContext.getCurrent()
         webContext.javaClass.getDeclaredField("queryString").apply {
             isAccessible = true
-            set(webContext, mapOf<String, List<String>>())
+            set(webContext, setOf<QueryString>())
         }
         pageHelper.withContext(webContext)
         pageHelper.addBooleanAggregation(ElasticPageHelperEntity.BOOLEAN_FIELD)
@@ -62,7 +63,7 @@ class ElasticPageHelperTest {
         val webContext = WebContext.getCurrent()
         webContext.javaClass.getDeclaredField("queryString").apply {
             isAccessible = true
-            set(webContext, mapOf("booleanField" to listOf("1")))
+            set(webContext, QueryString("?booleanField=1"))
         }
         pageHelper.withContext(webContext)
         pageHelper.addBooleanAggregation(ElasticPageHelperEntity.BOOLEAN_FIELD)

--- a/src/test/kotlin/sirius/biz/pagehelper/ElasticPageHelperTest.kt
+++ b/src/test/kotlin/sirius/biz/pagehelper/ElasticPageHelperTest.kt
@@ -35,7 +35,7 @@ class ElasticPageHelperTest {
         val webContext = WebContext.getCurrent()
         webContext.javaClass.getDeclaredField("queryString").apply {
             isAccessible = true
-            set(webContext, setOf<QueryString>())
+            set(webContext, QueryString("?"))
         }
         pageHelper.withContext(webContext)
         pageHelper.addBooleanAggregation(ElasticPageHelperEntity.BOOLEAN_FIELD)

--- a/src/test/kotlin/sirius/biz/pagehelper/MongoPageHelperTest.kt
+++ b/src/test/kotlin/sirius/biz/pagehelper/MongoPageHelperTest.kt
@@ -17,6 +17,7 @@ import sirius.db.mongo.Mango
 import sirius.kernel.SiriusExtension
 import sirius.kernel.async.CallContext
 import sirius.kernel.di.std.Part
+import sirius.web.http.QueryString
 import sirius.web.http.WebContext
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -35,7 +36,7 @@ class MongoPageHelperTest {
         val webContext = WebContext.getCurrent()
         webContext.javaClass.getDeclaredField("queryString").apply {
             isAccessible = true
-            set(webContext, mapOf<String, List<String>>())
+            set(webContext, QueryString("?"))
         }
         pageHelper.withContext(webContext)
         pageHelper.addBooleanAggregation(MongoPageHelperEntity.BOOLEAN_FIELD)
@@ -65,7 +66,7 @@ class MongoPageHelperTest {
         val webContext = WebContext.getCurrent()
         webContext.javaClass.getDeclaredField("queryString").apply {
             isAccessible = true
-            set(webContext, mapOf("booleanField" to listOf("true")))
+            set(webContext, QueryString("?booleanField=true"))
         }
         pageHelper.withContext(webContext)
         pageHelper.addBooleanAggregation(MongoPageHelperEntity.BOOLEAN_FIELD)
@@ -90,7 +91,7 @@ class MongoPageHelperTest {
         val webContext = WebContext.getCurrent()
         webContext.javaClass.getDeclaredField("queryString").apply {
             isAccessible = true
-            set(webContext, mapOf<String, List<String>>())
+            set(webContext, QueryString("?"))
         }
         pageHelper.withContext(webContext)
         pageHelper.addTermAggregation(MongoPageHelperEntity.STRING_FIELD)
@@ -118,7 +119,7 @@ class MongoPageHelperTest {
         val webContext = WebContext.getCurrent()
         webContext.javaClass.getDeclaredField("queryString").apply {
             isAccessible = true
-            set(webContext, mapOf("stringField" to listOf("field-value-a")))
+            set(webContext, QueryString("?stringField=field-value-a"))
         }
         pageHelper.withContext(webContext)
         pageHelper.addTermAggregation(MongoPageHelperEntity.STRING_FIELD)


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes
Breaking due to changes in https://github.com/scireum/sirius-web/commit/70a8dedbd68441233c964bad95621a986e2957de 

- This PR fixes or works on following ticket(s): [SIRI-965](https://scireum.myjetbrains.com/youtrack/issue/SIRI-965)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1423

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
