### PR TITLE
EventRecorder - Adds Blockwise Event Fetching

### DIFF
--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -543,16 +543,13 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
         return result;
     }
 
-    /**
-     * Fetches all user events which match the given query.
-     * <p>
-     * Duplicates are prevented by assuming that users do not generate multiple events of the same type at the same
-     * time.
-     *
-     * @param query the query to execute
-     * @param <E>   the type of the events to fetch
-     * @return a stream of events which match the given query
-     */
+    /// Fetches all user events which match the given query assuming that users can only trigger one event (of the type
+    /// in question) at the same time.
+    ///
+    ///
+    /// @param query the query to execute
+    /// @param <E>   the type of the events to fetch
+    /// @return a stream of events which match the given query
     public <E extends Event<E> & UserEvent> Stream<E> fetchUserEventsBlockwise(SmartQuery<E> query) {
         return StreamSupport.stream(new EventSpliterator<E>(query, (effectiveQuery, lastEvent) -> {
             query.where(OMA.FILTERS.not(OMA.FILTERS.and(OMA.FILTERS.eq(Event.EVENT_TIMESTAMP,
@@ -562,14 +559,13 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
         }), false);
     }
 
-    /**
-     * Fetches all events which match the given query considering the given duplicate preventer.
-     *
-     * @param query              the query to execute
-     * @param duplicatePreventer the duplicate preventer to apply to prevent fetching the same events multiple times
-     * @param <E>                the type of the events to fetch
-     * @return a stream of events which match the given query
-     */
+    /// Fetches all events which match the given query considering the given duplicate preventer.
+    ///
+    /// @param query              the query to execute
+    /// @param duplicatePreventer the duplicate preventer to apply to prevent fetching the same events multiple times
+    /// @param <E>                the type of the events to fetch
+    /// @return a stream of events which match the given query
+    /// @see EventSpliterator for a detailed explanation of the duplicate preventer
     public <E extends Event<E>> Stream<E> fetchEventsBlockwise(SmartQuery<E> query,
                                                                BiConsumer<SmartQuery<E>, E> duplicatePreventer) {
         return StreamSupport.stream(new EventSpliterator<>(query, duplicatePreventer), false);

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -551,17 +551,11 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
     /// @param <E>   the type of the events to fetch
     /// @return a stream of events which match the given query
     public <E extends Event<E> & UserEvent> Stream<E> fetchUserEventsBlockwise(SmartQuery<E> query) {
-        return StreamSupport.stream(new EventSpliterator<E>(query, (effectiveQuery, lastEvents) -> {
-            effectiveQuery.where(OMA.FILTERS.not(OMA.FILTERS.and(OMA.FILTERS.eq(Event.EVENT_TIMESTAMP,
-                                                                                lastEvents.getLast()
-                                                                                          .getEventTimestamp()),
-                                                                 OMA.FILTERS.oneInField(UserEvent.USER_DATA.inner(
-                                                                                                UserData.USER_ID),
-                                                                                        lastEvents.stream()
-                                                                                                  .map(UserEvent::getUserData)
-                                                                                                  .map(UserData::getUserId)
-                                                                                                  .toList()).build())));
-        }), false);
+        return StreamSupport.stream(new EventSpliterator<E>(query,
+                                                            List.of(UserEvent.USER_DATA.inner(UserData.SCOPE_ID),
+                                                                    UserEvent.USER_DATA.inner(UserData.TENANT_ID),
+                                                                    UserEvent.USER_DATA.inner(UserData.USER_ID))),
+                                    false);
     }
 
     /// Fetches all events which match the given query considering the given duplicate preventer.

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -575,4 +575,15 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
                                                                BiConsumer<SmartQuery<E>, List<E>> duplicatePreventer) {
         return StreamSupport.stream(new EventSpliterator<>(query, duplicatePreventer), false);
     }
+
+    /// Fetches all events which match the given query considering the given distinct fields to prevent duplicates.
+    ///
+    /// @param query          the query to execute
+    /// @param distinctFields the fields to consider when preventing duplicates
+    /// @param <E>            the type of the events to fetch
+    /// @return a stream of events which match the given query
+    /// @see EventSpliterator#EventSpliterator(SmartQuery, List)  for a detailed explanation of the distinct fields
+    public <E extends Event<E>> Stream<E> fetchEventsBlockwise(SmartQuery<E> query, List<Mapping> distinctFields) {
+        return StreamSupport.stream(new EventSpliterator<E>(query, distinctFields), false);
+    }
 }

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -551,11 +551,10 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
     /// @param <E>   the type of the events to fetch
     /// @return a stream of events which match the given query
     public <E extends Event<E> & UserEvent> Stream<E> fetchUserEventsBlockwise(SmartQuery<E> query) {
-        return StreamSupport.stream(new EventSpliterator<E>(query,
-                                                            List.of(UserEvent.USER_DATA.inner(UserData.SCOPE_ID),
-                                                                    UserEvent.USER_DATA.inner(UserData.TENANT_ID),
-                                                                    UserEvent.USER_DATA.inner(UserData.USER_ID))),
-                                    false);
+        return fetchEventsBlockwise(query,
+                                    List.of(UserEvent.USER_DATA.inner(UserData.SCOPE_ID),
+                                            UserEvent.USER_DATA.inner(UserData.TENANT_ID),
+                                            UserEvent.USER_DATA.inner(UserData.USER_ID)));
     }
 
     /// Fetches all events which match the given query considering the given duplicate preventer.

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -42,7 +42,10 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Responsible for collecting and storing {@link Event events} for analytical and statistical purposes.
@@ -538,5 +541,18 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
         }
 
         return result;
+    }
+
+    /**
+     * Fetches all events which match the given query considering the given duplicate preventer.
+     *
+     * @param query              the query to execute
+     * @param duplicatePreventer the duplicate preventer to apply to prevent fetching the same events multiple times
+     * @param <E>                the type of the events to fetch
+     * @return a stream of events which match the given query
+     */
+    public <E extends Event<E>> Stream<E> fetchEventsBlockwise(SmartQuery<E> query,
+                                                               BiConsumer<SmartQuery<E>, E> duplicatePreventer) {
+        return StreamSupport.stream(new EventSpliterator<>(query, duplicatePreventer), false);
     }
 }

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -546,7 +546,6 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
     /// Fetches all user events which match the given query assuming that users can only trigger one event (of the type
     /// in question) at the same time.
     ///
