### PR TITLE
hide quirky show-password field in edge - we have our own one.

### DIFF
--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -10,6 +10,9 @@
             #wrapper-menu {
                 display: none;
             }
+            ::-ms-reveal {
+                display: none;
+            }
         </style>
     </i:block>
 


### PR DESCRIPTION
### Description
We do not want the second "make password visible" button as it is quite quirky.

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
<img width="570" alt="Bildschirmfoto 2025-01-27 um 15 45 45" src="https://github.com/user-attachments/assets/c16c36b1-6efd-464f-acdb-4b0791a91c7a" />

### Additional Notes

- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
