### PR TITLE
Improves caching of virtual URLs

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
@@ -261,6 +261,12 @@ public class BlobDispatcher implements WebDispatcher {
             return;
         }
 
+        if (urlResult.urlType() == URLBuilder.UrlType.VIRTUAL) {
+            // A conversion will be attempted and tunneled over. Disable caching completely as we expect
+            // subsequent requests to deliver a redirect URL the new converted physical file.
+            response.notCached();
+        }
+
         String filename = blobUri.getFilename();
 
         if (blobUri.isDownload()) {

--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
@@ -244,7 +244,9 @@ public class BlobDispatcher implements WebDispatcher {
         }
 
         if (blobUri.isCacheable()) {
-            response.cachedForSeconds(cacheSeconds);
+            // Limit the cache time to a maximum of 1 hour for all virtual URLs, since it does not make sense to cache
+            // those for long as the underlying file might change.
+            response.cachedForSeconds(Math.min(cacheSeconds, 3600));
         } else {
             response.notCached();
         }
@@ -255,10 +257,6 @@ public class BlobDispatcher implements WebDispatcher {
                 buildPhysicalRedirectUrl(storageSpace, blobUri, cacheSeconds == Response.HTTP_CACHE_INFINITE);
         if (urlResult.urlType() == URLBuilder.UrlType.PHYSICAL) {
             // ... and if so, redirect to the physical URL ...
-            if (blobUri.isCacheable()) {
-                // ... but only caches the redirect URL to maximum 1 hour, so the underlying URL can be changed.
-                response.cachedForSeconds(Math.min(cacheSeconds, 3600));
-            }
             response.redirectTemporarily(urlResult.url());
             return;
         }


### PR DESCRIPTION
### Description

1. defines an overall limit as it makes no sense to cache those too long
2. no caching if a conversion will be attempted

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11230](https://scireum.myjetbrains.com/youtrack/issue/OX-11230)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
