### PR TITLE
fix not working lookup-tables modal pagination

### DIFF
--- a/src/main/resources/default/assets/scripts/lookup-tables.js.pasta
+++ b/src/main/resources/default/assets/scripts/lookup-tables.js.pasta
@@ -22,16 +22,16 @@ function LookupTableInfo(options) {
     this.entriesToSkip = 0;
     this._paginationLeft = this._modal.querySelector('.pagination-left-js');
     this._paginationLeft.addEventListener('click', event => {
-        if (event.target.dataset.skip != null) {
-            this.entriesToSkip = event.target.dataset.skip;
+        if (this._paginationLeft.dataset.skip != null) {
+            this.entriesToSkip = this._paginationLeft.dataset.skip;
             this.reload();
         }
         event.preventDefault();
     });
     this._paginationRight = this._modal.querySelector('.pagination-right-js');
     this._paginationRight.addEventListener('click', event => {
-        if (event.target.dataset.skip != null) {
-            this.entriesToSkip = event.target.dataset.skip;
+        if (this._paginationRight.dataset.skip != null) {
+            this.entriesToSkip = this._paginationRight.dataset.skip;
             this.reload();
         }
         event.preventDefault();


### PR DESCRIPTION
by clicking on the < > arrows or the area between the arrow-arms, the event is not the link, but the svg or the inner path. So the link is not working properly. Therefore using the element itself for setting data-attribute now to make clicking work on the whole button.

### Description
<img width="292" alt="Bildschirmfoto 2024-06-24 um 12 59 47" src="https://github.com/scireum/sirius-biz/assets/55080004/9c238618-62e6-4941-b5a2-ea671b8cc370">

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
