### PR TITLE
SIRI-1035 password-field optimizations

### DIFF
--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -112,6 +112,7 @@
             }
 
             _togglePasswordButton.addEventListener('click', function () {
+                // the <i> is changed to the <svg> after loading so we need to get the icon on clicking to make it work.
                 const _togglePasswordIcon = document.getElementById('passwordToggleIcon');
 
                 if (_passwordField.getAttribute('type') === 'password') {

--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -35,7 +35,7 @@
                                        value="@WebContext.getCurrent().get('user').asString()"
                                        class="form-control input-block-level"/>
                             </div>
-                            <div class="form-group mb-3 position-relative">
+                            <div class="form-group input-group mb-3">
                                 <input id="password"
                                        tabindex="2"
                                        placeholder="@i18n('Model.login.password')"
@@ -44,10 +44,9 @@
                                        required
                                        autocomplete="off"
                                        spellcheck="false"
-                                       class="form-control input-block-level pe-5"/>
-                                <span id="passwordToggleButton">
-                                    <i class="fa fa-eye position-absolute" id="passwordToggleIcon"
-                                       style="top: 50%; right: 10px; transform: translateY(-50%); cursor: pointer;"></i>
+                                       class="form-control input-block-level"/>
+                                <span id="passwordToggleButton" class="input-group-text">
+                                    <i class="fa fa-eye" id="passwordToggleIcon" style="cursor: pointer;"></i>
                                 </span>
                             </div>
                             <div>

--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -29,7 +29,9 @@
                                        placeholder="@i18n('Model.login.user')"
                                        name="user"
                                        type="text"
+                                       required
                                        autocomplete="off"
+                                       spellcheck="false"
                                        value="@WebContext.getCurrent().get('user').asString()"
                                        class="form-control input-block-level"/>
                             </div>
@@ -37,9 +39,11 @@
                                 <input id="password"
                                        tabindex="2"
                                        placeholder="@i18n('Model.login.password')"
-                                       autocomplete="off"
                                        name="password"
                                        type="password"
+                                       required
+                                       autocomplete="off"
+                                       spellcheck="false"
                                        class="form-control input-block-level"/>
                             </div>
                             <div>

--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -35,7 +35,7 @@
                                        value="@WebContext.getCurrent().get('user').asString()"
                                        class="form-control input-block-level"/>
                             </div>
-                            <div class="form-group mb-3">
+                            <div class="form-group mb-3 position-relative">
                                 <input id="password"
                                        tabindex="2"
                                        placeholder="@i18n('Model.login.password')"
@@ -44,7 +44,11 @@
                                        required
                                        autocomplete="off"
                                        spellcheck="false"
-                                       class="form-control input-block-level"/>
+                                       class="form-control input-block-level pe-5"/>
+                                <span id="passwordToggleButton">
+                                    <i class="fa fa-eye position-absolute" id="passwordToggleIcon"
+                                       style="top: 50%; right: 10px; transform: translateY(-50%); cursor: pointer;"></i>
+                                </span>
                             </div>
                             <div>
                                 <input type="checkbox" tabindex="4" value="true" name="keepLogin" checked/>
@@ -100,12 +104,27 @@
         sirius.ready(function () {
             const _userField = document.getElementById('user');
             const _passwordField = document.getElementById('password');
+            const _togglePasswordButton = document.getElementById('passwordToggleButton');
 
             if (!sirius.isEmpty(_userField.value)) {
                 _passwordField.focus();
             } else {
                 _userField.focus();
             }
+
+            _togglePasswordButton.addEventListener('click', function () {
+                const _togglePasswordIcon = document.getElementById('passwordToggleIcon');
+
+                if (_passwordField.getAttribute('type') === 'password') {
+                    _passwordField.setAttribute('type', 'text');
+                    _togglePasswordIcon.classList.remove('fa-eye');
+                    _togglePasswordIcon.classList.add('fa-eye-slash');
+                } else {
+                    _passwordField.setAttribute('type', 'password');
+                    _togglePasswordIcon.classList.remove('fa-eye-slash');
+                    _togglePasswordIcon.classList.add('fa-eye');
+                }
+            });
 
             try {
                 window.localStorage.setItem('samlPostLoginUri', '<i:raw>@originalUrl</i:raw>');


### PR DESCRIPTION
### Description
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
Makes password visible by clicking the eye-icon and also prevent spellcheckers to get usernames/passwords and give a required hint to not send empty username/password


<img width="698" alt="Bildschirmfoto 2024-12-04 um 10 37 27" src="https://github.com/user-attachments/assets/1931d834-6d4a-4d68-acd1-0ce1b7d9ee04">


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1035](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1035)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
