### PR TITLE
Permits to override the suggestion uri in t:lookupValue

### DIFF
--- a/src/main/resources/default/taglib/t/lookupValue.html.pasta
+++ b/src/main/resources/default/taglib/t/lookupValue.html.pasta
@@ -12,6 +12,7 @@
 <i:arg name="allowCustomEntries" type="boolean" default="@value.acceptsCustomValues()"/>
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
 <i:arg name="suggestDeprecatedValues" type="boolean" default="false"/>
+<i:arg name="suggestionUri" type="String" default="@apply('/system/lookuptable/autocomplete/%s/%s/%s?considerDeprecatedValues=%s', table, value.getDisplay(), value.getExtendedDisplay(), suggestDeprecatedValues)"/>
 
 <i:pragma name="inline" value="true"/>
 <i:pragma name="description" value="Renders a dropdown field for a LookupValue field"/>
@@ -25,7 +26,7 @@
                 id="@id"
                 allowCustomEntries="@allowCustomEntries"
                 class="@class"
-                suggestionUri="@apply('/system/lookuptable/autocomplete/%s/%s/%s?considerDeprecatedValues=%s', table, value.getDisplay(), value.getExtendedDisplay(), suggestDeprecatedValues)">
+                suggestionUri="@suggestionUri">
     <i:block name="addon">
         <i:if test="showSelectionButton">
             <a class="btn btn-outline-secondary" id="@id-addon" tabindex="0"><i class="fa-solid fa-bolt"></i></a>


### PR DESCRIPTION
### Description

This is needed for the coming ability to define sub-properties of a property.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11245](https://scireum.myjetbrains.com/youtrack/issue/OX-11245)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
