### PR TITLE
Sets max cached days for virtual URLs based on config value

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -119,7 +119,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     /**
      * Contains the name of the config key used to determine the maximal number of days a virtual URL is cached.
      */
-    private static final String CONFIG_KEY_MAX_VALIDITY_DAYS_VIRTUAL_URL = "maxValidityDaysForVirtualURL";
+    private static final String CONFIG_KEY_MAX_VALIDITY_DAYS_VIRTUAL_URL = "maxValidityDaysForVirtualUrl";
 
     /**
      * Contains the name of the config key used to determine which permission is required to write blobs
@@ -290,7 +290,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     protected final String description;
     protected String spaceName;
     protected String readPermission;
-    protected int maxValidityDaysForVirtualURL;
+    protected int maxValidityDaysForVirtualUrl;
     protected String writePermission;
     protected String baseUrl;
     protected boolean useNormalizedNames;
@@ -310,7 +310,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         this.spaceName = spaceName;
         this.config = config;
         this.readPermission = config.get(CONFIG_KEY_PERMISSION_READ).asString();
-        this.maxValidityDaysForVirtualURL = config.get(CONFIG_KEY_MAX_VALIDITY_DAYS_VIRTUAL_URL).asInt(-1);
+        this.maxValidityDaysForVirtualUrl = config.get(CONFIG_KEY_MAX_VALIDITY_DAYS_VIRTUAL_URL).asInt(-1);
         this.writePermission = config.get(CONFIG_KEY_PERMISSION_WRITE).asString();
         this.baseUrl = config.get(CONFIG_KEY_BASE_URL).getString();
         this.useNormalizedNames = config.get(CONFIG_KEY_USE_NORMALIZED_NAMES).asBoolean();
@@ -385,7 +385,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
 
     @Override
     public int getMaxValidityDaysForVirtualUrl() {
-        return maxValidityDaysForVirtualURL;
+        return maxValidityDaysForVirtualUrl;
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -117,6 +117,11 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     private static final String CONFIG_KEY_PERMISSION_READ = "readPermission";
 
     /**
+     * Contains the name of the config key used to determine the maximal number of days a virtual URL is cached.
+     */
+    private static final String CONFIG_KEY_MAX_VALIDITY_DAYS_VIRTUAL_URL = "maxValidityDaysForVirtualURL";
+
+    /**
      * Contains the name of the config key used to determine which permission is required to write blobs
      * in the space.
      */
@@ -285,6 +290,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     protected final String description;
     protected String spaceName;
     protected String readPermission;
+    protected int maxValidityDaysForVirtualURL;
     protected String writePermission;
     protected String baseUrl;
     protected boolean useNormalizedNames;
@@ -304,6 +310,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         this.spaceName = spaceName;
         this.config = config;
         this.readPermission = config.get(CONFIG_KEY_PERMISSION_READ).asString();
+        this.maxValidityDaysForVirtualURL = config.get(CONFIG_KEY_MAX_VALIDITY_DAYS_VIRTUAL_URL).asInt(-1);
         this.writePermission = config.get(CONFIG_KEY_PERMISSION_WRITE).asString();
         this.baseUrl = config.get(CONFIG_KEY_BASE_URL).getString();
         this.useNormalizedNames = config.get(CONFIG_KEY_USE_NORMALIZED_NAMES).asBoolean();
