### PR TITLE
ExtractArchiveJob: Fixes job not stopping when cancelled by user, also changes state to use "cancelled" instead of "terminated"

### DIFF
--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -600,7 +600,7 @@ public class Processes {
             if (process.getState() != ProcessState.STANDBY) {
                 process.setErrorneous(process.isErrorneous() || !TaskContext.get().isActive());
                 //Do not alter the job state if the job was previously cancelled by the user
-                if (process.getCanceled()==null) {
+                if (process.getState() != ProcessState.CANCELED) {
                     process.setState(ProcessState.TERMINATED);
                     process.setCompleted(LocalDateTime.now());
                 }

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -599,7 +599,12 @@ public class Processes {
         return modify(processId, process -> process.getState() != ProcessState.TERMINATED, process -> {
             if (process.getState() != ProcessState.STANDBY) {
                 process.setErrorneous(process.isErrorneous() || !TaskContext.get().isActive());
-                process.setState(ProcessState.TERMINATED);
+                //Do not alter the job state if the job was previously cancelled by the user
+                if (process.getState() != ProcessState.CANCELED) {
+                    process.setState(ProcessState.TERMINATED);
+                } else {
+                    process.setState(ProcessState.CANCELED);
+                }
                 process.setCompleted(LocalDateTime.now());
                 process.setComputationTime(process.getComputationTime() + computationTimeInSeconds);
                 process.setExpires(process.getPersistencePeriod().plus(LocalDate.now()));

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -602,10 +602,10 @@ public class Processes {
                 //Do not alter the job state if the job was previously cancelled by the user
                 if (process.getCanceled()==null) {
                     process.setState(ProcessState.TERMINATED);
+                    process.setCompleted(LocalDateTime.now());
                 } else {
                     process.setState(ProcessState.CANCELED);
                 }
-                process.setCompleted(LocalDateTime.now());
                 process.setComputationTime(process.getComputationTime() + computationTimeInSeconds);
                 process.setExpires(process.getPersistencePeriod().plus(LocalDate.now()));
             }

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -603,8 +603,6 @@ public class Processes {
                 if (process.getCanceled()==null) {
                     process.setState(ProcessState.TERMINATED);
                     process.setCompleted(LocalDateTime.now());
-                } else {
-                    process.setState(ProcessState.CANCELED);
                 }
                 process.setComputationTime(process.getComputationTime() + computationTimeInSeconds);
                 process.setExpires(process.getPersistencePeriod().plus(LocalDate.now()));

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -600,7 +600,7 @@ public class Processes {
             if (process.getState() != ProcessState.STANDBY) {
                 process.setErrorneous(process.isErrorneous() || !TaskContext.get().isActive());
                 //Do not alter the job state if the job was previously cancelled by the user
-                if (process.getState() != ProcessState.CANCELED) {
+                if (process.getCanceled()==null) {
                     process.setState(ProcessState.TERMINATED);
                 } else {
                     process.setState(ProcessState.CANCELED);

--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -137,14 +137,12 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
                               .withContext("size", NLS.formatSize(sourceFile.size())));
 
         try (FileHandle archive = sourceFile.download()) {
-            extractor.extractAll(sourceFile.name(),
-                                 archive.getFile(),
-                                 null,
-                                 file -> handleExtractedFile(file,
-                                                             process,
-                                                             overrideMode,
-                                                             targetDirectory,
-                                                             flattenDirs));
+            extractor.extractAll(sourceFile.name(), archive.getFile(), null, file -> {
+                if (!process.isActive()) {
+                    return;
+                }
+                handleExtractedFile(file, process, overrideMode, targetDirectory, flattenDirs);
+            });
             process.forceUpdateState(NLS.get("ExtractArchiveJob.completed"));
         } catch (Exception exception) {
             process.log(ProcessLog.error().withMessage(exception.getMessage()));

--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -79,6 +79,8 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
 
     private static final String FILE_SKIPPED_COUNTER = "ExtractArchiveJob.fileSkipped";
     private static final String FILE_EMPTY_COUNTER = "ExtractArchiveJob.fileEmpty";
+    private static final String ARCHIVE_JOB_EMPTY_FILE = "ExtractArchiveJob.emptyFile";
+    private static final String FILENAME = "filename";
 
     /**
      * Creates the job factory so that it can be invoked by the framework.
@@ -165,7 +167,7 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
 
         if (extractedFile == null) {
             // if this happens we don't know the file name of this entry, we just log with an empty name
-            process.log(ProcessLog.warn().withNLSKey("ExtractArchiveJob.emptyFile").withContext("filename", ""));
+            process.log(ProcessLog.warn().withNLSKey(ARCHIVE_JOB_EMPTY_FILE).withContext(FILENAME, ""));
             process.addTiming(FILE_EMPTY_COUNTER, watch.elapsedMillis());
             return;
         }
@@ -176,8 +178,8 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
 
         if (extractedFile.size() == 0) {
             process.log(ProcessLog.warn()
-                                  .withNLSKey("ExtractArchiveJob.emptyFile")
-                                  .withContext("filename", extractedFile.getFilePath()));
+                                  .withNLSKey(ARCHIVE_JOB_EMPTY_FILE)
+                                  .withContext(FILENAME, extractedFile.getFilePath()));
             process.addTiming(FILE_EMPTY_COUNTER, watch.elapsedMillis());
             return;
         }
@@ -186,8 +188,8 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
         VirtualFile targetFile = fetchTargetFile(targetDirectory, targetPath);
         if (targetFile == null) {
             process.log(ProcessLog.warn()
-                                  .withNLSKey("ExtractArchiveJob.emptyFile")
-                                  .withContext("filename", extractedFile.getFilePath()));
+                                  .withNLSKey(ARCHIVE_JOB_EMPTY_FILE)
+                                  .withContext(FILENAME, extractedFile.getFilePath()));
             process.addTiming(FILE_SKIPPED_COUNTER, watch.elapsedMillis());
             return;
         }

--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -145,7 +145,9 @@ public class ExtractArchiveJob extends SimpleBatchProcessJobFactory {
                 }
                 handleExtractedFile(file, process, overrideMode, targetDirectory, flattenDirs);
             });
-            process.forceUpdateState(NLS.get("ExtractArchiveJob.completed"));
+            if(processes.fetchProcessForUser(process.getProcessId()).orElse(null).getCanceled() == null){
+                process.forceUpdateState(NLS.get("ExtractArchiveJob.completed"));
+            }
         } catch (Exception exception) {
             process.log(ProcessLog.error().withMessage(exception.getMessage()));
         }


### PR DESCRIPTION
### Description
Before:
Still unpacking:
<img width="934" alt="image" src="https://github.com/scireum/sirius-biz/assets/150906388/a3a78eb1-fea3-4297-bff5-bb79eafda3cc">
After unpacking:
<img width="864" alt="image" src="https://github.com/scireum/sirius-biz/assets/150906388/08686496-707a-4c4a-b7de-e0a96ee39040">

After fixes:
<img width="847" alt="image" src="https://github.com/scireum/sirius-biz/assets/150906388/83fae11f-2793-4ef7-a997-53e318bd476a">

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-972](https://scireum.myjetbrains.com/youtrack/issue/SIRI-972)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
