### PR TITLE
Skips deleted onboarding videos from deletion marking

### DIFF
--- a/src/main/java/sirius/biz/tycho/academy/jdbc/SQLOnboardingEngine.java
+++ b/src/main/java/sirius/biz/tycho/academy/jdbc/SQLOnboardingEngine.java
@@ -64,6 +64,7 @@ public class SQLOnboardingEngine extends OnboardingEngine {
     protected void markOutdatedAcademyVideosAsDeleted(String academy, String tokenToSkip) {
         oma.select(SQLAcademyVideo.class)
            .eq(SQLAcademyVideo.ACADEMY_VIDEO_DATA.inner(AcademyVideoData.ACADEMY), academy)
+           .eq(SQLAcademyVideo.ACADEMY_VIDEO_DATA.inner(AcademyVideoData.DELETED), false)
            .ne(SQLAcademyVideo.ACADEMY_VIDEO_DATA.inner(AcademyVideoData.SYNC_TOKEN), tokenToSkip)
            .iterateAll(video -> {
                try {

--- a/src/main/java/sirius/biz/tycho/academy/mongo/MongoOnboardingEngine.java
+++ b/src/main/java/sirius/biz/tycho/academy/mongo/MongoOnboardingEngine.java
@@ -67,6 +67,7 @@ public class MongoOnboardingEngine extends OnboardingEngine {
     protected void markOutdatedAcademyVideosAsDeleted(String academy, String tokenToSkip) {
         mango.select(MongoAcademyVideo.class)
              .eq(MongoAcademyVideo.ACADEMY_VIDEO_DATA.inner(AcademyVideoData.ACADEMY), academy)
+             .eq(MongoAcademyVideo.ACADEMY_VIDEO_DATA.inner(AcademyVideoData.DELETED), false)
              .ne(MongoAcademyVideo.ACADEMY_VIDEO_DATA.inner(AcademyVideoData.SYNC_TOKEN), tokenToSkip)
              .iterateAll(video -> {
                  try {


### PR DESCRIPTION
### Description

Already deleted videos (deleted = true) don't need to be marked again. This might cause the following error if the video has not been physically deleted yet when the recompute loops run:
```
Ein Fehler ist aufgetreten: Tried to update the changed entity MONGOACADEMYVIDEO-2HB7AN57L814PM709QGAFBDDFO (2HB7AN57L814PM709QGAFBDDFO), but actually nothing was changed in the database! There might be an error in one of its properties' transform or equals methods, as the framework indicated a changed property. The following properties are considered changed: academyVideoData_lastUpdated
```

### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
