### PR TITLE
SIRI-989: File Storage – Fix Duplicate Listing of Files and incorrect Total Count for Pagination

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -285,7 +285,7 @@ public class L3Uplink implements VFSRoot {
                                      List<VirtualFile> children,
                                      BasePageHelper<? extends Blob, ?, ?, ?> blobPageHelper) {
             Page<? extends Blob> blobPage =
-                    blobPageHelper.withStart(limit.getItemsToSkip()).withPageSize(limit.getMaxItems()).asPage();
+                    blobPageHelper.withStart(limit.getItemsToSkip() + 1).withPageSize(limit.getMaxItems()).asPage();
             blobPage.getItems()
                     .stream()
                     .filter(blob -> Strings.isFilled(blob.getFilename()))

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -39,6 +39,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 /**
@@ -245,11 +246,15 @@ public class L3Uplink implements VFSRoot {
             List<VirtualFile> children = new ArrayList<>();
 
             BasePageHelper<? extends Blob, ?, ?, ?> blobPageHelper = directory.queryChildBlobsAsPage(webContext);
-            blobPageHelper.withTotalCount();
-            if (!blobPageHelper.hasFacetFilters()) {
+
+            if (blobPageHelper.hasFacetFilters()) {
+                blobPageHelper.withTotalCount();
+            } else {
                 // We only query for directories if there are no filters (facets) are active,
                 // as we know that we cannot satisfy them anyway...
                 queryChildDirectories(parent, directory, result, limit, children);
+                // We need to calculate total count manually as the page's base query does not include directories.
+                result.withTotalItems(determineTotalChildElements(directory, result, blobPageHelper));
             }
 
             queryChildBlobs(parent, result, limit, children, blobPageHelper);
@@ -263,6 +268,21 @@ public class L3Uplink implements VFSRoot {
             result.withItems(children);
 
             return result;
+        }
+
+        private int determineTotalChildElements(Directory directory,
+                                                Page<VirtualFile> result,
+                                                BasePageHelper<? extends Blob, ?, ?, ?> blobPageHelper) {
+            AtomicInteger counter = new AtomicInteger();
+
+            directory.listChildDirectories(result.getQuery(), Integer.MAX_VALUE, _ -> {
+                counter.incrementAndGet();
+                return true;
+            });
+
+            counter.addAndGet((int) blobPageHelper.getBaseQuery().count());
+
+            return counter.get();
         }
 
         private void queryChildDirectories(VirtualFile parent,


### PR DESCRIPTION
### Description

If directories are present, the total count can't just be calculated based on the number of SQLBlob / MongoBlob entities. While fixing this, a second bug emerged: The last file of a page is also listed as the first file of the next one.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-989](https://scireum.myjetbrains.com/youtrack/issue/SIRI-989)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
