### PR TITLE
BREAKING: change the way saving processTypes.

### DIFF
--- a/src/main/java/sirius/biz/jobs/FixProcessTypes.java
+++ b/src/main/java/sirius/biz/jobs/FixProcessTypes.java
@@ -1,0 +1,134 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs;
+
+import sirius.biz.jobs.batch.SimpleBatchProcessJobFactory;
+import sirius.biz.jobs.params.BooleanParameter;
+import sirius.biz.jobs.params.Parameter;
+import sirius.biz.process.Process;
+import sirius.biz.process.ProcessContext;
+import sirius.biz.process.Processes;
+import sirius.biz.process.logs.ProcessLog;
+import sirius.biz.tenants.TenantUserManager;
+import sirius.db.es.Elastic;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.PriorityParts;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.nls.NLS;
+import sirius.web.security.Permission;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * Provides a job which fixes process types to now used getName() instead of the NLS-key as processType.
+ */
+@Register(framework = Processes.FRAMEWORK_PROCESSES)
+@Permission(TenantUserManager.PERMISSION_SYSTEM_ADMINISTRATOR)
+public class FixProcessTypes extends SimpleBatchProcessJobFactory {
+
+    @PriorityParts(JobFactory.class)
+    private List<JobFactory> factories;
+
+    @Part
+    private Elastic elastic;
+
+    private static final Parameter<Boolean> SIMULATION =
+            new BooleanParameter("simulation", "Simulation").withDescription(
+                                                                    "Simulation mode will only output which keys are missing and how many processes would have their type changed.")
+                                                            .withDefaultTrue()
+                                                            .build();
+
+    @Override
+    protected void collectParameters(Consumer<Parameter<?>> parameterCollector) {
+        parameterCollector.accept(SIMULATION);
+    }
+
+    @Override
+    protected void execute(ProcessContext process) throws Exception {
+        boolean simulation = process.require(SIMULATION);
+
+        Map<String, String> jobTypesAndKeys = factories.stream()
+                                                       .filter(JobFactory::canStartInBackground)
+                                                       .distinct()
+                                                       .collect(HashMap::new,
+                                                                (map, job) -> map.put(job.getName(),
+                                                                                      job.getClass().getSimpleName()
+                                                                                      + ".label"),
+                                                                HashMap::putAll);
+
+        process.log(ProcessLog.info().withMessage(Strings.apply("Found %s jobs", jobTypesAndKeys.size())));
+        jobTypesAndKeys.forEach((type, nlsKey) -> {
+            AtomicInteger counter = new AtomicInteger();
+            if (!NLS.exists(nlsKey, null)) {
+                process.log(ProcessLog.warn()
+                                      .withMessage(Strings.apply("No NLS key found for type %s (%s)", type, nlsKey)));
+            }
+
+            elastic.select(Process.class).eq(Process.PROCESS_TYPE, nlsKey).iterateAll(executedProcess -> {
+                if (!simulation) {
+                    executedProcess.setProcessType(type);
+                    elastic.update(executedProcess);
+                }
+                counter.getAndIncrement();
+            });
+
+            if (counter.get() > 0) {
+                if (simulation) {
+                    process.log(ProcessLog.info()
+                                          .withMessage(Strings.apply(
+                                                  "Would update the processType on %s Processes from '%s' to '%s'",
+                                                  counter.get(),
+                                                  nlsKey,
+                                                  type)));
+                } else {
+                    process.log(ProcessLog.success()
+                                          .withMessage(Strings.apply(
+                                                  "Updated the processType on %s Processes from '%s' to '%s'",
+                                                  counter.get(),
+                                                  nlsKey,
+                                                  type)));
+                }
+            }
+        });
+    }
+
+    @Override
+    protected String createProcessTitle(Map<String, String> context) {
+        return "Fix process types";
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "fix-process-types";
+    }
+
+    @Nullable
+    @Override
+    public String getDescription() {
+        return "Fixes process-types to now use getName() instead of the NLS-key as processType.";
+    }
+
+    @Override
+    public String getLabel() {
+        return "Fix process types";
+    }
+
+    @Override
+    public String getCategory() {
+        return StandardCategories.SYSTEM_ADMINISTRATION;
+    }
+}

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
@@ -119,7 +119,7 @@ public abstract class BatchProcessJobFactory extends BasicJobFactory {
      * @return the id of the newly created process
      */
     protected String startWithContext(Map<String, String> context) {
-        String processId = processes.createProcess(getClass().getSimpleName() + ".label",
+        String processId = processes.createProcess(getName(),
                                                    createProcessTitle(context),
                                                    getIcon(),
                                                    getCurrentOrRootUser(),

--- a/src/main/java/sirius/biz/process/ProcessController.java
+++ b/src/main/java/sirius/biz/process/ProcessController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import sirius.biz.cluster.work.DistributedTasks;
+import sirius.biz.jobs.JobFactory;
 import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.process.logs.ProcessLogHandler;
 import sirius.biz.process.logs.ProcessLogState;
@@ -105,7 +106,7 @@ public class ProcessController extends BizController {
                                      Process.REFERENCES,
                                      NLS.get("ProcessController.reference"),
                                      null);
-        pageHelper.addTermAggregation(Process.PROCESS_TYPE, value -> NLS.getIfExists(value, null).orElse(null));
+        pageHelper.addTermAggregation(Process.PROCESS_TYPE, this::findJobLabel);
         pageHelper.addTimeAggregation(Process.STARTED,
                                       false,
                                       DateRange.LAST_FIVE_MINUTES,
@@ -119,6 +120,11 @@ public class ProcessController extends BizController {
         pageHelper.withTotalCount();
 
         webContext.respondWith().template("/templates/biz/process/processes.html.pasta", pageHelper.asPage());
+    }
+
+    private String findJobLabel(String value) {
+        JobFactory result = context.getPart(value, JobFactory.class);
+        return result != null ? result.getLabel() : null;
     }
 
     private Process findAccessibleProcess(String processId) {


### PR DESCRIPTION
until now we always stored getClass().getSimpleName() + ".label" = MyJobFactory.label in the processType field on processes. For overridden implementations of e.g. abstract jobs this leads to not make the processes filterable on /ps. Now we will use the job#getName and store it as the processType. So the filtering url no longer is `/ps?processType=BmecatImportJobFactory.label` but `/ps?processType=import-bmecat`
To migrate existing values we implement a temporary job which resolves all available jobs and resolves the correct new type.

<img width="1051" alt="Bildschirmfoto 2024-07-18 um 18 37 58" src="https://github.com/user-attachments/assets/46861414-5f64-409c-97ed-075797b8209b">
<img width="1027" alt="Bildschirmfoto 2024-07-18 um 18 39 51" src="https://github.com/user-attachments/assets/1a31c986-8ff0-4582-ab00-c34b55c22bcd">

Patch-Task: Execute the job in simulation-mode (e.g. on a staging-system) and maybe adjust missing NLS-Keys.
Then execute it with simulation: no to fix all existing values.

BREAKING: If the job isn't executed - old jobs are not visible filterable by type

### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-990](https://scireum.myjetbrains.com/youtrack/issue/SIRI-990)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
