### PR TITLE
only link delete files job on deletable directories.

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
@@ -341,7 +341,9 @@ public class DeleteFilesJob extends BatchJob {
 
         @Override
         protected boolean hasPresetFor(@Nonnull QueryString queryString, @Nullable Object targetObject) {
-            return (targetObject instanceof VirtualFile virtualFile && virtualFile.isDirectory());
+            return (targetObject instanceof VirtualFile virtualFile
+                    && virtualFile.isDirectory()
+                    && virtualFile.canDelete());
         }
 
         @Nonnull


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

Some directories are linked as root-directories or linked only readonly where we cannot delete files, so the linking to the job is not helpful.
<img width="1724" alt="Bildschirmfoto 2024-05-24 um 17 36 31" src="https://github.com/scireum/sirius-biz/assets/55080004/bb603271-d55a-4411-aee7-3fa816b21cc5">
before vs now

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
