### PR TITLE
Shows more information for wrapped exceptions

### DIFF
--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -156,7 +156,7 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
             // Therefore, the first element is skipped.
             Throwables.getCausalChain(throwable).stream().skip(1).forEach(cause -> {
                 stringBuilder.append("\n").append("Caused by: ").append(cause.getClass().getName()).append(":").append("\n");
-                stringBuilder.append(truncateErrorMessage(cause.getMessage(), numberOfCharactersPerMessage)).append("\n\n");
+                stringBuilder.append(truncateErrorMessage(determineErrorMessage(cause), numberOfCharactersPerMessage)).append("\n\n");
             });
         } catch (IllegalArgumentException exception) {
             // This happens if the causal chain has a circular reference.
@@ -165,6 +165,16 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
         }
 
         return stringBuilder.toString();
+    }
+
+    private String determineErrorMessage(Throwable throwable) {
+        if (Strings.isFilled(throwable.getMessage())) {
+            return throwable.getMessage();
+        }
+        if (Strings.areEqual(throwable.getClass().getName(), throwable.toString())) {
+            return "";
+        }
+        return throwable.toString();
     }
 
     private String truncateErrorMessage(String errorMessage, int length) {


### PR DESCRIPTION

### Description

Sometimes we have to handle exceptions that are wrapped in other exceptions. Hopefully these wrapper-exceptions give us information about its wrapped exceptions in the message. Unfortunately, some of them does not. So we can try to catch the missing information from the overriden toString()-method that includes this information e.g. com.lowagie.text.ExceptionConverter

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-985](https://scireum.myjetbrains.com/youtrack/issue/SIRI-985)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/1997

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
