### PR TITLE
VFS - DeleteFilesJob: Fixes job skipping files while iterating over all files when job is not set to simulation

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
@@ -260,7 +260,7 @@ public class DeleteFilesJob extends BatchJob {
             }
 
             if (!simulation) {
-                file.delete();
+                filesToDelete.add(file);
             }
             String messageKey = isDirectory ? "DeleteFilesJob.directory.deleted" : "DeleteFilesJob.file.deleted";
             process.log(ProcessLog.info().withNLSKey(messageKey).withContext(PATH_KEY, file.path()));

--- a/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
@@ -35,6 +35,8 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -83,6 +85,7 @@ public class DeleteFilesJob extends BatchJob {
     private LocalDateTime lastModifiedBefore;
     private PathMatcher pathMatcher;
     private boolean onlyUnused;
+    private List<VirtualFile> filesToDelete;
 
     @Part
     private static VirtualFileSystem vfs;
@@ -150,7 +153,7 @@ public class DeleteFilesJob extends BatchJob {
     private boolean handleDirectory(VirtualFile directory) {
         Monoflop childSkipped = Monoflop.create();
         boolean isRoot = "/".equals(directory.parent().path());
-
+        filesToDelete = new ArrayList<>();
         if (recursive) {
             // Only enters child directories in recursive mode
             directory.allChildren().excludeFiles().subTreeOnly().maxDepth(1).iterate(subDirectory -> {

--- a/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
@@ -120,6 +120,9 @@ public class DeleteFilesJob extends BatchJob {
         process.getParameter(LAST_MODIFIED_BEFORE_PARAMETER)
                .ifPresent(date -> lastModifiedBefore = date.atStartOfDay());
         handleDirectory(sourcePath);
+        for (VirtualFile file : filesToDelete) {
+            file.delete();
+        }
     }
 
     /**


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-973](https://scireum.myjetbrains.com/youtrack/issue/SIRI-973)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