-    ///
     /// @param query the query to execute
     /// @param <E>   the type of the events to fetch
     /// @return a stream of events which match the given query

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -551,10 +551,10 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
     /// @return a stream of events which match the given query
     public <E extends Event<E> & UserEvent> Stream<E> fetchUserEventsBlockwise(SmartQuery<E> query) {
         return StreamSupport.stream(new EventSpliterator<E>(query, (effectiveQuery, lastEvent) -> {
-            query.where(OMA.FILTERS.not(OMA.FILTERS.and(OMA.FILTERS.eq(Event.EVENT_TIMESTAMP,
-                                                                       lastEvent.getEventTimestamp()),
-                                                        OMA.FILTERS.eq(UserEvent.USER_DATA.inner(UserData.USER_ID),
-                                                                       lastEvent.getUserData().getUserId()))));
+            effectiveQuery.where(OMA.FILTERS.not(OMA.FILTERS.and(OMA.FILTERS.eq(Event.EVENT_TIMESTAMP,
+                                                                                lastEvent.getEventTimestamp()),
+                                                                 OMA.FILTERS.eq(UserEvent.USER_DATA.inner(UserData.USER_ID),
+                                                                                lastEvent.getUserData().getUserId()))));
         }), false);
     }
 

--- a/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
+++ b/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
@@ -44,6 +44,10 @@ import java.util.function.BiConsumer;
 /// [UserData#USER_ID] and [Event#EVENT_TIMESTAMP] are used to prevent fetching the same event triggered by the
 /// same user at the same time again.
 ///
