### PR TITLE
Fix: Deprecated Attributes (OX-11128)

### DIFF
--- a/src/main/resources/default/kb/00000.html.pasta
+++ b/src/main/resources/default/kb/00000.html.pasta
@@ -27,8 +27,7 @@
                         <div class="pb-2">
                             <div>
                                 <k:link link="@apply('/kba/%s/%s', chapter.getLanguage(), chapter.getArticleId())"
-                                        icon="fa-solid fa-book"
-                                        name="@chapter.getTitle()"/>
+                                        icon="fa-solid fa-book">@chapter.getTitle()</k:link>
                             </div>
                             <div class="text-muted">
                                 @chapter.getDescription()

--- a/src/main/resources/default/kb/en/user/noodle.html.pasta
+++ b/src/main/resources/default/kb/en/user/noodle.html.pasta
@@ -35,7 +35,7 @@
             </li>
             <li>
                 Macro calls: <k:inlineCode>isEmpty("test")</k:inlineCode>. All available macros are listed here:
-                <k:link link="/system/tags" name="Tagliatelle Tag Overview" target="_blank"/>.
+                <k:link link="/system/tags" target="_blank">Tagliatelle Tag Overview</k:link>
             </li>
             <li>
                 If statements: <k:inlineCode>if (condition) { statements; }</k:inlineCode>

--- a/src/main/resources/default/kb/en/user/tagliatelle.html.pasta
+++ b/src/main/resources/default/kb/en/user/tagliatelle.html.pasta
@@ -48,6 +48,6 @@
     </k:section>
     <k:section heading="Available tags and macros" anchor="available-tags-and-macros">
         A list of all available tags and macros can be found here:
-        <k:link link="/system/tags" name="Tagliatelle Tag Overview" target="_blank"/>.
+        <k:link link="/system/tags" target="_blank">Tagliatelle Tag Overview</k:link>
     </k:section>
 </k:article>

--- a/src/main/resources/default/taglib/k/base.html.pasta
+++ b/src/main/resources/default/taglib/k/base.html.pasta
@@ -61,8 +61,9 @@
                     <i:if test="parent != null">
                         <t:inlineInfo>
                             <k:link link="@apply('/kba/%s/%s', parent.getLanguage(), parent.getArticleId())"
-                                    icon="fa-solid fa-book"
-                                    name="@parent.getTitle()"/>
+                                    icon="fa-solid fa-book">
+                                @parent.getTitle()
+                            </k:link>
                         </t:inlineInfo>
                     </i:if>
                     <t:inlineInfo>
@@ -132,8 +133,9 @@
                                 <div class="pb-2">
                                     <div>
                                         <k:link link="@apply('/kba/%s/%s', reference.getLanguage(), reference.getArticleId())"
-                                                icon="@(reference.isChapter() ? 'fa-solid fa-book' : 'fa-solid fa-file-alt')"
-                                                name="@reference.getTitle()"/>
+                                                icon="@(reference.isChapter() ? 'fa-solid fa-book' : 'fa-solid fa-file-alt')">
+                                            @reference.getTitle()
+                                        </k:link>
                                     </div>
                                     <div class="text-muted">
                                         @reference.getDescription()

--- a/src/main/resources/default/taglib/k/chapter.html.pasta
+++ b/src/main/resources/default/taglib/k/chapter.html.pasta
@@ -38,8 +38,7 @@
                 <div class="pb-2">
                     <div>
                         <k:link link="@apply('/kba/%s/%s', chapter.getLanguage(), chapter.getArticleId())"
-                                icon="fa-solid fa-book"
-                                name="@chapter.getTitle()"/>
+                                icon="fa-solid fa-book">@chapter.getTitle()</k:link>
                     </div>
                     <div class="text-muted">
                         @chapter.getDescription()
@@ -56,8 +55,7 @@
                 <div class="pb-2">
                     <div>
                         <k:link link="@apply('/kba/%s/%s', child.getLanguage(), child.getArticleId())"
-                                icon="fa-solid fa-file-alt"
-                                name="@child.getTitle()"/>
+                                icon="fa-solid fa-file-alt">@child.getTitle()</k:link>
                     </div>
                     <div class="text-muted">
                         @child.getDescription()

--- a/src/main/resources/default/templates/biz/tycho/kb/welcome.html.pasta
+++ b/src/main/resources/default/templates/biz/tycho/kb/welcome.html.pasta
@@ -15,7 +15,7 @@
     <i:if test="isFrameworkEnabled('tycho.open-search')">
         <t:permission permission="permission-open-search">
             Also note that you can use the
-            <k:link link="/open-search" icon="fa-solid fa-search" name="System-wide Search"/>
+            <k:link link="/open-search" icon="fa-solid fa-search">System-wide Search</k:link>
             to find articles for a given keyword.
         </t:permission>
     </i:if>

--- a/src/main/resources/default/templates/biz/tycho/kb/welcome_de.html.pasta
+++ b/src/main/resources/default/templates/biz/tycho/kb/welcome_de.html.pasta
@@ -15,7 +15,7 @@
     <i:if test="isFrameworkEnabled('tycho.open-search')">
         <t:permission permission="permission-open-search">
             Bitte beachten Sie, dass Sie auch die
-            <k:link link="/open-search" icon="fa-solid fa-search" name="Systemweite Suche"/>
+            <k:link link="/open-search" icon="fa-solid fa-search">Systemweite Suche</k:link>
             verwenden können, um entsprechende Hilfeseiten zu finden.
         </t:permission>
     </i:if>


### PR DESCRIPTION
### Description

The `name` attribute has been deprecated earlier in commit a5f4a410156dc2078c474f7aafdc83b6c2e43cd6, thus leading to unwanted warnings when running `eod synchronize-knowledgebase`.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11128](https://scireum.myjetbrains.com/youtrack/issue/OX-11128)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
