### PR TITLE
Ensure better caching of redirected Blob URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>dev-44.0.0</sirius.kernel>
-        <sirius.web>dev-86.0.0</sirius.web>
+        <sirius.web>dev-86.1.0</sirius.web>
         <sirius.db>dev-59.0.0</sirius.db>
     </properties>
 


### PR DESCRIPTION
### Description

VirtualDelivery URLs were marked to be cached very long. When the underlying file changed a new URL would redirect there, but external sources (varnish, browsers and so on) would have already cached the URL and will be calling the old redirected URL.

This change ensures that:
1. Once a physical URL exists, we will always redirect
2. The redirected URL will either be not cached at all, or cached to a maximum of 1h.

Note that physical URLs are not affected by this change and respect the caching times defined by the call or its storage space definitions.

**Examples**
- Physical URL is indefinitely cached
```
> GET /dasd/p/tenants/74dd32864152cce6e57fde4f014f617f/M7CELNNL7JDT9UE7PHJ9GU2OD4/P0930KVRLNPL105N66RNCPAH2O HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Disposition: inline;filename="P0930KVRLNPL105N66RNCPAH2O";filename*=UTF-8''P0930KVRLNPL105N66RNCPAH2O
< Content-MD5: ZA06iGDNLyQv5nLsGIKgvg==
< ETag: 640d3a8860cd2f242fe672ec1882a0be
< X-Amz-Date: 20241206T121615Z
< x-amz-content-sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD
< x-amz-decoded-content-length: 43997
< access-control-expose-headers: ETag
< date: Fri, 06 Dec 2024 12:29:49 GMT
< accept-ranges: bytes
< content-length: 43997
< content-type: application/octet-stream
< expires: Sat, 04 Jan 2025 23:00:01 GMT
< cache-control: public, max-age=2543412
< last-modified: Fri, 06 Dec 2024 12:16:15 GMT
< connection: keep-alive
< server: mbp-ili2.net
< P3P: CP="This site does not have a p3p policy."
< vary: origin
```

- Redirect to the URL above (not cached)
```
> GET /dasd/v/tenants/5f1c86cf1db3307e4b688d28fa77759c/tenant-small/M7CELNNL7JDT9UE7PHJ9GU2OD4 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 307 Temporary Redirect
< cache-control: no-cache, max-age=0
< last-modified: Fri, 06 Dec 2024 13:02:42 GMT
< connection: keep-alive
< server: mbp-ili2.net
< P3P: CP="This site does not have a p3p policy."
< vary: origin
< content-length: 0
< location: /dasd/p/tenants/74dd32864152cce6e57fde4f014f617f/M7CELNNL7JDT9UE7PHJ9GU2OD4/P0930KVRLNPL105N66RNCPAH2O
```

- Redirect to URL above (cached)
```
> GET /dasd/cv/tenants/5f1c86cf1db3307e4b688d28fa77759c/tenant-small/M7CELNNL7JDT9UE7PHJ9GU2OD4 HTTP/1.1
> 
* Request completely sent off
< HTTP/1.1 307 Temporary Redirect
< date: Fri, 06 Dec 2024 12:26:13 GMT
< expires: Fri, 06 Dec 2024 13:26:13 GMT
< cache-control: public, max-age=3600
< last-modified: Fri, 06 Dec 2024 12:26:13 GMT
< connection: keep-alive
< server: mbp-ili2.net
< P3P: CP="This site does not have a p3p policy."
< vary: origin
< content-length: 0
< location: /dasd/p/tenants/74dd32864152cce6e57fde4f014f617f/M7CELNNL7JDT9UE7PHJ9GU2OD4/P0930KVRLNPL105N66RNCPAH2O
```

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11230](https://scireum.myjetbrains.com/youtrack/issue/OX-11230)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1487

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
