### PR TITLE
Rate Limiting: Miscellaneous Improvements

### DIFF
--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -182,10 +182,6 @@ public class Isenguard {
         return isRateLimitReached(scope, realm, explicitLimit, null, infoSupplier);
     }
 
-    private String formatLimit(Tuple<Integer, Integer> limit) {
-        return Strings.apply("%s calls within %ss", limit.getFirst(), limit.getSecond());
-    }
-
     /**
      * Determines if the rate limit of the given realm for the given IP is reached.
      *
@@ -258,6 +254,10 @@ public class Isenguard {
                                                       .withIp(info.getIp())
                                                       .withTenant(info.getTenantId())
                                                       .withLocation(Strings.limit(info.getLocation(), 255)));
+    }
+
+    private String formatLimit(Tuple<Integer, Integer> limit) {
+        return Strings.apply("%s calls within %ss", limit.getFirst(), limit.getSecond());
     }
 
     private boolean increaseAndCheckLimit(String scope,

--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -211,7 +211,7 @@ public class Isenguard {
                 return false;
             }
 
-            return isRateLimitReached(scope, realm, limit.getSecond(), limit.getFirst(), () -> {
+            return increaseAndCheckLimit(scope, realm, limit.getSecond(), limit.getFirst(), () -> {
                 handleLimitReached(scope, realm, limit, infoSupplier.get());
 
                 if (limitReachedOnce != null) {
@@ -260,11 +260,11 @@ public class Isenguard {
                                                       .withLocation(Strings.limit(info.getLocation(), 255)));
     }
 
-    private boolean isRateLimitReached(String scope,
-                                       String realm,
-                                       int intervalInSeconds,
-                                       int limit,
-                                       Runnable limitReachedOnce) {
+    private boolean increaseAndCheckLimit(String scope,
+                                          String realm,
+                                          int intervalInSeconds,
+                                          int limit,
+                                          Runnable limitReachedOnce) {
         String key = computeRateLimitingKey(scope, realm, intervalInSeconds);
         return limiter.increaseAndCheckLimit(key, intervalInSeconds, limit, limitReachedOnce);
     }

--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -166,14 +166,15 @@ public class Isenguard {
     /**
      * Registers an event and determines if the rate limit of the given realm for the given scope is reached.
      * <p>
-     * Note that invoking this method counts towards the limit.
+     * Note that invoking this method counts towards the limit. Use {@link #checkRateLimitReached(String, String, int)}
+     * if you only want to check the current state without counting the call.
      *
-     * @param scope         the key which is used for grouping multiple events - e.g. the ip of the caller
+     * @param scope         the key which is used for grouping multiple events - e.g. the IP of the caller
      * @param realm         the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>
      * @param explicitLimit the explicit limit which overwrites the limit given in the config.
      *                      Use {@link #USE_LIMIT_FROM_CONFIG} if no explicit limit is set
      * @param infoSupplier  a supplier which is invoked to provide additional incident data once the rate limit is first hit
-     * @return <tt>true</tt> if the rate limit for the given ip, realm and check interval is reached,
+     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is reached,
      * <tt>false</tt> otherwise. Note, that once the limit was reached, an {@link AuditLog audit log entry} will be
      * created.
      */
