### PR TITLE
Smart Value - Show edit option in tenant smart value even when tenant is already selected

### DIFF
--- a/src/main/java/sirius/biz/tycho/smart/TenantSmartValueProvider.java
+++ b/src/main/java/sirius/biz/tycho/smart/TenantSmartValueProvider.java
@@ -41,10 +41,8 @@ public class TenantSmartValueProvider implements SmartValueProvider {
         }
 
         UserInfo currentUser = UserContext.getCurrentUser();
-        if (Strings.areEqual(tenant.getIdAsString(), currentUser.getTenantId())) {
-            return;
-        }
-        if (currentUser.hasPermission("permission-select-tenant")) {
+        if (currentUser.hasPermission("permission-select-tenant") && !Strings.areEqual(tenant.getIdAsString(),
+                                                                                       currentUser.getTenantId())) {
             valueCollector.accept(new SmartValue("fa-solid fa-exchange-alt",
                                                  NLS.get("TenantController.select"),
                                                  "/tenants/select/" + tenant.getIdAsString(),

--- a/src/main/java/sirius/biz/tycho/smart/TenantSmartValueProvider.java
+++ b/src/main/java/sirius/biz/tycho/smart/TenantSmartValueProvider.java
@@ -9,6 +9,8 @@
 package sirius.biz.tycho.smart;
 
 import sirius.biz.tenants.Tenant;
+import sirius.biz.tenants.TenantController;
+import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.tenants.Tenants;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
@@ -41,15 +43,15 @@ public class TenantSmartValueProvider implements SmartValueProvider {
         }
 
         UserInfo currentUser = UserContext.getCurrentUser();
-        if (currentUser.hasPermission("permission-select-tenant") && !Strings.areEqual(tenant.getIdAsString(),
-                                                                                       currentUser.getTenantId())) {
+        if (currentUser.hasPermission(TenantUserManager.PERMISSION_SELECT_TENANT)
+            && !Strings.areEqual(tenant.getIdAsString(), currentUser.getTenantId())) {
             valueCollector.accept(new SmartValue("fa-solid fa-exchange-alt",
                                                  NLS.get("TenantController.select"),
                                                  "/tenants/select/" + tenant.getIdAsString(),
                                                  null));
         }
 
-        if (currentUser.hasPermission("permission-manage-tenants")) {
+        if (currentUser.hasPermission(TenantController.PERMISSION_MANAGE_TENANTS)) {
             valueCollector.accept(new SmartValue("fa-solid fa-pen-to-square",
                                                  NLS.get("TenantController.edit"),
                                                  "/tenant/" + tenant.getIdAsString(),

--- a/src/main/java/sirius/biz/tycho/smart/UserAccountSmartValueProvider.java
+++ b/src/main/java/sirius/biz/tycho/smart/UserAccountSmartValueProvider.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.tycho.smart;
 
+import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.tenants.Tenants;
 import sirius.biz.tenants.UserAccount;
 import sirius.kernel.commons.Strings;
@@ -33,14 +34,15 @@ public class UserAccountSmartValueProvider implements SmartValueProvider {
     public void collectValues(String type, Object payload, Consumer<SmartValue> valueCollector) {
         if (payload instanceof UserAccount<?, ?> user) {
             if (tenants != null
-                && UserContext.getCurrentUser().hasPermission("permission-select-tenant")
+                && UserContext.getCurrentUser()
+                              .hasPermission(TenantUserManager.PERMISSION_SELECT_TENANT)
                 && !Strings.areEqual(user.getTenantAsString(), UserContext.getCurrentUser().getTenantId())) {
                 valueCollector.accept(new SmartValue("fa-solid fa-exchange-alt",
                                                      tenants.fetchCachedTenantName(user.getTenantAsString()),
                                                      "/tenants/select/" + user.getTenantAsString(),
                                                      null));
             }
-            if (UserContext.getCurrentUser().hasPermission("permission-select-user-account")
+            if (UserContext.getCurrentUser().hasPermission(TenantUserManager.PERMISSION_SELECT_USER_ACCOUNT)
                 && !Strings.areEqual(user.getUniqueName(), UserContext.getCurrentUser().getUserId())) {
                 valueCollector.accept(new SmartValue("fa-solid fa-exchange-alt",
                                                      user.getUserAccountData().getShortName(),


### PR DESCRIPTION
### Description

The edit option should be presented independently of whether the tenant is already the current tenant or not.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1020](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1020)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