@@ -374,6 +381,11 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     @Override
     public int getUrlValidityDays() {
         return urlValidityDays;
+    }
+
+    @Override
+    public int getMaxValidityDaysForVirtualUrl() {
+        return maxValidityDaysForVirtualURL;
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
@@ -198,7 +198,7 @@ public class BlobDispatcher implements WebDispatcher {
      */
     private Integer computeCacheDurationFromHash(Response response, String accessToken, String key, String space) {
         BlobStorageSpace storageSpace = blobStorage.getSpace(space);
-        Optional<Integer> optionalHashDays = utils.verifyHash(key, accessToken, storageSpace.getUrlValidityDays());
+        Optional<Integer> optionalHashDays = utils.verifyHash(key, accessToken, storageSpace);
         if (optionalHashDays.isEmpty()) {
             response.error(HttpResponseStatus.UNAUTHORIZED);
             return null;

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
@@ -380,4 +380,11 @@ public interface BlobStorageSpace {
      * @return the amount of days
      */
     int getUrlValidityDays();
+
+    /**
+     * Defines for up to how many days a generated {@linkplain URLBuilder url} for virtual files is valid max.
+     *
+     * @return the amount of days
+     */
+    int getMaxValidityDaysForVirtualUrl();
 }

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -80,6 +80,9 @@ public class URLBuilder {
     @ConfigValue("storage.layer2.largeFileLimit")
     private static long largeFileLimit;
 
+    @ConfigValue("storage.layer2.maxCachedDaysForVirtualURL")
+    private static int maxCachedDaysForVirtualURL;
+
     /**
      * Contains the {@linkplain #buildUrlResult() generated URL} and an {@linkplain UrlType indicator} if it is a
      * virtual, physical, the fallback URL, or empty.
@@ -526,7 +529,7 @@ public class URLBuilder {
         result.append("/");
         result.append(space.getName());
         result.append("/");
-        result.append(computeAccessToken(blobKey + "-" + variant));
+        result.append(computeAccessTokenForVirtualURL(blobKey + "-" + variant));
         result.append("/");
         result.append(variant);
         if (forceDownload) {
@@ -601,6 +604,14 @@ public class URLBuilder {
             return utils.computeEternallyValidHash(authToken);
         } else {
             return utils.computeHash(authToken, 0);
+        }
+    }
+
+    private String computeAccessTokenForVirtualURL(String authToken) {
+        if (maxCachedDaysForVirtualURL >= 0 && eternallyValid) {
+            return utils.computeHash(authToken, maxCachedDaysForVirtualURL);
+        } else {
+            return computeAccessToken(authToken);
         }
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -526,7 +526,7 @@ public class URLBuilder {
         result.append("/");
         result.append(space.getName());
         result.append("/");
-        result.append(computeAccessTokenForVirtualURL(blobKey + "-" + variant));
+        result.append(computeAccessTokenForVirtualUrl(blobKey + "-" + variant));
         result.append("/");
         result.append(variant);
         if (forceDownload) {
@@ -604,7 +604,7 @@ public class URLBuilder {
         }
     }
 
-    private String computeAccessTokenForVirtualURL(String authToken) {
+    private String computeAccessTokenForVirtualUrl(String authToken) {
         if (space.getMaxValidityDaysForVirtualUrl() >= 0 && eternallyValid) {
             return utils.computeHash(authToken, space.getMaxValidityDaysForVirtualUrl());
         } else {

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -80,9 +80,6 @@ public class URLBuilder {
     @ConfigValue("storage.layer2.largeFileLimit")
     private static long largeFileLimit;
 
-    @ConfigValue("storage.layer2.maxCachedDaysForVirtualURL")
-    private static int maxCachedDaysForVirtualURL;
-
     /**
      * Contains the {@linkplain #buildUrlResult() generated URL} and an {@linkplain UrlType indicator} if it is a
      * virtual, physical, the fallback URL, or empty.
@@ -608,8 +605,8 @@ public class URLBuilder {
     }
 
     private String computeAccessTokenForVirtualURL(String authToken) {
-        if (maxCachedDaysForVirtualURL >= 0 && eternallyValid) {
-            return utils.computeHash(authToken, maxCachedDaysForVirtualURL);
+        if (space.getMaxValidityDaysForVirtualUrl() >= 0 && eternallyValid) {
+            return utils.computeHash(authToken, space.getMaxValidityDaysForVirtualUrl());
         } else {
             return computeAccessToken(authToken);
         }

--- a/src/main/java/sirius/biz/storage/util/StorageUtils.java
+++ b/src/main/java/sirius/biz/storage/util/StorageUtils.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.storage.util;
 
+import sirius.biz.storage.layer2.BlobStorageSpace;
 import sirius.kernel.Sirius;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Hasher;
@@ -96,12 +97,12 @@ public class StorageUtils {
      * <p>
      * 0 means the hash is valid today. A negative number represents past days and a positive number days in the future.
      *
-     * @param key          the key to verify
-     * @param hash         the hash to verify
-     * @param validityDays the number of days the hash should be valid into the past
+     * @param key   the key to verify
+     * @param hash  the hash to verify
+     * @param space the space to use for the verification
      * @return the day count from today for which the hash is valid or an empty optional if the hash is invalid
      */
-    public Optional<Integer> verifyHash(String key, String hash, int validityDays) {
+    public Optional<Integer> verifyHash(String key, String hash, BlobStorageSpace space) {
         // Check for a hash for today...
         if (Strings.areEqual(hash, computeHash(key, 0))) {
             return Optional.of(0);
@@ -112,8 +113,13 @@ public class StorageUtils {
             return Optional.of(Integer.MAX_VALUE);
         }
 
+        // Check for max validity of virtual urls...
+        if (Strings.areEqual(hash, computeHash(key, space.getMaxValidityDaysForVirtualUrl()))) {
+            return Optional.of(space.getMaxValidityDaysForVirtualUrl());
+        }
+
         // Check for hashes up to X days into the past...
-        for (int i = 1; i <= validityDays; i++) {
+        for (int i = 1; i <= space.getUrlValidityDays(); i++) {
             if (Strings.areEqual(hash, computeHash(key, -i))) {
                 return Optional.of(-i);
             }

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -988,6 +988,9 @@ storage {
         # Note that this check has to be enabled manually using URLBuilder.enableLargeFileDetection.
         largeFileLimit = 128M
 
+        # Number of days to cache virtual URLs. If set to -1, there will be no special handling for virtual URLs.
+        maxCachedDaysForVirtualURL = -1
+
         # Controls the conversion settings used by the BlobStorageSpace to generate variants of a blob.
         conversion {
 

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1083,7 +1083,7 @@ storage {
                 kba = ""
 
                 # Number of days to cache virtual URLs. If set to -1, there will be no special handling for virtual URLs.
-                maxValidityDaysForVirtualURL = -1
+                maxValidityDaysForVirtualUrl = -1
             }
 
             # Defines a work space which is shared by all users of a tenant and can be used to provide

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -988,9 +988,6 @@ storage {
         # Note that this check has to be enabled manually using URLBuilder.enableLargeFileDetection.
         largeFileLimit = 128M
 
-        # Number of days to cache virtual URLs. If set to -1, there will be no special handling for virtual URLs.
-        maxCachedDaysForVirtualURL = -1
-
         # Controls the conversion settings used by the BlobStorageSpace to generate variants of a blob.
         conversion {
 
@@ -1084,6 +1081,9 @@ storage {
 
                 # Contains the knowledge base article (KBA) to link to, when showing this space in /fs
                 kba = ""
+
+                # Number of days to cache virtual URLs. If set to -1, there will be no special handling for virtual URLs.
+                maxValidityDaysForVirtualURL = -1
             }
 
             # Defines a work space which is shared by all users of a tenant and can be used to provide


### PR DESCRIPTION
### Description

On some systems, images are exchanged very frequently (with the same name). Here we need a shorter cache time so that the wrong image is not displayed and a new variant for preview etc. can be created.

Breaking because this PR extends an interface `sirius.biz.storage.layer2.BlobStorageSpace` and changes the methode-signature in a method `sirius.biz.storage.util.StorageUtils#verifyHash`.

### Additional Notes

- This PR fixes or works on following ticket(s): https://scireum.myjetbrains.com/youtrack/issue/SE-13898
### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