+/// Event deduplication may result in complex queries, which can potentially slow down performance or generate queries
+/// that are too large to process.Therefore, if individual events are not needed, using
+/// [metrics][sirius.kernel.health.metrics.Metric] may be a better choice for fetching aggregated data.
+///
 /// @param <E> the type of the events to fetch
 public class EventSpliterator<E extends Event<E>> extends PullBasedSpliterator<E> {
 

--- a/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
+++ b/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
@@ -37,12 +37,13 @@ import java.util.function.BiConsumer;
 /// last event of the block) are supplied to the preventer as all preceding events will not be fetched again due to the
 /// next fetch starting with the timestamp of the last event of the block.
 ///
-/// Implementations of the duplicate preventer should in most cases add an 'AND NOT (A=X AND B=Y AND ...)' constraint
-/// to the query based on the supplied events. Here, A and B are fields specific to the event type while X and Y
-/// are the values of the supplied event. The combination of the fields and values should take care of not fetching the
-/// same events multiple times. See [EventRecorder#fetchUserEventsBlockwise(SmartQuery)] for an example where the fields
-/// [UserData#USER_ID] and [Event#EVENT_TIMESTAMP] are used to prevent fetching the same event triggered by the
-/// same user at the same time again.
+/// Implementations of the duplicate preventer should in most cases add an 'AND NOT (eventTimestamp=X AND (A=Y OR A=Z
+/// OR ...)' constraint to the query based on the supplied events. Here, X is the timestamp of the last event in the
+/// preceding block and A is a distinct field where Y and Z are the corresponding values based on the supplied events.
+/// The combination of the fields and values should take care of not fetching the same events multiple times. See
+/// [EventRecorder#fetchUserEventsBlockwise(SmartQuery)] for an example where the fields [Event#EVENT_TIMESTAMP] and
+/// user event specific fields [UserData#SCOPE_ID], [UserData#TENANT_ID] and [UserData#USER_ID] are used to prevent
+/// fetching the same event triggered by the same user at the same time again.
 ///
 /// Event deduplication may result in complex queries, which can potentially slow down performance or generate queries
 /// that are too large to process. Therefore, if individual events are not needed, using

--- a/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
+++ b/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
@@ -45,7 +45,7 @@ import java.util.function.BiConsumer;
 /// same user at the same time again.
 ///
 /// Event deduplication may result in complex queries, which can potentially slow down performance or generate queries
-/// that are too large to process.Therefore, if individual events are not needed, using
+/// that are too large to process. Therefore, if individual events are not needed, using
 /// [metrics][sirius.kernel.health.metrics.Metric] may be a better choice for fetching aggregated data.
 ///
 /// @param <E> the type of the events to fetch
@@ -56,14 +56,14 @@ public class EventSpliterator<E extends Event<E>> extends PullBasedSpliterator<E
     private final SmartQuery<E> query;
 
     /// Contains the last events fetched.
-    private final ArrayList<E> lastEvents = new ArrayList<>();
+    private final List<E> lastEvents = new ArrayList<>();
 
     /// Contains a consumer which is used to prevent fetching the same events multiple times.
     private final BiConsumer<SmartQuery<E>, List<E>> duplicatePreventer;
 
     /// Creates a new spliterator for the given query and duplicate preventer.
     ///
-    /// The given will be copied to allow re-use by the caller. Additionally, the given query does not need to
+    /// The given query will be copied to allow re-use by the caller. Additionally, the given query does not need to
     /// provide ordering or limits as this is handled by the spliterator itself.
     ///
     /// The given duplicate preventer must add additional constraints to the query to prevent fetching the same events
@@ -88,7 +88,7 @@ public class EventSpliterator<E extends Event<E>> extends PullBasedSpliterator<E
     /// of the previously fetched events.
     ///
     /// The duplicate preventing portion of the SQL query will have the form:
-    /// ```
+    /// ```sql
     /// AND NOT (timestamp = last_timestamp -- Only constraint events with the same timestamp
     ///         AND ((field1 = event_1_field_1 AND field2 = event_1_field_2 AND ...) -- Ignore already fetched event 1
     ///             OR (field1 = event_2_field_1 AND field2 = event_2_field_2 AND ...) -- Ignore already fetched event 2

--- a/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
+++ b/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
@@ -1,0 +1,97 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.analytics.events;
+
+import sirius.db.jdbc.OMA;
+import sirius.db.jdbc.SmartQuery;
+import sirius.kernel.async.TaskContext;
+import sirius.kernel.commons.PullBasedSpliterator;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/**
+ * Provides a spliterator which fetches events blockwise.
+ *
+ * @param <E> the type of events to fetch
+ */
+public class EventSpliterator<E extends Event<E>> extends PullBasedSpliterator<E> {
+
+    private static final int BLOCK_SIZE = 1000;
+
+    private final SmartQuery<E> query;
+
+    /**
+     * Contains the last events fetched (all sharing the same {@linkplain Event#getEventTimestamp() timestamp}) to
+     * prevent fetching the same events multiple times.
+     */
+    private List<E> lastEvents;
+
+    /**
+     * Contains a consumer which is used to prevent fetching the same events multiple times.
+     */
+    private final BiConsumer<SmartQuery<E>, E> duplicatePreventer;
+
+    /**
+     * Creates a new spliterator for the given query and duplicate preventer.
+     * <p>
+     * The duplicate preventer is supposed to add additional constraints to the query to prevent fetching the same
+     * events multiple times.
+     *
+     * @param query              the query to use to fetch the events
+     * @param duplicatePreventer a consumer which is used to prevent fetching the same events multiple times
+     */
+    public EventSpliterator(SmartQuery<E> query, BiConsumer<SmartQuery<E>, E> duplicatePreventer) {
+        super();
+        this.query = query.copy().orderAsc(Event.EVENT_TIMESTAMP).limit(BLOCK_SIZE);
+        this.duplicatePreventer = duplicatePreventer;
+    }
+
+    @Nullable
+    @Override
+    protected Iterator<E> pullNextBlock() {
+        if (!TaskContext.get().isActive()) {
+            return null;
+        }
+
+        if (lastEvents != null && lastEvents.size() < BLOCK_SIZE) {
+            return null;
+        }
+
+        List<E> events = resolveEffectiveQuery().queryList();
+        if (events.isEmpty()) {
+            return null;
+        }
+
+        lastEvents = events.reversed()
+                           .stream()
+                           .filter(event -> event.getEventTimestamp().equals(events.getLast().getEventTimestamp()))
+                           .toList();
+
+        return events.iterator();
+    }
+
+    @Override
+    public int characteristics() {
+        return NONNULL | IMMUTABLE | ORDERED;
+    }
+
+    private SmartQuery<E> resolveEffectiveQuery() {
+        SmartQuery<E> effectiveQuery = query.copy();
+
+        if (lastEvents != null) {
+            effectiveQuery.where(OMA.FILTERS.gte(Event.EVENT_TIMESTAMP, lastEvents.getFirst().getEventTimestamp()));
+            lastEvents.forEach(lastEvent -> duplicatePreventer.accept(effectiveQuery, lastEvent));
+        }
+
+        return effectiveQuery;
+    }
+}

--- a/src/main/java/sirius/biz/analytics/events/PageImpressionEvent.java
+++ b/src/main/java/sirius/biz/analytics/events/PageImpressionEvent.java
@@ -35,7 +35,7 @@ import sirius.web.http.WebContext;
  * @see EventRecorder
  * @see #withAggregationUrl(String)
  */
-public class PageImpressionEvent extends Event<PageImpressionEvent> {
+public class PageImpressionEvent extends Event<PageImpressionEvent> implements UserEvent {
 
     /**
      * Contains a generic or shortened URI which can be used to aggregate on.
@@ -82,7 +82,6 @@ public class PageImpressionEvent extends Event<PageImpressionEvent> {
     /**
      * Contains the current user, tenant and scope if available.
      */
-    public static final Mapping USER_DATA = Mapping.named("userData");
     private final UserData userData = new UserData();
 
     /**
@@ -168,6 +167,7 @@ public class PageImpressionEvent extends Event<PageImpressionEvent> {
         return aggregationUri;
     }
 
+    @Override
     public UserData getUserData() {
         return userData;
     }

--- a/src/main/java/sirius/biz/analytics/events/UserActivityEvent.java
+++ b/src/main/java/sirius/biz/analytics/events/UserActivityEvent.java
@@ -24,12 +24,11 @@ import sirius.web.security.UserManager;
  *
  * @see sirius.biz.tenants.TenantUserManager#recordUserActivityEvent(UserInfo)
  */
-public class UserActivityEvent extends Event<UserActivityEvent> {
+public class UserActivityEvent extends Event<UserActivityEvent> implements UserEvent {
 
     /**
      * Contains the current user, tenant and scope if available.
      */
-    public static final Mapping USER_DATA = Mapping.named("userData");
     private final UserData userData = new UserData();
 
     /**
@@ -38,6 +37,7 @@ public class UserActivityEvent extends Event<UserActivityEvent> {
     public static final Mapping WEB_DATA = Mapping.named("webData");
     private final WebData webData = new WebData();
 
+    @Override
     public UserData getUserData() {
         return userData;
     }

--- a/src/main/java/sirius/biz/analytics/events/UserEvent.java
+++ b/src/main/java/sirius/biz/analytics/events/UserEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.analytics.events;
+
+import sirius.db.mixing.Mapping;
+
+/**
+ * May be implemented by an {@link Event} to provide access to the {@link UserData} of the current user.
+ */
+public interface UserEvent {
+
+    /**
+     * Contains the user data of the event.
+     */
+    Mapping USER_DATA = Mapping.named("userData");
+
+    /**
+     * Returns the user data of the event.
+     *
+     * @return the user data of the event
+     */
+    UserData getUserData();
+}

--- a/src/main/java/sirius/biz/tycho/updates/UpdateClickEvent.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdateClickEvent.java
@@ -10,6 +10,7 @@ package sirius.biz.tycho.updates;
 
 import sirius.biz.analytics.events.Event;
 import sirius.biz.analytics.events.UserData;
+import sirius.biz.analytics.events.UserEvent;
 import sirius.db.mixing.Mapping;
 
 /**
@@ -17,7 +18,7 @@ import sirius.db.mixing.Mapping;
  *
  * @see UpdateManager
  */
-public class UpdateClickEvent extends Event<UpdateClickEvent> {
+public class UpdateClickEvent extends Event<UpdateClickEvent> implements UserEvent {
 
     public static final Mapping UPDATE_GUID = Mapping.named("updateGuid");
     private String updateGuid;
@@ -25,7 +26,6 @@ public class UpdateClickEvent extends Event<UpdateClickEvent> {
     /**
      * Contains the current user, tenant and scope if available.
      */
-    public static final Mapping USER_DATA = Mapping.named("userData");
     private final UserData userData = new UserData();
 
     /**
@@ -43,6 +43,7 @@ public class UpdateClickEvent extends Event<UpdateClickEvent> {
         return updateGuid;
     }
 
+    @Override
     public UserData getUserData() {
         return userData;
     }

--- a/src/main/java/sirius/biz/util/SOAPCallEvent.java
+++ b/src/main/java/sirius/biz/util/SOAPCallEvent.java
@@ -10,6 +10,7 @@ package sirius.biz.util;
 
 import sirius.biz.analytics.events.Event;
 import sirius.biz.analytics.events.UserData;
+import sirius.biz.analytics.events.UserEvent;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.NullAllowed;
 import sirius.db.mixing.annotations.Trim;
@@ -17,11 +18,11 @@ import sirius.db.mixing.annotations.Trim;
 /**
  * Record a SOAP call performed by {@link sirius.biz.util.MonitoredSOAPClient}.
  */
-public class SOAPCallEvent extends Event<SOAPCallEvent> {
+public class SOAPCallEvent extends Event<SOAPCallEvent> implements UserEvent {
+
     /**
      * Contains the shop, customer and user which triggered the event.
      */
-    public static final Mapping USER_DATA = Mapping.named("userData");
     private final UserData userData = new UserData();
 
     /**
@@ -155,6 +156,7 @@ public class SOAPCallEvent extends Event<SOAPCallEvent> {
         return erroneous;
     }
 
+    @Override
     public UserData getUserData() {
         return userData;
     }


### PR DESCRIPTION
### Description

Adds support for blockwise events fetching to allow fetching possibly larger number of events without having to keep database connections open.

As Events have no distinct fields by default (they do not have an ID), callers must provide a so called "duplicate preventer" that adjusts the query before fetching each block based on the result of the last block.

As events often have UserData fields, a default duplicate preventer is provided by introducing a new interface "UserEvent". The preventer assumes that users do not trigger events of the same type twice at the same time.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14230](https://scireum.myjetbrains.com/youtrack/issue/SE-14230)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
