### PR TITLE
Introduces new customer-scripting events

### DIFF
--- a/src/main/java/sirius/biz/importer/AfterLineLoadEvent.java
+++ b/src/main/java/sirius/biz/importer/AfterLineLoadEvent.java
@@ -1,0 +1,46 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.importer;
+
+import sirius.biz.scripting.ScriptableEvent;
+import sirius.kernel.commons.Context;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
+
+/**
+ * Triggered once a line has been loaded from a line-based file and parsed by an {@link sirius.biz.importer.format.ImportDictionary},
+ * providing the context read which could be manipulated by scripts before any other action is taken.
+ */
+public class AfterLineLoadEvent extends ScriptableEvent {
+
+    private final Context context;
+    private final ImporterContext importerContext;
+
+    /**
+     * Creates a new event for the given context and importer context.
+     *
+     * @param context         the context loaded from the input file
+     * @param importerContext the import context which can be used to access other handlers / the importer itself
+     */
+    @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
+    public AfterLineLoadEvent(Context context, ImporterContext importerContext) {
+        this.importerContext = importerContext;
+        this.context = context;
+    }
+
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
+    @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
+    public Context getContext() {
+        return context;
+    }
+
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
+    public ImporterContext getImporterContext() {
+        return importerContext;
+    }
+}

--- a/src/main/java/sirius/biz/importer/AfterNodeLoadEvent.java
+++ b/src/main/java/sirius/biz/importer/AfterNodeLoadEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.importer;
+
+import sirius.biz.scripting.ScriptableEvent;
+import sirius.kernel.xml.StructuredNode;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
+
+/**
+ * Triggered once a node has been loaded from an XML file for import, so the contents of the node could be manipulated.
+ */
+public class AfterNodeLoadEvent extends ScriptableEvent {
+    private final StructuredNode structuredNode;
+    private final ImporterContext importerContext;
+
+    /**
+     * Creates a new event for the given node and importer context.
+     *
+     * @param structuredNode  the node loaded from the input file
+     * @param importerContext the import context which can be used to access other handlers / the importer itself
+     **/
+    public AfterNodeLoadEvent(StructuredNode structuredNode, ImporterContext importerContext) {
+        this.structuredNode = structuredNode;
+        this.importerContext = importerContext;
+    }
+
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
+    public ImporterContext getImporterContext() {
+        return importerContext;
+    }
+
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
+    public StructuredNode getStructuredNode() {
+        return structuredNode;
+    }
+}

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedArchiveImportJob.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.jobs.batch.file;
 
+import sirius.biz.importer.AfterLineLoadEvent;
 import sirius.biz.process.ErrorContext;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.logs.ProcessLog;
@@ -72,7 +73,7 @@ public abstract class LineBasedArchiveImportJob extends DictionaryBasedArchiveIm
     /**
      * Normalizes how columns are exposed in each row's context.
      * <p>
-     * By default this method returns the column name as read from the input file.
+     * By default, this method returns the column name as read from the input file.
      * Use this method to normalize headers, such as converting them to lower case,
      * replacing characters or translating aliases into expected names.
      *
@@ -122,6 +123,10 @@ public abstract class LineBasedArchiveImportJob extends DictionaryBasedArchiveIm
         }
 
         try {
+            if (importer.getContext().getEventDispatcher().isActive()) {
+                AfterLineLoadEvent event = new AfterLineLoadEvent(context, importer.getContext());
+                importer.getContext().getEventDispatcher().handleEvent(event);
+            }
             importFile.rowHandler.invoke(Tuple.create(line, context));
         } catch (Exception exception) {
             process.incCounter("LineBasedJob.erroneousRow");


### PR DESCRIPTION
### Description

We need access to the data read right after a file is processed, either the `Context` for line-based files or the `StructuredNode` for XML, where data can be manipulated before any handler access the data.

Note that for XML this is called for every registered *stage*, so the script needs to take care of child nodes if necessary.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11624](https://scireum.myjetbrains.com/youtrack/issue/OX-11624)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
