### PR TITLE
Handles AmazonClientException properly

### DIFF
--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.storage.layer1;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
@@ -280,8 +281,9 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
     private S3Object getS3Object(String objectKey) throws IOException {
         try {
             return store.getClient().getObject(bucketName().getName(), objectKey);
-        } catch (AmazonS3Exception exception) {
-            if (exception.getStatusCode() == HttpResponseStatus.NOT_FOUND.code()) {
+        } catch (AmazonClientException exception) {
+            if (exception instanceof AmazonS3Exception s3Exception
+                && s3Exception.getStatusCode() == HttpResponseStatus.NOT_FOUND.code()) {
                 throw new FileNotFoundException(Strings.apply("Layer 1: No object found for key '%s' in bucket '%s'",
                                                               objectKey,
                                                               bucketName()));


### PR DESCRIPTION
### Description

We only handled a sub-class of this exception type so client errors were not properly handled nor properly logged.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-988](https://scireum.myjetbrains.com/youtrack/issue/SIRI-988)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/2019

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
