### PR TITLE
Fixes system-files not being ignored by ZIP-native extractor when executing an import-job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <url>https://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-44.0.0</sirius.kernel>
+        <sirius.kernel>dev-44.1.0</sirius.kernel>
         <sirius.web>dev-86.1.0</sirius.web>
         <sirius.db>dev-59.0.0</sirius.db>
     </properties>

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -17,6 +17,7 @@ import sirius.biz.util.ExtractedFile;
 import sirius.biz.util.ExtractedZipFile;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Amount;
+import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Producer;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Exceptions;
@@ -110,7 +111,7 @@ public abstract class ArchiveImportJob extends FileImportJob {
         Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
         while (zipEntries.hasMoreElements() && taskContext.isActive()) {
             ZipEntry zipEntry = zipEntries.nextElement();
-            if (FILE_FILTER.stream().anyMatch(zipEntry.getName()::startsWith)) {
+            if (Files.isConsideredHidden(zipEntry.getName()) || Files.isConsideredMetadata(zipEntry.getName())) {
                 continue;
             }
             if (Strings.areEqual(fileName, zipEntry.getName())) {

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -42,6 +43,11 @@ import java.util.zip.ZipFile;
 public abstract class ArchiveImportJob extends FileImportJob {
 
     private static final String ZIP_FILE_EXTENSION = "zip";
+
+    /**
+     * Contains a list of file names which should be ignored when extracting files from the archive.
+     */
+    private static final List <String> FILE_FILTER = List.of("__MACOSX");
 
     /**
      * Contains a customized parameter which should be used in {@link FileImportJobFactory#createFileParameter()}

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -110,7 +110,7 @@ public abstract class ArchiveImportJob extends FileImportJob {
         Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
         while (zipEntries.hasMoreElements() && taskContext.isActive()) {
             ZipEntry zipEntry = zipEntries.nextElement();
-            if (FILE_FILTER.stream().anyMatch(zipEntry.getName()::contains)) {
+            if (FILE_FILTER.stream().anyMatch(zipEntry.getName()::startsWith)) {
                 continue;
             }
             if (Strings.areEqual(fileName, zipEntry.getName())) {

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -104,7 +104,9 @@ public abstract class ArchiveImportJob extends FileImportJob {
         Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
         while (zipEntries.hasMoreElements() && taskContext.isActive()) {
             ZipEntry zipEntry = zipEntries.nextElement();
-
+            if(zipEntry.getName().contains("__MACOSX")) {
+                continue;
+            }
             if (Strings.areEqual(fileName, zipEntry.getName())) {
                 return Optional.of(new ExtractedZipFile(zipEntry,
                                                         () -> zipFile.getInputStream(zipEntry),

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -110,7 +110,7 @@ public abstract class ArchiveImportJob extends FileImportJob {
         Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
         while (zipEntries.hasMoreElements() && taskContext.isActive()) {
             ZipEntry zipEntry = zipEntries.nextElement();
-            if(zipEntry.getName().contains("__MACOSX")) {
+            if (FILE_FILTER.stream().anyMatch(zipEntry.getName()::contains)) {
                 continue;
             }
             if (Strings.areEqual(fileName, zipEntry.getName())) {

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -46,11 +46,6 @@ public abstract class ArchiveImportJob extends FileImportJob {
     private static final String ZIP_FILE_EXTENSION = "zip";
 
     /**
-     * Contains a list of file names which should be ignored when extracting files from the archive.
-     */
-    private static final List <String> FILE_FILTER = List.of("__MACOSX");
-
-    /**
      * Contains a customized parameter which should be used in {@link FileImportJobFactory#createFileParameter()}
      * in its factory.
      */

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -173,6 +172,9 @@ public abstract class ArchiveImportJob extends FileImportJob {
         Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
         while (zipEntries.hasMoreElements() && taskContext.isActive()) {
             ZipEntry zipEntry = zipEntries.nextElement();
+            if (Files.isConsideredHidden(zipEntry.getName()) || Files.isConsideredMetadata(zipEntry.getName())) {
+                continue;
+            }
             fileHandler.accept(new ExtractedZipFile(zipEntry, () -> zipFile.getInputStream(zipEntry), Amount.NOTHING));
         }
     }

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -178,9 +178,7 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
                     handleMissingFile(importFile.filename, importFile.required);
                 }
 
-                if(!(Files.isConsideredHidden(importFile.filename) || Files.isConsideredMetadata(importFile.filename))) {
-                    handledFiles.add(importFile.filename);
-                }
+                handledFiles.add(importFile.filename);
             }
         }
 

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -16,6 +16,7 @@ import sirius.biz.util.ExtractedFile;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Callback;
 import sirius.kernel.commons.Context;
+import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.UnitOfWork;
 import sirius.web.data.LineBasedProcessor;
@@ -177,7 +178,9 @@ public abstract class DictionaryBasedArchiveImportJob extends ArchiveImportJob {
                     handleMissingFile(importFile.filename, importFile.required);
                 }
 
-                handledFiles.add(importFile.filename);
+                if(!(Files.isConsideredHidden(importFile.filename) || Files.isConsideredMetadata(importFile.filename))) {
+                    handledFiles.add(importFile.filename);
+                }
             }
         }
 

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystemController.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystemController.java
@@ -13,6 +13,7 @@ import sirius.biz.storage.layer2.Blob;
 import sirius.biz.tycho.QuickAction;
 import sirius.biz.tycho.UserAssistant;
 import sirius.biz.web.BizController;
