### PR TITLE
SIRI-1007 Allow entities to supply custom journal info

### DIFF
--- a/src/main/java/sirius/biz/protocol/CustomJournalProvider.java
+++ b/src/main/java/sirius/biz/protocol/CustomJournalProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.protocol;
+
+import java.util.function.Consumer;
+
+/**
+ * Permits to add custom info to a {@link JournalEntry}.
+ * <p>
+ * This can be added to a {@link sirius.db.mixing.BaseEntity} in order to write custom journal info. For example,
+ * changes to serialized data, or {@link sirius.db.mixing.Nested} properties can be logged in a more readable manner.
+ */
+public interface CustomJournalProvider {
+
+    /**
+     * Permits to add additional info when writing a {@link JournalEntry}.
+     *
+     * @param journalConsumer the consumer to supply additional info to
+     */
+    void addCustomJournal(Consumer<String> journalConsumer);
+}

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -85,10 +85,7 @@ public class JournalData extends Composite {
      * @return a stream of all journaled properties
      */
     public Stream<Property> fetchJournaledProperties() {
-        return owner.getDescriptor()
-                    .getProperties()
-                    .stream()
-                    .filter(p -> p.getAnnotation(NoJournal.class).isEmpty());
+        return owner.getDescriptor().getProperties().stream().filter(p -> p.getAnnotation(NoJournal.class).isEmpty());
     }
 
     /**

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -85,7 +85,10 @@ public class JournalData extends Composite {
      * @return a stream of all journaled properties
      */
     public Stream<Property> fetchJournaledProperties() {
-        return owner.getDescriptor().getProperties().stream().filter(p -> p.getAnnotation(NoJournal.class).isEmpty());
+        return owner.getDescriptor()
+                    .getProperties()
+                    .stream()
+                    .filter(property -> property.getAnnotation(NoJournal.class).isEmpty());
     }
 
     /**
@@ -94,7 +97,7 @@ public class JournalData extends Composite {
      * @return a stream of all journaled properties which are changed
      */
     public Stream<Property> fetchJournaledAndChangedProperties() {
-        return fetchJournaledProperties().filter(p -> p.getDescriptor().isChanged(owner, p));
+        return fetchJournaledProperties().filter(property -> property.getDescriptor().isChanged(owner, property));
     }
 
     /**
@@ -106,12 +109,12 @@ public class JournalData extends Composite {
      */
     public String buildChangeJournal() {
         StringBuilder changes = new StringBuilder();
-        fetchJournaledAndChangedProperties().forEach(p -> {
-            changes.append(p.getName());
+        fetchJournaledAndChangedProperties().forEach(property -> {
+            changes.append(property.getName());
             changes.append(": ");
-            changes.append(NLS.toUserString(owner.getPersistedValue(p), NLS.getDefaultLanguage()));
+            changes.append(NLS.toUserString(owner.getPersistedValue(property), NLS.getDefaultLanguage()));
             changes.append(" -> ");
-            changes.append(NLS.toUserString(p.getValue(owner), NLS.getDefaultLanguage()));
+            changes.append(NLS.toUserString(property.getValue(owner), NLS.getDefaultLanguage()));
             changes.append("\n");
         });
 

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -118,6 +118,10 @@ public class JournalData extends Composite {
             changes.append("\n");
         });
 
+        if (owner instanceof CustomJournalProvider customJournalProvider) {
+            customJournalProvider.addCustomJournal(changes::append);
+        }
+
         return changes.toString();
     }
 
@@ -238,7 +242,7 @@ public class JournalData extends Composite {
             return false;
         }
 
-        return fetchJournaledAndChangedProperties().findAny().isPresent();
+        return Strings.isFilled(buildChangeJournal());
     }
 
     /**


### PR DESCRIPTION
### Description
This can be added to a BaseEntity in order to write custom journal info. For example, changes to serialized data, or Nested properties can be logged in a more readable manner.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1007](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1007)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
