### PR TITLE
SIRI-975: Uniformly take deprecated Lookup Entries into account or not

### DIFF
--- a/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
@@ -98,11 +98,11 @@ class CodeListLookupTable extends LookupTable {
     }
 
     private String performReverseLookupScan(String name) {
-        return scan(NLS.getCurrentLanguage(), Limit.UNLIMITED).filter(pair -> Strings.equalIgnoreCase(name,
-                                                                                                      pair.getName()))
-                                                              .findFirst()
-                                                              .map(LookupTableEntry::getCode)
-                                                              .orElse(null);
+        return scan(NLS.getCurrentLanguage(), Limit.UNLIMITED, true).filter(pair -> Strings.equalIgnoreCase(name,
+                                                                                                            pair.getName()))
+                                                                    .findFirst()
+                                                                    .map(LookupTableEntry::getCode)
+                                                                    .orElse(null);
     }
 
     @Override
@@ -111,7 +111,10 @@ class CodeListLookupTable extends LookupTable {
     }
 
     @Override
-    protected Stream<LookupTableEntry> performSuggest(Limit limit, String searchTerm, String language) {
+    protected Stream<LookupTableEntry> performSuggest(Limit limit,
+                                                      String searchTerm,
+                                                      String language,
+                                                      boolean considerDeprecatedValues) {
         return codeLists.getEntries(codeList)
                         .stream()
                         .filter(entry -> filter(entry, searchTerm, language))
@@ -124,7 +127,7 @@ class CodeListLookupTable extends LookupTable {
     protected Stream<LookupTableEntry> performSearch(String searchTerm, Limit limit, String language) {
         // As plain code lists don't support deprecations or source data, we can re-use the same
         // method..
-        return performSuggest(limit, searchTerm, language);
+        return performSuggest(limit, searchTerm, language, true);
     }
 
     private LookupTableEntry extractEntryData(CodeListEntry<?, ?> entry, String language) {
@@ -144,7 +147,7 @@ class CodeListLookupTable extends LookupTable {
     }
 
     @Override
-    public Stream<LookupTableEntry> scan(String language, Limit limit) {
+    public Stream<LookupTableEntry> scan(String language, Limit limit, boolean considerDeprecatedValues) {
         return codeLists.getEntries(codeList)
                         .stream()
                         .skip(limit.getItemsToSkip())

--- a/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
@@ -125,8 +125,7 @@ class CodeListLookupTable extends LookupTable {
 
     @Override
     protected Stream<LookupTableEntry> performSearch(String searchTerm, Limit limit, String language) {
-        // As plain code lists don't support deprecations or source data, we can re-use the same
-        // method..
+        // Plain code lists do not support deprecations or source data. Therefore, the suggest method can be reused.
         return performSuggest(limit, searchTerm, language, true);
     }
 

--- a/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
@@ -126,7 +126,7 @@ class ConfigLookupTable extends LookupTable {
 
     @Override
     protected Stream<LookupTableEntry> performSearch(String searchTerm, Limit limit, String language) {
-        // Deprecations or source data not supported yet, so we can re-use the same method..
+        // Configs do not support deprecations or source data. Therefore, the suggest method can be reused.
         return performSuggest(limit, searchTerm, language, true);
     }
 

--- a/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
@@ -94,7 +94,10 @@ class ConfigLookupTable extends LookupTable {
     @SuppressWarnings("unchecked")
     @Explain("The data is provided in the configuration as String keys with assigned value objects.")
     @Override
-    protected Stream<LookupTableEntry> performSuggest(Limit limit, String searchTerm, String language) {
+    protected Stream<LookupTableEntry> performSuggest(Limit limit,
+                                                      String searchTerm,
+                                                      String language,
+                                                      boolean considerDeprecatedValues) {
         Map<String, Object> data = extension.get(CONFIG_KEY_DATA).get(Map.class, Collections.emptyMap());
         return data.keySet()
                    .stream()
@@ -124,13 +127,13 @@ class ConfigLookupTable extends LookupTable {
     @Override
     protected Stream<LookupTableEntry> performSearch(String searchTerm, Limit limit, String language) {
         // Deprecations or source data not supported yet, so we can re-use the same method..
-        return performSuggest(limit, searchTerm, language);
+        return performSuggest(limit, searchTerm, language, true);
     }
 
     @SuppressWarnings("unchecked")
     @Explain("The data is provided in the configuration as String keys with assigned value objects.")
     @Override
-    public Stream<LookupTableEntry> scan(String language, Limit limit) {
+    public Stream<LookupTableEntry> scan(String language, Limit limit, boolean considerDeprecatedValues) {
         Map<String, Object> data = extension.get(CONFIG_KEY_DATA).get(Map.class, Collections.emptyMap());
         return data.keySet()
                    .stream()

--- a/src/main/java/sirius/biz/codelists/CustomLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CustomLookupTable.java
@@ -89,10 +89,16 @@ class CustomLookupTable extends LookupTable {
     }
 
     @Override
-    protected Stream<LookupTableEntry> performSuggest(Limit limit, String searchTerm, String language) {
+    protected Stream<LookupTableEntry> performSuggest(Limit limit,
+                                                      String searchTerm,
+                                                      String language,
+                                                      boolean considerDeprecatedValues) {
         Set<String> codes = new HashSet<>();
-        return Stream.concat(customTable.performSuggest(Limit.UNLIMITED, searchTerm, language),
-                             baseTable.performSuggest(Limit.UNLIMITED, searchTerm, language))
+        return Stream.concat(customTable.performSuggest(Limit.UNLIMITED,
+                                                        searchTerm,
+                                                        language,
+                                                        considerDeprecatedValues),
+                             baseTable.performSuggest(Limit.UNLIMITED, searchTerm, language, considerDeprecatedValues))
                      .filter(entry -> codes.add(entry.getCode()))
                      .skip(limit.getItemsToSkip())
                      .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems());
@@ -109,9 +115,10 @@ class CustomLookupTable extends LookupTable {
     }
 
     @Override
-    public Stream<LookupTableEntry> scan(String language, Limit limit) {
+    public Stream<LookupTableEntry> scan(String language, Limit limit, boolean considerDeprecatedValues) {
         Set<String> codes = new HashSet<>();
-        return Stream.concat(customTable.scan(language, Limit.UNLIMITED), baseTable.scan(language, Limit.UNLIMITED))
+        return Stream.concat(customTable.scan(language, Limit.UNLIMITED, considerDeprecatedValues),
+                             baseTable.scan(language, Limit.UNLIMITED, considerDeprecatedValues))
                      .filter(entry -> codes.add(entry.getCode()))
                      .skip(limit.getItemsToSkip())
                      .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems());

--- a/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
@@ -108,16 +108,19 @@ class IDBFilteredLookupTable extends LookupTable {
     }
 
     @Override
-    protected Stream<LookupTableEntry> performSuggest(Limit limit, String searchTerm, String language) {
-        return baseTable.performSuggest(Limit.UNLIMITED, searchTerm, language)
+    protected Stream<LookupTableEntry> performSuggest(Limit limit,
+                                                      String searchTerm,
+                                                      String language,
+                                                      boolean considerDeprecatedValues) {
+        return baseTable.performSuggest(Limit.UNLIMITED, searchTerm, language, considerDeprecatedValues)
                         .filter(pair -> performContains(pair.getCode()))
                         .skip(limit.getItemsToSkip())
                         .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems());
     }
 
     @Override
-    public Stream<LookupTableEntry> scan(String language, Limit limit) {
-        return baseTable.scan(language, Limit.UNLIMITED)
+    public Stream<LookupTableEntry> scan(String language, Limit limit, boolean considerDeprecatedValues) {
+        return baseTable.scan(language, Limit.UNLIMITED, considerDeprecatedValues)
                         .filter(pair -> performContains(pair.getCode()))
                         .skip(limit.getItemsToSkip())
                         .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems());

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -277,6 +277,7 @@ class IDBLookupTable extends LookupTable {
                                                       String language,
                                                       boolean considerDeprecatedValues) {
         try {
+            // Caveat: IDBTable$QueryBuilder#manyRows can only be used when no filtering is applied afterwards.
             if (considerDeprecatedValues) {
                 return table.query()
                             .searchInAllFields()
@@ -315,6 +316,7 @@ class IDBLookupTable extends LookupTable {
     @Override
     public Stream<LookupTableEntry> scan(String language, Limit limit, boolean considerDeprecatedValues) {
         try {
+            // Caveat: IDBTable$QueryBuilder#manyRows can only be used when no filtering is applied afterwards.
             if (considerDeprecatedValues) {
                 return table.query()
                             .translate(language)

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -272,14 +272,30 @@ class IDBLookupTable extends LookupTable {
     }
 
     @Override
-    protected Stream<LookupTableEntry> performSuggest(Limit limit, String searchTerm, String language) {
+    protected Stream<LookupTableEntry> performSuggest(Limit limit,
+                                                      String searchTerm,
+                                                      String language,
+                                                      boolean considerDeprecatedValues) {
         try {
+            if (considerDeprecatedValues) {
+                return table.query()
+                            .searchInAllFields()
+                            .searchValue(searchTerm)
+                            .translate(language)
+                            .manyRows(limit, codeField, nameField, descriptionField)
+                            .map(row -> new LookupTableEntry(row.at(0).asString(),
+                                                             row.at(1).asString(),
+                                                             row.at(2).getString()));
+            }
+
             return table.query()
                         .searchInAllFields()
                         .searchValue(searchTerm)
                         .translate(language)
-                        .manyRows(limit, codeField, nameField, descriptionField, COL_DEPRECATED)
+                        .allRows(codeField, nameField, descriptionField, COL_DEPRECATED)
                         .filter(row -> row.at(3).asLong(0) != 1L)
+                        .skip(limit.getItemsToSkip())
+                        .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems())
                         .map(row -> new LookupTableEntry(row.at(0).asString(),
                                                          row.at(1).asString(),
                                                          row.at(2).getString()));
@@ -297,11 +313,21 @@ class IDBLookupTable extends LookupTable {
     }
 
     @Override
-    public Stream<LookupTableEntry> scan(String language, Limit limit) {
+    public Stream<LookupTableEntry> scan(String language, Limit limit, boolean considerDeprecatedValues) {
         try {
+            if (considerDeprecatedValues) {
+                return table.query()
+                            .translate(language)
+                            .manyRows(limit, codeField, nameField, descriptionField, COL_DEPRECATED, COL_SOURCE)
+                            .map(this::processSearchOrScanRow);
+            }
+
             return table.query()
                         .translate(language)
-                        .manyRows(limit, codeField, nameField, descriptionField, COL_DEPRECATED, COL_SOURCE)
+                        .allRows(codeField, nameField, descriptionField, COL_DEPRECATED, COL_SOURCE)
+                        .filter(row -> row.at(3).asLong(0) != 1L)
+                        .skip(limit.getItemsToSkip())
+                        .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems())
                         .map(this::processSearchOrScanRow);
         } catch (Exception exception) {
             Exceptions.createHandled()

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -763,18 +763,6 @@ public abstract class LookupTable {
     }
 
     /**
-     * Suggests several entries for the given search term using the currently active language.
-     *
-     * @param searchTerm               the term used to filter the suggestions
-     * @param considerDeprecatedValues whether deprecated values should be suggested as well
-     * @return a stream of suggestions for the given term. Note that most probably {@link Stream#limit(long)} should
-     * be used on the result as this might yield quite a bunch of suggestions in order to optimize internal queries.
-     */
-    public Stream<LookupTableEntry> suggest(@Nullable String searchTerm, boolean considerDeprecatedValues) {
-        return suggest(searchTerm, NLS.getCurrentLanguage(), considerDeprecatedValues);
-    }
-
-    /**
      * Suggests several entries for the given search term aside from deprecated entries using the given language.
      *
      * @param searchTerm the term used to filter the suggestions
@@ -829,17 +817,6 @@ public abstract class LookupTable {
      */
     public Stream<LookupTableEntry> scan(Limit limit) {
         return scan(NLS.getCurrentLanguage(), limit, true);
-    }
-
-    /**
-     * Enumerates all entries in the table using the current language.
-     *
-     * @param limit                    the limit to apply to fetch a sane number of entries
-     * @param considerDeprecatedValues whether deprecated values should be included in the scan
-     * @return a stream of all entries in this table, or an empty stream is scanning isn't supported
-     */
-    public Stream<LookupTableEntry> scan(Limit limit, boolean considerDeprecatedValues) {
-        return scan(NLS.getCurrentLanguage(), limit, considerDeprecatedValues);
     }
 
     /**

--- a/src/main/java/sirius/biz/codelists/LookupTableController.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableController.java
@@ -59,7 +59,7 @@ public class LookupTableController extends BizController {
         LookupValue.Display completionDisplayMode =
                 Value.of(extendedDisplay).getEnum(LookupValue.Display.class).orElse(LookupValue.Display.NAME);
         AutocompleteHelper.handle(webContext, (query, result) -> {
-            lookupTable.suggest(query, considerDeprecatedValues)
+            lookupTable.suggest(query, NLS.getCurrentLanguage(), considerDeprecatedValues)
                        .limit(MAX_SUGGESTIONS_ITEMS)
                        .map(entry -> entry.toAutocompletion(fieldDisplayMode, completionDisplayMode))
                        .forEach(result);

--- a/src/main/java/sirius/biz/codelists/LookupTableController.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableController.java
@@ -51,26 +51,8 @@ public class LookupTableController extends BizController {
                                        String tableName,
                                        String display,
                                        String extendedDisplay) {
-        suggestFromLookupTable(webContext, tableName, display, extendedDisplay, false);
-    }
+        boolean considerDeprecatedValues = webContext.get("considerDeprecatedValues").asBoolean();
 
-    /**
-     * Responds with possible suggestions from the given {@link LookupTable} using {@link AutocompleteHelper}.
-     *
-     * @param webContext               the web requests calling the autocomplete service
-     * @param tableName                the name of the table for which suggestions should be gathered
-     * @param display                  the requested {@link sirius.biz.codelists.LookupValue.Display display mode} for
-     *                                 the field label
-     * @param extendedDisplay          the requested {@link sirius.biz.codelists.LookupValue.Display display mode} for
-     *                                 the completion label
-     * @param considerDeprecatedValues whether deprecated values should be suggested
-     */
-    @Routed("/system/lookuptable/autocomplete/:1/:2/:3/:4")
-    public void suggestFromLookupTable(WebContext webContext,
-                                       String tableName,
-                                       String display,
-                                       String extendedDisplay,
-                                       boolean considerDeprecatedValues) {
         LookupTable lookupTable = lookupTables.fetchTable(tableName);
         LookupValue.Display fieldDisplayMode =
                 Value.of(display).getEnum(LookupValue.Display.class).orElse(LookupValue.Display.NAME);

--- a/src/main/java/sirius/biz/codelists/LookupTableController.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableController.java
@@ -77,8 +77,7 @@ public class LookupTableController extends BizController {
         LookupValue.Display completionDisplayMode =
                 Value.of(extendedDisplay).getEnum(LookupValue.Display.class).orElse(LookupValue.Display.NAME);
         AutocompleteHelper.handle(webContext, (query, result) -> {
-            lookupTable.suggest(query)
-                       .filter(entry -> !entry.isDeprecated())
+            lookupTable.suggest(query, considerDeprecatedValues)
                        .limit(MAX_SUGGESTIONS_ITEMS)
                        .map(entry -> entry.toAutocompletion(fieldDisplayMode, completionDisplayMode))
                        .forEach(result);

--- a/src/main/java/sirius/biz/codelists/LookupTableController.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableController.java
@@ -51,6 +51,26 @@ public class LookupTableController extends BizController {
                                        String tableName,
                                        String display,
                                        String extendedDisplay) {
+        suggestFromLookupTable(webContext, tableName, display, extendedDisplay, false);
+    }
+
+    /**
+     * Responds with possible suggestions from the given {@link LookupTable} using {@link AutocompleteHelper}.
+     *
+     * @param webContext               the web requests calling the autocomplete service
+     * @param tableName                the name of the table for which suggestions should be gathered
+     * @param display                  the requested {@link sirius.biz.codelists.LookupValue.Display display mode} for
+     *                                 the field label
+     * @param extendedDisplay          the requested {@link sirius.biz.codelists.LookupValue.Display display mode} for
+     *                                 the completion label
+     * @param considerDeprecatedValues whether deprecated values should be suggested
+     */
+    @Routed("/system/lookuptable/autocomplete/:1/:2/:3/:4")
+    public void suggestFromLookupTable(WebContext webContext,
+                                       String tableName,
+                                       String display,
+                                       String extendedDisplay,
+                                       boolean considerDeprecatedValues) {
         LookupTable lookupTable = lookupTables.fetchTable(tableName);
         LookupValue.Display fieldDisplayMode =
                 Value.of(display).getEnum(LookupValue.Display.class).orElse(LookupValue.Display.NAME);

--- a/src/main/resources/default/taglib/t/lookupValue.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValue.html.pasta
@@ -25,7 +25,7 @@
                 id="@id"
                 allowCustomEntries="@allowCustomEntries"
                 class="@class"
-                suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s/%s', table, value.getDisplay(), value.getExtendedDisplay(), suggestDeprecatedValues)">
+                suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s?considerDeprecatedValues=%s', table, value.getDisplay(), value.getExtendedDisplay(), suggestDeprecatedValues)">
     <i:block name="addon">
         <i:if test="showSelectionButton">
             <a class="btn btn-outline-secondary" id="@id-addon" tabindex="0"><i class="fa-solid fa-bolt"></i></a>

--- a/src/main/resources/default/taglib/t/lookupValue.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValue.html.pasta
@@ -11,7 +11,7 @@
 <i:arg name="id" type="String" default="@generateId('singleselect-%s')"/>
 <i:arg name="allowCustomEntries" type="boolean" default="@value.acceptsCustomValues()"/>
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
-
+<i:arg name="suggestDeprecatedValues" type="boolean" default="false"/>
 
 <i:pragma name="inline" value="true"/>
 <i:pragma name="description" value="Renders a dropdown field for a LookupValue field"/>
@@ -25,7 +25,7 @@
                 id="@id"
                 allowCustomEntries="@allowCustomEntries"
                 class="@class"
-                suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s', table, value.getDisplay(), value.getExtendedDisplay())">
+                suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s/%s', table, value.getDisplay(), value.getExtendedDisplay(), suggestDeprecatedValues)">
     <i:block name="addon">
         <i:if test="showSelectionButton">
             <a class="btn btn-outline-secondary" id="@id-addon" tabindex="0"><i class="fa-solid fa-bolt"></i></a>

--- a/src/main/resources/default/taglib/t/lookupValues.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValues.html.pasta
@@ -9,7 +9,7 @@
 <i:arg name="table" type="String" default="@values.getTableName()"/>
 <i:arg name="id" type="String" default="@generateId('singleselect-%s')"/>
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
-
+<i:arg name="suggestDeprecatedValues" type="boolean" default="false"/>
 
 <i:pragma name="inline" value="true"/>
 <i:pragma name="description" value="Renders a multiselect dropdown field for LookupValues field"/>
@@ -22,7 +22,7 @@
                id="@id"
                allowCustomEntries="@values.acceptsCustomValues()"
                class="@class"
-               suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s', table, values.getDisplay(), values.getExtendedDisplay())">
+               suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s/%s', table, values.getDisplay(), values.getExtendedDisplay(), suggestDeprecatedValues)">
     <i:block name="addon">
         <i:if test="showSelectionButton">
             <a class="btn btn-outline-secondary" id="@id-addon"><i class="fa-solid fa-bolt"></i></a>

--- a/src/main/resources/default/taglib/t/lookupValues.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValues.html.pasta
@@ -22,7 +22,7 @@
                id="@id"
                allowCustomEntries="@values.acceptsCustomValues()"
                class="@class"
-               suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s/%s', table, values.getDisplay(), values.getExtendedDisplay(), suggestDeprecatedValues)">
+               suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s?considerDeprecatedValues=%s', table, values.getDisplay(), values.getExtendedDisplay(), suggestDeprecatedValues)">
     <i:block name="addon">
         <i:if test="showSelectionButton">
             <a class="btn btn-outline-secondary" id="@id-addon"><i class="fa-solid fa-bolt"></i></a>

--- a/src/main/resources/default/taglib/w/lookupValue.html.pasta
+++ b/src/main/resources/default/taglib/w/lookupValue.html.pasta
@@ -12,6 +12,7 @@
 <i:arg name="adminOnly" type="boolean" default="false"/>
 <i:arg name="allowCustomEntries" type="boolean" default="@value.acceptsCustomValues()"/>
 <i:arg name="id" type="String" default="@generateId('multiselect-%s')"/>
+<i:arg name="suggestDeprecatedValues" type="boolean" default="false"/>
 
 <i:pragma name="inline" value="true"/>
 <i:pragma name="description" value="Renders a dropdown field for a LookupValue field"/>
@@ -47,7 +48,7 @@
             selector: '#@id',
             noMatchesText: '@i18n("template.html.selects.noMatches")',
             placeholderText: '@i18n("template.html.selects.selection")',
-            suggestionsUri: '/system/lookuptable/autocomplete/@value.getTableName()/@value.getDisplay()/@value.getExtendedDisplay()'
+            suggestionsUri: '/system/lookuptable/autocomplete/@value.getTableName()/@value.getDisplay()/@value.getExtendedDisplay()/@suggestDeprecatedValues',
         });
     });
 </script>

--- a/src/main/resources/default/taglib/w/lookupValue.html.pasta
+++ b/src/main/resources/default/taglib/w/lookupValue.html.pasta
@@ -48,7 +48,7 @@
             selector: '#@id',
             noMatchesText: '@i18n("template.html.selects.noMatches")',
             placeholderText: '@i18n("template.html.selects.selection")',
-            suggestionsUri: '/system/lookuptable/autocomplete/@value.getTableName()/@value.getDisplay()/@value.getExtendedDisplay()/@suggestDeprecatedValues',
+            suggestionsUri: '/system/lookuptable/autocomplete/@value.getTableName()/@value.getDisplay()/@value.getExtendedDisplay()?considerDeprecatedValues=@suggestDeprecatedValues',
         });
     });
 </script>

--- a/src/main/resources/default/taglib/w/lookupValues.html.pasta
+++ b/src/main/resources/default/taglib/w/lookupValues.html.pasta
@@ -49,7 +49,7 @@
             allowCustomEntries: @values.acceptsCustomValues(),
             noMatchesText: '@i18n("template.html.selects.noMatches")',
             placeholderText: '@i18n("template.html.selects.selection")',
-            suggestionsUri: '/system/lookuptable/autocomplete/@values.getTableName()/@values.getDisplay()/@values.getExtendedDisplay()/@suggestDeprecatedValues'
+            suggestionsUri: '/system/lookuptable/autocomplete/@values.getTableName()/@values.getDisplay()/@values.getExtendedDisplay()?considerDeprecatedValues=@suggestDeprecatedValues'
         });
     });
 </script>

--- a/src/main/resources/default/taglib/w/lookupValues.html.pasta
+++ b/src/main/resources/default/taglib/w/lookupValues.html.pasta
@@ -9,6 +9,7 @@
 <i:arg name="required" type="boolean" default="false"/>
 <i:arg name="readonly" type="boolean" default="false"/>
 <i:arg name="adminOnly" type="boolean" default="false"/>
+<i:arg name="suggestDeprecatedValues" type="boolean" default="false"/>
 
 <i:pragma name="inline" value="true"/>
 <i:pragma name="description" value="Renders a multiselect dropdown field for LookupValues field"/>
@@ -48,7 +49,7 @@
             allowCustomEntries: @values.acceptsCustomValues(),
             noMatchesText: '@i18n("template.html.selects.noMatches")',
             placeholderText: '@i18n("template.html.selects.selection")',
-            suggestionsUri: '/system/lookuptable/autocomplete/@values.getTableName()/@values.getDisplay()/@values.getExtendedDisplay()'
+            suggestionsUri: '/system/lookuptable/autocomplete/@values.getTableName()/@values.getDisplay()/@values.getExtendedDisplay()/@suggestDeprecatedValues'
         });
     });
 </script>


### PR DESCRIPTION
### Description

The autocomplete route already filtered out deprecated values. The implementations of LookupTable also filtered out deprecated values when using LookupTable#suggest with a filled search term. However LookupTable#scan and LookupTable#suggest without a search term wouldn't filter out deprecated values as it used the #scan method, thus introducing inconsistencies in handling deprecated values.

Whether or not deprecated values should be considered is now handled at low level to prevent:
- Filtering deprecated values multiple times
- Not filtering out deprecated values when no search term is present ("scan" method is used then), but filtering them once the user typed something (e.g. in case a custom autocomplete route is used).
- Limiting the stream of entities before filtering some of them out leaving the user with less suggestions as they should be shown.

The changes are effectively NON breaking, as the existing route is still available (with default to filter out deprecated values) as well as all existing the LookupTable#scan (defaults to filtering out deprecated values) and LookupTable#suggest methods (defaults to not filter out deprecated values).

Note, that only IDB table lookup was tested locally, but it is also the only table with major adjustments.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-975](https://scireum.myjetbrains.com/youtrack/issue/SIRI-975)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
