### PR TITLE
Permits to fine tune S3 connections

### DIFF
--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -44,7 +44,6 @@ public class ObjectStores {
     /*
      * Extended socket timeout when talkting to our S3 store
      */
-    private static final int LONG_SOCKET_TIMEOUT = 60 * 1000 * 5;
     private static final String STORES_EXTENSION_POINT = "s3.stores";
     private static final String KEY_BUCKET_SUFFIX = "bucketSuffix";
     private static final String KEY_ACCESS_KEY = "accessKey";
@@ -52,6 +51,7 @@ public class ObjectStores {
     private static final String KEY_SIGNER = "signer";
     private static final String KEY_PATH_STYLE_ACCESS = "pathStyleAccess";
     private static final String KEY_END_POINT = "endPoint";
+    private static final String KEY_SOCKET_TIMEOUT = "socketTimeout";
 
     /**
      * Contains the logger used for all concerns related to object stores
@@ -143,7 +143,8 @@ public class ObjectStores {
     }
 
     protected AmazonS3 createClient(String name, Settings extension) {
-        ClientConfiguration config = new ClientConfiguration().withSocketTimeout(LONG_SOCKET_TIMEOUT);
+        ClientConfiguration config =
+                new ClientConfiguration().withSocketTimeout((int) extension.getDuration(KEY_SOCKET_TIMEOUT).toMillis());
         if (!extension.get(KEY_SIGNER).isEmptyString()) {
             config.withSignerOverride(extension.get(KEY_SIGNER).asString());
         }

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -42,9 +42,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Register(classes = ObjectStores.class)
 public class ObjectStores {
 
-    /*
-     * Extended socket timeout when talkting to our S3 store
-     */
     private static final String STORES_EXTENSION_POINT = "s3.stores";
     private static final String KEY_BUCKET_SUFFIX = "bucketSuffix";
     private static final String KEY_ACCESS_KEY = "accessKey";

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -31,6 +31,7 @@ import sirius.kernel.settings.Settings;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -54,6 +55,7 @@ public class ObjectStores {
     private static final String KEY_SOCKET_TIMEOUT = "socketTimeout";
     private static final String KEY_CONNECTION_TIMEOUT = "connectionTimeout";
     private static final String KEY_MAX_CONNECTIONS = "maxConnections";
+    private static final String KEY_CONNECTION_TTL = "connectionTTL";
 
     /**
      * Contains the logger used for all concerns related to object stores
@@ -150,6 +152,11 @@ public class ObjectStores {
                                          .withConnectionTimeout((int) extension.getDuration(KEY_CONNECTION_TIMEOUT)
                                                                                .toMillis())
                                          .withMaxConnections(extension.getInt(KEY_MAX_CONNECTIONS));
+        Duration connectionTTL = extension.getDuration(KEY_CONNECTION_TTL);
+        if (connectionTTL.isPositive()) {
+            config.setConnectionTTL((int) connectionTTL.toMillis());
+        }
+
         if (!extension.get(KEY_SIGNER).isEmptyString()) {
             config.withSignerOverride(extension.get(KEY_SIGNER).asString());
         }

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -52,6 +52,7 @@ public class ObjectStores {
     private static final String KEY_PATH_STYLE_ACCESS = "pathStyleAccess";
     private static final String KEY_END_POINT = "endPoint";
     private static final String KEY_SOCKET_TIMEOUT = "socketTimeout";
+    private static final String KEY_CONNECTION_TIMEOUT = "connectionTimeout";
 
     /**
      * Contains the logger used for all concerns related to object stores
@@ -144,7 +145,9 @@ public class ObjectStores {
 
     protected AmazonS3 createClient(String name, Settings extension) {
         ClientConfiguration config =
-                new ClientConfiguration().withSocketTimeout((int) extension.getDuration(KEY_SOCKET_TIMEOUT).toMillis());
+                new ClientConfiguration().withSocketTimeout((int) extension.getDuration(KEY_SOCKET_TIMEOUT).toMillis())
+                                         .withConnectionTimeout((int) extension.getDuration(KEY_CONNECTION_TIMEOUT)
+                                                                               .toMillis());
         if (!extension.get(KEY_SIGNER).isEmptyString()) {
             config.withSignerOverride(extension.get(KEY_SIGNER).asString());
         }

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -53,6 +53,7 @@ public class ObjectStores {
     private static final String KEY_END_POINT = "endPoint";
     private static final String KEY_SOCKET_TIMEOUT = "socketTimeout";
     private static final String KEY_CONNECTION_TIMEOUT = "connectionTimeout";
+    private static final String KEY_MAX_CONNECTIONS = "maxConnections";
 
     /**
      * Contains the logger used for all concerns related to object stores
@@ -147,7 +148,8 @@ public class ObjectStores {
         ClientConfiguration config =
                 new ClientConfiguration().withSocketTimeout((int) extension.getDuration(KEY_SOCKET_TIMEOUT).toMillis())
                                          .withConnectionTimeout((int) extension.getDuration(KEY_CONNECTION_TIMEOUT)
-                                                                               .toMillis());
+                                                                               .toMillis())
+                                         .withMaxConnections(extension.getInt(KEY_MAX_CONNECTIONS));
         if (!extension.get(KEY_SIGNER).isEmptyString()) {
             config.withSignerOverride(extension.get(KEY_SIGNER).asString());
         }

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -154,7 +154,7 @@ public class ObjectStores {
                                          .withMaxConnections(extension.getInt(KEY_MAX_CONNECTIONS));
         Duration connectionTTL = extension.getDuration(KEY_CONNECTION_TTL);
         if (connectionTTL.isPositive()) {
-            config.setConnectionTTL((int) connectionTTL.toMillis());
+            config.setConnectionTTL(connectionTTL.toMillis());
         }
 
         if (!extension.get(KEY_SIGNER).isEmptyString()) {

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -82,7 +82,7 @@ public class ObjectStores {
     protected Counter tunnelledBytes = new Counter();
 
     /**
-     * Provides acccess to the default or <tt>system</tt> store.
+     * Provides access to the default or <tt>system</tt> store.
      *
      * @return the object store which uses the configuration of <tt>system</tt>
      */

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -856,6 +856,7 @@ s3 {
             pathStyleAccess = true
             socketTimeout = 5m
             connectionTimeout = 10s
+            maxConnections = 50
 
             # Specifies the signer to use. Leave empty to use the standard signer of the
             # current AWS SDK.

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -857,6 +857,7 @@ s3 {
             socketTimeout = 5m
             connectionTimeout = 10s
             maxConnections = 50
+            connectionTTL = 0s
 
             # Specifies the signer to use. Leave empty to use the standard signer of the
             # current AWS SDK.

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -855,6 +855,7 @@ s3 {
             bucketSuffix = ""
             pathStyleAccess = true
             socketTimeout = 5m
+            connectionTimeout = 10s
 
             # Specifies the signer to use. Leave empty to use the standard signer of the
             # current AWS SDK.

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -854,13 +854,15 @@ s3 {
             endPoint = ""
             bucketSuffix = ""
             pathStyleAccess = true
-            # Defines the time to wait for a transfer to finish once it has been started.
+            # Defines the time to wait for a transfer to finish once it has been started. We had it previously tuned up to 5 minutes.
+            # the default value defined in com.amazonaws.ClientConfiguration is 50s
             socketTimeout = 5m
-            # Defines the time to wait for a connection to be established.
+            # Defines the time to wait for a connection to be established. 10s is the default value defined in com.amazonaws.ClientConfiguration
             connectionTimeout = 10s
-            # Defines the size of the connection pool.
+            # Defines the size of the connection pool. 50 is the default value defined in com.amazonaws.ClientConfiguration
             maxConnections = 50
-            # Defines how long a connection can be idle before it is closed. If set to 0, connections are never closed.
+            # Defines how long a connection can be idle before it is closed. If set to a value <= 0, connections are never closed
+            # which is the default value defined in com.amazonaws.ClientConfiguration
             connectionTTL = 0s
 
             # Specifies the signer to use. Leave empty to use the standard signer of the

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -854,9 +854,13 @@ s3 {
             endPoint = ""
             bucketSuffix = ""
             pathStyleAccess = true
+            # Defines the time to wait for a transfer to finish once it has been started.
             socketTimeout = 5m
+            # Defines the time to wait for a connection to be established.
             connectionTimeout = 10s
+            # Defines the size of the connection pool.
             maxConnections = 50
+            # Defines how long a connection can be idle before it is closed. If set to 0, connections are never closed.
             connectionTTL = 0s
 
             # Specifies the signer to use. Leave empty to use the standard signer of the

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -854,6 +854,7 @@ s3 {
             endPoint = ""
             bucketSuffix = ""
             pathStyleAccess = true
+            socketTimeout = 5m
 
             # Specifies the signer to use. Leave empty to use the standard signer of the
             # current AWS SDK.


### PR DESCRIPTION
### Description

By enabling the customization of the socket timeout, connection timeout, connection pool size and connection TTL.

The initialization is using the very same default values as before, so this change is no breaking.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-988](https://scireum.myjetbrains.com/youtrack/issue/SIRI-988)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