@@ -187,17 +188,19 @@ public class Isenguard {
     /**
      * Registers an event and determines if the rate limit of the given realm for the given scope is reached.
      * <p>
-     * Note that invoking this method counts towards the limit.
+     * Note that invoking this method counts towards the limit. Use {@link #checkRateLimitReached(String, String, int)}
+     * if you only want to check the current state without counting the call.
      *
-     * @param scope            the key which is used for grouping multiple events - e.g. the ip of the caller
+     * @param scope            the key which is used for grouping multiple events - e.g. the IP of the caller
      * @param realm            the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>
      * @param explicitLimit    the explicit limit which overwrites the limit given in the config.
      *                         Use {@link #USE_LIMIT_FROM_CONFIG} if no explicit limit is set
      * @param limitReachedOnce specifies an action which is executed once the limit was reached, but then skipped for
      *                         this scope, realm and check interval.
      * @param infoSupplier     a supplier which is invoked to provide additional incident data once the rate limit is first hit
-     * @return <tt>true</tt> if the rate limit for the given ip, realm and check interval is reached,
-     * <tt>false</tt> otherwise.
+     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is reached,
+     * <tt>false</tt> otherwise. Note, that once the limit was reached, an {@link AuditLog audit log entry} will be
+     * created.
      */
     public boolean registerCallAndCheckRateLimitReached(String scope,
                                                         String realm,
@@ -206,7 +209,6 @@ public class Isenguard {
                                                         Supplier<RateLimitingInfo> infoSupplier) {
         try {
             Tuple<Integer, Integer> limit = fetchLimit(realm, explicitLimit);
-
             if (limit.getFirst() == 0 || limit.getSecond() == 0) {
                 return false;
             }

--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -52,8 +52,8 @@ public class Isenguard {
     /**
      * Signals that the limit as given in the system configuration should be used.
      * <p>
-     * This is used by {@link #isRateLimitReached(String, String, int, Supplier)} and
-     * {@link #isRateLimitReached(String, String, int, Runnable, Supplier)}.
+     * This is used by {@link #increaseAndCheckRateLimitReached(String, String, int, Supplier)} and
+     * {@link #increaseAndCheckRateLimitReached(String, String, int, Runnable, Supplier)}.
      */
     public static final int USE_LIMIT_FROM_CONFIG = 0;
 
@@ -153,7 +153,7 @@ public class Isenguard {
                                     String realm,
                                     int explicitLimit,
                                     Supplier<RateLimitingInfo> infoSupplier) {
-        if (isRateLimitReached(scope, realm, explicitLimit, infoSupplier)) {
+        if (increaseAndCheckRateLimitReached(scope, realm, explicitLimit, infoSupplier)) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage("Rate Limit reached: %s (%s)",
                                                     realm,
@@ -164,7 +164,7 @@ public class Isenguard {
     }
 
     /**
-     * Determines if the rate limit of the given realm for the given scope is reached.
+     * Registers an event and determines if the rate limit of the given realm for the given scope is reached.
      * <p>
      * Note that invoking this method counts towards the limit.
      *
@@ -177,15 +177,15 @@ public class Isenguard {
      * <tt>false</tt> otherwise. Note, that once the limit was reached, an {@link AuditLog audit log entry} will be
      * created.
      */
-    public boolean isRateLimitReached(String scope,
-                                      String realm,
-                                      int explicitLimit,
-                                      Supplier<RateLimitingInfo> infoSupplier) {
-        return isRateLimitReached(scope, realm, explicitLimit, null, infoSupplier);
+    public boolean increaseAndCheckRateLimitReached(String scope,
+                                                    String realm,
+                                                    int explicitLimit,
+                                                    Supplier<RateLimitingInfo> infoSupplier) {
+        return increaseAndCheckRateLimitReached(scope, realm, explicitLimit, null, infoSupplier);
     }
 
     /**
-     * Determines if the rate limit of the given realm for the given scope is reached.
+     * Registers an event and determines if the rate limit of the given realm for the given scope is reached.
      * <p>
      * Note that invoking this method counts towards the limit.
      *
@@ -199,11 +199,11 @@ public class Isenguard {
      * @return <tt>true</tt> if the rate limit for the given ip, realm and check interval is reached,
      * <tt>false</tt> otherwise.
      */
-    public boolean isRateLimitReached(String scope,
-                                      String realm,
-                                      int explicitLimit,
-                                      Runnable limitReachedOnce,
-                                      Supplier<RateLimitingInfo> infoSupplier) {
+    public boolean increaseAndCheckRateLimitReached(String scope,
+                                                    String realm,
+                                                    int explicitLimit,
+                                                    Runnable limitReachedOnce,
+                                                    Supplier<RateLimitingInfo> infoSupplier) {
         try {
             Tuple<Integer, Integer> limit = fetchLimit(realm, explicitLimit);
 

--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -96,7 +96,7 @@ public class Isenguard {
      */
     public boolean isIPBlacklisted(String ipAddress) {
         try {
-            return limiter != null && limiter.isIPBLacklisted(ipAddress);
+            return limiter != null && limiter.isIPBlacklisted(ipAddress);
         } catch (Exception exception) {
             // In case of an error e.g. Redis might not be available,
             // we resort to ignoring any checks and let the application run.

--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -58,7 +58,7 @@ public class Isenguard {
     public static final int USE_LIMIT_FROM_CONFIG = 0;
 
     /**
-     * Contains the logged used for all firewall sepcific events.
+     * Contains the log used for all firewall-specific events.
      */
     public static final Log LOG = Log.get("isenguard");
 
@@ -89,9 +89,9 @@ public class Isenguard {
     private EventRecorder events;
 
     /**
-     * Determins if the given ipAddress has already been blocked via {@link #blockIP(String)}.
+     * Determines if the given {@code ipAddress} has already been blocked via {@link #blockIP(String)}.
      *
-     * @param ipAddress the ip address to check
+     * @param ipAddress the IP address to check
      * @return <tt>true</tt> if the address has been blocked, <tt>false</tt> otherwise
      */
     public boolean isIPBlacklisted(String ipAddress) {
@@ -194,7 +194,7 @@ public class Isenguard {
      * @param explicitLimit    the explicit limit which overwrites the limit given in the config.
      *                         Use {@link #USE_LIMIT_FROM_CONFIG} if no explicit limit is set
      * @param limitReachedOnce specifies an action which is executed once the limit was reached, but then skipped for
-     *                         this scope, relam and check interval.
+     *                         this scope, realm and check interval.
      * @param infoSupplier     a supplier which is invoked to provide additional incident data once the rate limit is first hit
      * @return <tt>true</tt> if the rate limit for the given ip, realm and check interval is reached,
      * <tt>false</tt> otherwise.
@@ -300,7 +300,7 @@ public class Isenguard {
     }
 
     /**
-     * Lists all known relams with the given type.
+     * Lists all known realms with the given type.
      * <p>
      * Note that there a some common types:
      * <ul>

--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -165,6 +165,8 @@ public class Isenguard {
 
     /**
      * Determines if the rate limit of the given realm for the given scope is reached.
+     * <p>
+     * Note that invoking this method counts towards the limit.
      *
      * @param scope         the key which is used for grouping multiple events - e.g. the ip of the caller
      * @param realm         the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>
@@ -183,7 +185,9 @@ public class Isenguard {
     }
 
     /**
-     * Determines if the rate limit of the given realm for the given IP is reached.
+     * Determines if the rate limit of the given realm for the given scope is reached.
+     * <p>
+     * Note that invoking this method counts towards the limit.
      *
      * @param scope            the key which is used for grouping multiple events - e.g. the ip of the caller
      * @param realm            the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>

--- a/src/main/java/sirius/biz/isenguard/IsenguardFirewall.java
+++ b/src/main/java/sirius/biz/isenguard/IsenguardFirewall.java
@@ -34,11 +34,12 @@ public class IsenguardFirewall implements Firewall {
     @Override
     public boolean handleRateLimiting(WebContext webContext, String realm) {
         String ip = webContext.getRemoteIP().getHostAddress();
-        boolean rateLimitReached = isenguard.isRateLimitReached(ip,
-                                                                realm,
-                                                                Isenguard.USE_LIMIT_FROM_CONFIG,
-                                                                () -> RateLimitingInfo.fromWebContext(webContext,
-                                                                                                      null));
+        boolean rateLimitReached = isenguard.increaseAndCheckRateLimitReached(ip,
+                                                                              realm,
+                                                                              Isenguard.USE_LIMIT_FROM_CONFIG,
+                                                                              () -> RateLimitingInfo.fromWebContext(
+                                                                                      webContext,
+                                                                                      null));
         if (rateLimitReached) {
             webContext.respondWith().error(HttpResponseStatus.TOO_MANY_REQUESTS);
             return true;

--- a/src/main/java/sirius/biz/isenguard/IsenguardFirewall.java
+++ b/src/main/java/sirius/biz/isenguard/IsenguardFirewall.java
@@ -34,12 +34,12 @@ public class IsenguardFirewall implements Firewall {
     @Override
     public boolean handleRateLimiting(WebContext webContext, String realm) {
         String ip = webContext.getRemoteIP().getHostAddress();
-        boolean rateLimitReached = isenguard.increaseAndCheckRateLimitReached(ip,
-                                                                              realm,
-                                                                              Isenguard.USE_LIMIT_FROM_CONFIG,
-                                                                              () -> RateLimitingInfo.fromWebContext(
-                                                                                      webContext,
-                                                                                      null));
+        boolean rateLimitReached = isenguard.registerCallAndCheckRateLimitReached(ip,
+                                                                                  realm,
+                                                                                  Isenguard.USE_LIMIT_FROM_CONFIG,
+                                                                                  () -> RateLimitingInfo.fromWebContext(
+                                                                                          webContext,
+                                                                                          null));
         if (rateLimitReached) {
             webContext.respondWith().error(HttpResponseStatus.TOO_MANY_REQUESTS);
             return true;

--- a/src/main/java/sirius/biz/isenguard/Limiter.java
+++ b/src/main/java/sirius/biz/isenguard/Limiter.java
@@ -23,7 +23,7 @@ public interface Limiter extends Named {
      * @param ip the ip to check
      * @return <tt>true</tt> if the IP is currently blacklisted, <tt>false</tt> otherwise
      */
-    boolean isIPBLacklisted(String ip);
+    boolean isIPBlacklisted(String ip);
 
     /**
      * Blocks the given IP for a certain amount of time.

--- a/src/main/java/sirius/biz/isenguard/Limiter.java
+++ b/src/main/java/sirius/biz/isenguard/Limiter.java
@@ -40,28 +40,28 @@ public interface Limiter extends Named {
     void unblock(String ipAddress);
 
     /**
-     * Increases the interval counter and determines if the given limit was reached.
+     * Increases the call counter for the current interval and determines if the given limit was reached.
      *
-     * @param key               the unique name of this counter which represents the ip, realm and check-interval
+     * @param key               the unique name of this counter which represents the scope, realm and check-interval
      * @param intervalInSeconds the duration of this interval in seconds (used to remove outdated counters)
      * @param limit             the limit i.e. max number of calls
      * @param limitReachedOnce  the handler to execute once if the limit for this interval is reached
      * @return <tt>true</tt> if the interval was reached, <tt>false</tt> otherwise
      */
-    boolean increaseAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce);
+    boolean registerCallAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce);
 
     /**
-     * Reads the current value for the given key.
+     * Reads the current call count for the given key.
      *
-     * @param key the unique name of this counter which represents the ip, realm and check-interval
-     * @return the current counter value for the given key
+     * @param key the unique name of this counter which represents the scope, realm and check-interval
+     * @return the current call counter value for the given key
      */
-    int readLimit(String key);
+    int readCallCount(String key);
 
     /**
      * Returns the set of currently blocked IPs.
      * <p>
-     * For efficiency reasons, this list can be limited to the latest matches (e.g. the top 50).
+     * For efficiency reasons, this set may be limited to the latest matches (e.g. the top 50).
      *
      * @return a set of currently blocked IPs
      */

--- a/src/main/java/sirius/biz/isenguard/Limiter.java
+++ b/src/main/java/sirius/biz/isenguard/Limiter.java
@@ -40,7 +40,7 @@ public interface Limiter extends Named {
     void unblock(String ipAddress);
 
     /**
-     * Increates the interval counter and determines if the given limit was reached.
+     * Increases the interval counter and determines if the given limit was reached.
      *
      * @param key               the unique name of this counter which represents the ip, realm and check-interval
      * @param intervalInSeconds the duration of this interval in seconds (used to remove outdated counters)
@@ -59,11 +59,11 @@ public interface Limiter extends Named {
     int readLimit(String key);
 
     /**
-     * Returns a list of currently blocked IPs.
+     * Returns the set of currently blocked IPs.
      * <p>
      * For efficiency reasons, this list can be limited to the latest matches (e.g. the top 50).
      *
-     * @return a list of currently blocked IPs
+     * @return a set of currently blocked IPs
      */
     Set<String> getBlockedIPs();
 }

--- a/src/main/java/sirius/biz/isenguard/NOOPLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/NOOPLimiter.java
@@ -42,12 +42,12 @@ public class NOOPLimiter implements Limiter {
     }
 
     @Override
-    public boolean increaseAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce) {
+    public boolean registerCallAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce) {
         return false;
     }
 
     @Override
-    public int readLimit(String key) {
+    public int readCallCount(String key) {
         return 0;
     }
 

--- a/src/main/java/sirius/biz/isenguard/NOOPLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/NOOPLimiter.java
@@ -27,7 +27,7 @@ public class NOOPLimiter implements Limiter {
     }
 
     @Override
-    public boolean isIPBLacklisted(String ip) {
+    public boolean isIPBlacklisted(String ip) {
         return false;
     }
 

--- a/src/main/java/sirius/biz/isenguard/RedisLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/RedisLimiter.java
@@ -71,9 +71,9 @@ public class RedisLimiter implements Limiter {
     }
 
     @Override
-    public boolean increaseAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce) {
+    public boolean registerCallAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce) {
         String effectiveKey = COUNTER_PREFIX + key;
-        return getDB().query(() -> "Update rate limit: " + effectiveKey, db -> {
+        return getDB().query(() -> "Update rate limiting call counter: " + effectiveKey, db -> {
             long value = db.incr(effectiveKey);
             if (value == 1) {
                 db.expire(effectiveKey, intervalInSeconds);
@@ -86,9 +86,9 @@ public class RedisLimiter implements Limiter {
     }
 
     @Override
-    public int readLimit(String key) {
+    public int readCallCount(String key) {
         String effectiveKey = COUNTER_PREFIX + key;
-        return getDB().query(() -> "Read rate limit: " + effectiveKey, db -> {
+        return getDB().query(() -> "Read rate limiting call counter: " + effectiveKey, db -> {
             String value = db.get(effectiveKey);
             if (Strings.isEmpty(value)) {
                 return 0;

--- a/src/main/java/sirius/biz/isenguard/RedisLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/RedisLimiter.java
@@ -44,7 +44,7 @@ public class RedisLimiter implements Limiter {
     }
 
     @Override
-    public boolean isIPBLacklisted(String ip) {
+    public boolean isIPBlacklisted(String ip) {
         return getDB().query(() -> "Check for blocked IP", db -> db.zrank(BLOCKED_IPS, ip) != null);
     }
 

--- a/src/main/java/sirius/biz/isenguard/SmartLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/SmartLimiter.java
@@ -47,8 +47,8 @@ public class SmartLimiter implements Limiter {
     }
 
     @Override
-    public boolean isIPBLacklisted(String ip) {
-        return getLimiter().isIPBLacklisted(ip);
+    public boolean isIPBlacklisted(String ip) {
+        return getLimiter().isIPBlacklisted(ip);
     }
 
     @Override

--- a/src/main/java/sirius/biz/isenguard/SmartLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/SmartLimiter.java
@@ -62,13 +62,13 @@ public class SmartLimiter implements Limiter {
     }
 
     @Override
-    public boolean increaseAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce) {
-        return getLimiter().increaseAndCheckLimit(key, intervalInSeconds, limit, limitReachedOnce);
+    public boolean registerCallAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce) {
+        return getLimiter().registerCallAndCheckLimit(key, intervalInSeconds, limit, limitReachedOnce);
     }
 
     @Override
-    public int readLimit(String key) {
-        return getLimiter().readLimit(key);
+    public int readCallCount(String key) {
+        return getLimiter().readCallCount(key);
     }
 
     @Override

--- a/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
+++ b/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
@@ -47,28 +47,36 @@ class IsenguardTest {
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
+        val thirdCheck = isenguard.checkRateLimitReached(scope, realm)
         val fourth = isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
+        val fourthCheck = isenguard.checkRateLimitReached(scope, realm)
         val fifth = isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
+        val fifthCheck = isenguard.checkRateLimitReached(scope, realm)
         val sixth = isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
+        val sixthCheck = isenguard.checkRateLimitReached(scope, realm)
 
+        assertFalse { thirdCheck }
         assertFalse { fourth }
+        assertFalse { fourthCheck }
         assertTrue { fifth }
+        assertTrue { fifthCheck }
         assertTrue { sixth }
+        assertTrue { sixthCheck }
         assertEquals(1, counter.get())
     }
 

--- a/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
+++ b/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
@@ -29,37 +29,37 @@ class IsenguardTest {
         val realm = "test"
 
         val counter = AtomicInteger()
-        isenguard.increaseAndCheckRateLimitReached(
+        isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        isenguard.increaseAndCheckRateLimitReached(
+        isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        isenguard.increaseAndCheckRateLimitReached(
+        isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        val fourth = isenguard.increaseAndCheckRateLimitReached(
+        val fourth = isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        val fifth = isenguard.increaseAndCheckRateLimitReached(
+        val fifth = isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        val sixth = isenguard.increaseAndCheckRateLimitReached(
+        val sixth = isenguard.registerCallAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,

--- a/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
+++ b/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
@@ -33,38 +33,38 @@ class IsenguardTest {
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
-            { -> counter.incrementAndGet() },
-            { -> RateLimitingInfo(null, null, null) })
+            { counter.incrementAndGet() },
+            { RateLimitingInfo(null, null, null) })
         isenguard.increaseAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
-            { -> counter.incrementAndGet() },
-            { -> RateLimitingInfo(null, null, null) })
+            { counter.incrementAndGet() },
+            { RateLimitingInfo(null, null, null) })
         isenguard.increaseAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
-            { -> counter.incrementAndGet() },
-            { -> RateLimitingInfo(null, null, null) })
+            { counter.incrementAndGet() },
+            { RateLimitingInfo(null, null, null) })
         val fourth = isenguard.increaseAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
-            { -> counter.incrementAndGet() },
-            { -> RateLimitingInfo(null, null, null) })
+            { counter.incrementAndGet() },
+            { RateLimitingInfo(null, null, null) })
         val fifth = isenguard.increaseAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
-            { -> counter.incrementAndGet() },
-            { -> RateLimitingInfo(null, null, null) })
+            { counter.incrementAndGet() },
+            { RateLimitingInfo(null, null, null) })
         val sixth = isenguard.increaseAndCheckRateLimitReached(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
-            { -> counter.incrementAndGet() },
-            { -> RateLimitingInfo(null, null, null) })
+            { counter.incrementAndGet() },
+            { RateLimitingInfo(null, null, null) })
 
         assertFalse { fourth }
         assertTrue { fifth }

--- a/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
+++ b/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
@@ -25,34 +25,37 @@ class IsenguardTest {
 
     @Test
     fun `Rate limiting works as intended`() {
+        val scope = "127.0.0.1"
+        val realm = "test"
+
         val counter = AtomicInteger()
-        isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
-                "test",
+        isenguard.increaseAndCheckRateLimitReached(scope,
+                realm,
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
-                "test",
+        isenguard.increaseAndCheckRateLimitReached(scope,
+                realm,
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
-                "test",
+        isenguard.increaseAndCheckRateLimitReached(scope,
+                realm,
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        val fourth = isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
-                "test",
+        val fourth = isenguard.increaseAndCheckRateLimitReached(scope,
+                realm,
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        val fifth = isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
-                "test",
+        val fifth = isenguard.increaseAndCheckRateLimitReached(scope,
+                realm,
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        val sixth = isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
-                "test",
+        val sixth = isenguard.increaseAndCheckRateLimitReached(scope,
+                realm,
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })

--- a/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
+++ b/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
@@ -26,32 +26,32 @@ class IsenguardTest {
     @Test
     fun `Rate limiting works as intended`() {
         val counter = AtomicInteger()
-        isenguard.isRateLimitReached("127.0.0.1",
+        isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
                 "test",
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        isenguard.isRateLimitReached("127.0.0.1",
+        isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
                 "test",
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        isenguard.isRateLimitReached("127.0.0.1",
+        isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
                 "test",
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        val fourth = isenguard.isRateLimitReached("127.0.0.1",
+        val fourth = isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
                 "test",
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        val fifth = isenguard.isRateLimitReached("127.0.0.1",
+        val fifth = isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
                 "test",
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },
                 { -> RateLimitingInfo(null, null, null) })
-        val sixth = isenguard.isRateLimitReached("127.0.0.1",
+        val sixth = isenguard.increaseAndCheckRateLimitReached("127.0.0.1",
                 "test",
                 Isenguard.USE_LIMIT_FROM_CONFIG,
                 { -> counter.incrementAndGet() },

--- a/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
+++ b/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
@@ -29,36 +29,42 @@ class IsenguardTest {
         val realm = "test"
 
         val counter = AtomicInteger()
-        isenguard.increaseAndCheckRateLimitReached(scope,
-                realm,
-                Isenguard.USE_LIMIT_FROM_CONFIG,
-                { -> counter.incrementAndGet() },
-                { -> RateLimitingInfo(null, null, null) })
-        isenguard.increaseAndCheckRateLimitReached(scope,
-                realm,
-                Isenguard.USE_LIMIT_FROM_CONFIG,
-                { -> counter.incrementAndGet() },
-                { -> RateLimitingInfo(null, null, null) })
-        isenguard.increaseAndCheckRateLimitReached(scope,
-                realm,
-                Isenguard.USE_LIMIT_FROM_CONFIG,
-                { -> counter.incrementAndGet() },
-                { -> RateLimitingInfo(null, null, null) })
-        val fourth = isenguard.increaseAndCheckRateLimitReached(scope,
-                realm,
-                Isenguard.USE_LIMIT_FROM_CONFIG,
-                { -> counter.incrementAndGet() },
-                { -> RateLimitingInfo(null, null, null) })
-        val fifth = isenguard.increaseAndCheckRateLimitReached(scope,
-                realm,
-                Isenguard.USE_LIMIT_FROM_CONFIG,
-                { -> counter.incrementAndGet() },
-                { -> RateLimitingInfo(null, null, null) })
-        val sixth = isenguard.increaseAndCheckRateLimitReached(scope,
-                realm,
-                Isenguard.USE_LIMIT_FROM_CONFIG,
-                { -> counter.incrementAndGet() },
-                { -> RateLimitingInfo(null, null, null) })
+        isenguard.increaseAndCheckRateLimitReached(
+            scope,
+            realm,
+            Isenguard.USE_LIMIT_FROM_CONFIG,
+            { -> counter.incrementAndGet() },
+            { -> RateLimitingInfo(null, null, null) })
+        isenguard.increaseAndCheckRateLimitReached(
+            scope,
+            realm,
+            Isenguard.USE_LIMIT_FROM_CONFIG,
+            { -> counter.incrementAndGet() },
+            { -> RateLimitingInfo(null, null, null) })
+        isenguard.increaseAndCheckRateLimitReached(
+            scope,
+            realm,
+            Isenguard.USE_LIMIT_FROM_CONFIG,
+            { -> counter.incrementAndGet() },
+            { -> RateLimitingInfo(null, null, null) })
+        val fourth = isenguard.increaseAndCheckRateLimitReached(
+            scope,
+            realm,
+            Isenguard.USE_LIMIT_FROM_CONFIG,
+            { -> counter.incrementAndGet() },
+            { -> RateLimitingInfo(null, null, null) })
+        val fifth = isenguard.increaseAndCheckRateLimitReached(
+            scope,
+            realm,
+            Isenguard.USE_LIMIT_FROM_CONFIG,
+            { -> counter.incrementAndGet() },
+            { -> RateLimitingInfo(null, null, null) })
+        val sixth = isenguard.increaseAndCheckRateLimitReached(
+            scope,
+            realm,
+            Isenguard.USE_LIMIT_FROM_CONFIG,
+            { -> counter.incrementAndGet() },
+            { -> RateLimitingInfo(null, null, null) })
 
         assertFalse { fourth }
         assertTrue { fifth }


### PR DESCRIPTION
### Description

Improves Rate Limiting:
- `Isenguard` now provides methods for checking the limit without affecting the state
- Methods have been renamed, as some names have been misleading – This is a *breaking change*!
  - `Limiter.isIPBLacklisted(…)` → `Limiter.isIPBlacklisted(…)` (typo)
  - `Limiter.readLimit(…)` → `Limiter.readCallCount(…)` (misleading name, the method returns the call count)
  - `Limiter.increaseAndCheckLimit(…)` → `Limiter.registerCallAndCheckLimit(…)` (harmonised naming to indicate purpose more obviously)
  - `Isenguard. isRateLimitReached(…)` → `Isenguard.registerCallAndCheckRateLimitReached(…)` (misleading name, the method has side effects as it increases the call count)
- Further typo fixes and documentation improvements

### Additional Notes

- This PR fixes or works on following ticket(s): [MIO-6376](https://scireum.myjetbrains.com/youtrack/issue/MIO-6376)

### Checklist

- [x] Code change has been tested and works locally (via Test Case)
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
