### PR TITLE
Solves an issue where importing an XML file causes large portions of the file to be loaded in RAM

### DIFF
--- a/src/main/java/sirius/biz/jobs/batch/file/XMLImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/XMLImportJob.java
@@ -140,10 +140,10 @@ public abstract class XMLImportJob extends FileImportJob {
                         }
                     });
                 } else {
-                    reader.addHandler(name, structuredNode -> {
-                        AfterNodeLoadEvent event = new AfterNodeLoadEvent(structuredNode, importer.getContext());
+                    reader.addHandler(name, node -> {
+                        AfterNodeLoadEvent event = new AfterNodeLoadEvent(node, importer.getContext());
                         importer.getContext().getEventDispatcher().handleEvent(event);
-                        originalHandler.process(structuredNode);
+                        originalHandler.process(node);
                     });
                 }
             });

--- a/src/main/java/sirius/biz/jobs/batch/file/XMLImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/XMLImportJob.java
@@ -126,15 +126,17 @@ public abstract class XMLImportJob extends FileImportJob {
     protected void executeProcessingStage(InputStream in, Consumer<BiConsumer<String, NodeHandler>> stage)
             throws Exception {
         XMLReader reader = new XMLReader();
-        stage.accept((name, originalHandler) -> {
-            reader.addHandler(name, structuredNode -> {
-                if (importer.getContext().getEventDispatcher().isActive()) {
+        if (importer.getContext().getEventDispatcher().isActive()) {
+            stage.accept((name, originalHandler) -> {
+                reader.addHandler(name, structuredNode -> {
                     AfterNodeLoadEvent event = new AfterNodeLoadEvent(structuredNode, importer.getContext());
                     importer.getContext().getEventDispatcher().handleEvent(event);
-                }
-                originalHandler.process(structuredNode);
+                    originalHandler.process(structuredNode);
+                });
             });
-        });
+        } else {
+            stage.accept(reader::addHandler);
+        }
         reader.parse(in, this::resolveResource);
     }
 


### PR DESCRIPTION
### Description

With the introduction of customer-scripting when loading XML files, we add a custom handler to process the events before calling the original handler, but unfortunately did not check if the original node handler was configured to ignore its contents (sub-tree). A use case for this: reading BMEcat's version from the root element, without having to load the entire file.

This change not only correctly cope with this case, but won't create this unnecessary handler if scripting is not active at all.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11723](https://scireum.myjetbrains.com/youtrack/issue/OX-11723)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
