### PR TITLE
Adds apache-mina as directly dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
             <version>5.4</version>
         </dependency>
 
+        <!-- Overrides the apache-mina embedded in org.apache.ftpserver due to https://osv.dev/vulnerability/GHSA-76h9-2vwh-w278 -->
+        <dependency>
+            <groupId>org.apache.mina</groupId>
+            <artifactId>mina-core</artifactId>
+            <version>2.1.10</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.ftpserver</groupId>
             <artifactId>ftpserver-core</artifactId>


### PR DESCRIPTION
### Description

This is included via org.apache.ftpserver, but has a Critical Vulnerability: https://osv.dev/vulnerability/GHSA-76h9-2vwh-w278 (CVE-2024-52046)

### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
