### PR TITLE
Maintenance: Unused Method (OX-10783)

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -405,31 +405,6 @@ public class URLBuilder {
     }
 
     /**
-     * Builds the URL for {@linkplain sirius.web.templates.pdf.TagliatellePDFContentHandler embedding the blob into a
-     * PDF}. This is done via a special {@link sirius.biz.web.BlobPdfReplaceHandler blob://} URI.
-     * <p>
-     * If the image is not available, a {@linkplain #fallbackUri fallback} URI using the
-     * {@link sirius.web.templates.pdf.handlers.ResourcePdfReplaceHandler resource://} scheme is returned.
-     *
-     * @return a <tt>blob://</tt> URI, or a <tt>resource://</tt> URI pointing to a fallback image in case of errors
-     */
-    public String buildUrlForEmbeddingIntoPdf() {
-        if (space == null || Strings.isEmpty(blobKey)) {
-            return "resource:/" + Optional.ofNullable(fallbackUri)
-                                          .filter(Strings::isFilled)
-                                          .map(string -> string.startsWith("assets/") ? '/' + string : string)
-                                          .filter(string -> string.startsWith("/assets/"))
-                                          .orElse(IMAGE_FALLBACK_URI);
-        }
-
-        StringBuilder builder = new StringBuilder("blob://").append(space.getName()).append('/').append(blobKey);
-        if (Strings.isFilled(variant)) {
-            builder.append('/').append(variant);
-        }
-        return builder.toString();
-    }
-
-    /**
      * Determines if a conversion for the given variant is expected.
      *
      * @return <tt>true</tt> if a variant is selected, for which no physical key is present. <tt>false</tt> if there


### PR DESCRIPTION
### Description

Removes a method that has been introduced while working on OXOMI's new PDF datasheet renderer. In the meantime, the PDF generator now supports direct use of plain URLs. We no longer need to manually output special URLs, and the deleted method is now unused. S2 apparently never used the method at all. The PR is thus only _mildly breaking_. 😇

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10783](https://scireum.myjetbrains.com/youtrack/issue/OX-10783)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