+import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Streams;
 import sirius.kernel.commons.Strings;
@@ -380,7 +381,7 @@ public class VirtualFileSystemController extends BizController {
             Arrays.stream(extensionString.asString().split(","))
                   .map(Strings::trim)
                   .filter(Strings::isFilled)
-                  .map(string -> string.startsWith(".") ? string.substring(1) : string)
+                  .map(string -> Files.isConsideredHidden(string) ? string.substring(1) : string)
                   .forEach(search::withFileExtension);
         });
 

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -194,7 +194,7 @@ public class ObjectStore {
                                                      .withS3Client(client)
                                                      .build();
 
-        if (Strings.isFilled(bucketSuffix) && bucketSuffix.contains(".") && !bucketSuffix.startsWith(".")) {
+        if (Strings.isFilled(bucketSuffix) && bucketSuffix.contains(".") && !Files.isConsideredHidden(bucketSuffix)) {
             ObjectStores.LOG.WARN(
                     "The bucketSuffix '%s' contains a '.' but does not start with one. This might lead to errors!",
                     bucketSuffix);

--- a/src/main/java/sirius/biz/util/ArchiveExtractor.java
+++ b/src/main/java/sirius/biz/util/ArchiveExtractor.java
@@ -244,7 +244,7 @@ public class ArchiveExtractor {
 
     private boolean ignoreHiddenFiles(String path) {
         String filename = Files.getFilenameAndExtension(path);
-        return Strings.isFilled(filename) && !filename.startsWith(".") && !filename.startsWith("__MACOSX");
+        return Strings.isFilled(filename) && !Files.isConsideredHidden(filename) && !Files.isConsideredMetadata(path);
     }
 
     private void extractZip(File archiveFile,

--- a/src/main/java/sirius/biz/util/LocalArchiveExtractCallback.java
+++ b/src/main/java/sirius/biz/util/LocalArchiveExtractCallback.java
@@ -72,7 +72,7 @@ public class LocalArchiveExtractCallback implements IArchiveExtractCallback {
             skipExtraction |= (attributes & PropID.AttributesBitMask.FILE_ATTRIBUTE_HIDDEN) != 0;
         }
         if (filePath != null) {
-            skipExtraction |= filePath.startsWith("__MACOSX");
+            skipExtraction |= Files.isConsideredMetadata(filePath);
             if (filter != null) {
                 skipExtraction |= !filter.apply(filePath);
             }
@@ -80,7 +80,7 @@ public class LocalArchiveExtractCallback implements IArchiveExtractCallback {
         if (fileName != null) {
             // need to filter hidden files (starting with dot), because some tar implementations create
             // hidden index files (ending with xml, too)
-            skipExtraction |= fileName.startsWith(".");
+            skipExtraction |= Files.isConsideredHidden(fileName);
         }
 
         if (skipExtraction) {


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1028](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1028)

### Additional PRs
- This PR depends on https://github.com/scireum/sirius-kernel/pull/544

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
