### PR TITLE
Makes Read-Only `<t:lookupValue>` and `<t:lookupValues>` Actually Read-Only

### DIFF
--- a/src/main/resources/default/taglib/t/lookupValue.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValue.html.pasta
@@ -38,7 +38,9 @@
                            tableName: '___table',
                            labelFormat: '___value.getDisplay()',
                            codeCallback: function (code, name) {
-                                autocomplete.val({value: code, text: name});
+                               @if (!readonly) {
+                                   autocomplete.val({value: code, text: name});
+                               }
                            }
                        });
             }

--- a/src/main/resources/default/taglib/t/lookupValue.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValue.html.pasta
@@ -12,12 +12,19 @@
 <i:arg name="allowCustomEntries" type="boolean" default="@value.acceptsCustomValues()"/>
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
 
+
 <i:pragma name="inline" value="true"/>
 <i:pragma name="description" value="Renders a dropdown field for a LookupValue field"/>
 
 
-<t:singleSelect name="@name" label="@label" help="@help" optional="@optional" readonly="@readonly" id="@id"
-                allowCustomEntries="@allowCustomEntries" class="@class"
+<t:singleSelect name="@name"
+                label="@label"
+                help="@help"
+                optional="@optional"
+                readonly="@readonly"
+                id="@id"
+                allowCustomEntries="@allowCustomEntries"
+                class="@class"
                 suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s', table, value.getDisplay(), value.getExtendedDisplay())">
     <i:block name="addon">
         <i:if test="showSelectionButton">

--- a/src/main/resources/default/taglib/t/lookupValues.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValues.html.pasta
@@ -5,6 +5,7 @@
 <i:arg name="helpKey" type="String" default=""/>
 <i:arg name="help" type="String" default="@i18n(helpKey)"/>
 <i:arg name="readonly" type="boolean" default="false"/>
+<i:arg name="showSelectionButton" type="boolean" default="true"/>
 <i:arg name="table" type="String" default="@values.getTableName()"/>
 <i:arg name="id" type="String" default="@generateId('singleselect-%s')"/>
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
@@ -23,9 +24,12 @@
                class="@class"
                suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s', table, values.getDisplay(), values.getExtendedDisplay())">
     <i:block name="addon">
-        <a class="btn btn-outline-secondary" id="@id-addon"><i class="fa-solid fa-bolt"></i></a>
+        <i:if test="showSelectionButton">
+            <a class="btn btn-outline-secondary" id="@id-addon"><i class="fa-solid fa-bolt"></i></a>
+        </i:if>
     </i:block>
     <i:block name="script">
+        <i:if test="showSelectionButton">
             const helper = document.getElementById('___id-addon');
             helper.addEventListener('click', function () {
                 new LookupTableInfo({
@@ -42,6 +46,7 @@
                     }
                 });
             });
+        </i:if>
     </i:block>
     <i:for var="tuple"
            type="Tuple"

--- a/src/main/resources/default/taglib/t/lookupValues.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValues.html.pasta
@@ -14,8 +14,13 @@
 <i:pragma name="description" value="Renders a multiselect dropdown field for LookupValues field"/>
 
 
-<t:multiSelect name="@name" label="@label" help="@help" readonly="@readonly" id="@id"
-               allowCustomEntries="@values.acceptsCustomValues()" class="@class"
+<t:multiSelect name="@name"
+               label="@label"
+               help="@help"
+               readonly="@readonly"
+               id="@id"
+               allowCustomEntries="@values.acceptsCustomValues()"
+               class="@class"
                suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s', table, values.getDisplay(), values.getExtendedDisplay())">
     <i:block name="addon">
         <a class="btn btn-outline-secondary" id="@id-addon"><i class="fa-solid fa-bolt"></i></a>

--- a/src/main/resources/default/taglib/t/lookupValues.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValues.html.pasta
@@ -27,10 +27,12 @@
                     tableName: '___table',
                     labelFormat: '___values.getDisplay()',
                     codeCallback: function (code, name) {
-                        if (!autocomplete.val().includes(code)) {
-                            autocomplete.addToken({value: code, text: name});
-                        } else {
-                            autocomplete.select.removeTokenWithText(name);
+                        @if (!readonly) {
+                            if (!autocomplete.val().includes(code)) {
+                                autocomplete.addToken({value: code, text: name});
+                            } else {
+                                autocomplete.select.removeTokenWithText(name);
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
### Description

Read-only `<t:lookupValue>` and `<t:lookupValues>` can currently by modified via the bolt icon and the following selection dialog. This PR suppresses this modification and also introduces a `showSelectionButton` in `<t:lookupValues>` that is already present in `<t:lookupValue>`.

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)