### PR TITLE
fix update report for hacky values

### DIFF
--- a/src/main/java/sirius/biz/tycho/updates/UpdatesController.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdatesController.java
@@ -13,6 +13,7 @@ import sirius.biz.web.BizController;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
 import sirius.web.controller.Routed;
 import sirius.web.http.WebContext;
 import sirius.web.services.InternalService;
@@ -39,8 +40,12 @@ public class UpdatesController extends BizController {
     @Routed("/tycho/updates/markAsSeen")
     public void markUpdatesAsSeen(WebContext webContext, JSONStructuredOutput output) {
         String updateId = webContext.require("updateId").asString();
-        if (Strings.isFilled(updateId)) {
+        if (Strings.isHttpUrl(updateId)) {
             eventRecorder.record(new UpdateClickEvent().forUpdateGuid(updateId));
+        } else {
+            throw Exceptions.createHandled()
+                            .withDirectMessage(Strings.apply("Invalid updateId: %s", updateId))
+                            .handle();
         }
     }
 }

--- a/src/main/java/sirius/biz/tycho/updates/UpdatesReport.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdatesReport.java
@@ -16,15 +16,13 @@ import sirius.biz.jobs.interactive.ReportJobFactory;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.tenants.TenantUserManager;
 import sirius.kernel.commons.Limit;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.nls.NLS;
 import sirius.web.security.Permission;
 
-import javax.annotation.Nonnull;
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +92,7 @@ public class UpdatesReport extends ReportJobFactory {
                         """).set("start", start).set("end", LocalDate.now()).iterateAll(row -> {
             String guid = row.getValue("updateGuid").asString();
             report.addRow(List.of(Tuple.create(COLUMN_GUID,
-                                               isURL(guid) ? cells.link(guid, guid, true) : cells.of(guid)),
+                                               Strings.isHttpUrl(guid) ? cells.link(guid, guid, true) : cells.of(guid)),
                                   Tuple.create(COLUMN_TOTAL, cells.of(row.getValue("all").asInt(0))),
                                   Tuple.create(COLUMN_LOGGED_IN, cells.of(row.getValue(COLUMN_LOGGED_IN).asInt(0))),
                                   Tuple.create(COLUMN_ANONYMOUS, cells.of(row.getValue(COLUMN_ANONYMOUS).asInt(0)))));
@@ -104,16 +102,6 @@ public class UpdatesReport extends ReportJobFactory {
         additionalMetricConsumer.accept(NLS.get("UpdatesReport.totalClicks"), cells.of(totalClicks.get()));
     }
 
-    private boolean isURL(String guid) {
-        try {
-            URI.create(guid).toURL();
-            return true;
-        } catch (MalformedURLException exception) {
-            return false;
-        }
-    }
-
-    @Nonnull
     @Override
     public String getName() {
         return "UpdatesReport";

--- a/src/main/resources/default/templates/biz/tycho/dashboard-news.html.pasta
+++ b/src/main/resources/default/templates/biz/tycho/dashboard-news.html.pasta
@@ -1,4 +1,4 @@
-<i:local name="updates" value="part(sirius.biz.tycho.updates.UpdateManager.class).fetchUpdates()" />
+<i:local name="updates" value="part(sirius.biz.tycho.updates.UpdateManager.class).fetchUpdates()"/>
 <i:if test="!updates.isEmpty()">
     <div class="card mb-4 flex-grow-1">
         <div class="card-body">
@@ -12,14 +12,20 @@
                     <div class="mb-1">
                         <b>@info.getLabel()</b>
                     </div>
-                    <div><i:raw>@info.getDescription()</i:raw></div>
-                    <i:local name="linkId" value="@apply('update-link-%s', generateId())" />
-                    <div><a id="@linkId" class="small stretched-link" href="@info.getLink()" target="_blank">@i18n("DashboardController.more")</a></div>
+                    <div>
+                        <i:raw>@info.getDescription()</i:raw>
+                    </div>
+                    <i:local name="linkId" value="@apply('update-link-%s', generateId())"/>
+                    <div>
+                        <a id="@linkId" class="small stretched-link" href="@info.getLink()" target="_blank">@i18n("DashboardController.more")</a>
+                    </div>
                     <script type="text/javascript">
                         sirius.ready(function () {
-                            document.querySelector('#@linkId').addEventListener('click', function() {
+                            document.querySelector('#@linkId').addEventListener('click', function () {
                                 sirius.postJSON('/tycho/updates/markAsSeen',
-                                    {updateId: '@info.getGuid()'});
+                                    {
+                                        updateId: '@info.getGuid()'
+                                    });
                             });
                         });
                     </script>

--- a/src/main/resources/default/templates/biz/tycho/dashboard-news.html.pasta
+++ b/src/main/resources/default/templates/biz/tycho/dashboard-news.html.pasta
@@ -17,7 +17,8 @@
                     </div>
                     <i:local name="linkId" value="@apply('update-link-%s', generateId())"/>
                     <div>
-                        <a id="@linkId" class="small stretched-link" href="@info.getLink()" target="_blank">@i18n("DashboardController.more")</a>
+                        <a id="@linkId" class="small stretched-link" href="@info.getLink()" rel="nofollow"
+                           target="_blank">@i18n("DashboardController.more")</a>
                     </div>
                     <script type="text/javascript">
                         sirius.ready(function () {


### PR DESCRIPTION
Use Strings#isHttpUrl for displaying the links in the update report instead of checking it in an extra method.

on some systems some bots have inserted guids like 
`(select(0)from(select(sleep(15)))v)/*'+(select(0)from(select(sleep(15)))v)+...`
or other hacky values. They will cause an IllegalArgumentException and so the whole report was broken here.
![Bildschirmfoto 2025-01-28 um 13 54 29](https://github.com/user-attachments/assets/2dc04ace-a317-4a11-9d90-5fa73e279c7f)


@ all Maybe we should check valid URLs on the event-recording - or should `/hallo` be a valid path?
see sirius.biz.tycho.updates.UpdatesController#markUpdatesAsSeen 

### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
