### PR TITLE
SIRI-1047 List Yes, No or Ja, Nein for allowed boolean values in job-docu, also translated enum values

### DIFF
--- a/src/main/java/sirius/biz/importer/format/EnumPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/EnumPropertyTransformer.java
@@ -11,7 +11,9 @@ package sirius.biz.importer.format;
 import sirius.db.mixing.properties.EnumProperty;
 import sirius.kernel.di.std.Register;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Generates a {@link FieldDefinition} for an {@link EnumProperty}.
@@ -32,9 +34,13 @@ public class EnumPropertyTransformer extends BaseFieldDefinitionTransformer<Enum
     @Override
     @SuppressWarnings("unchecked")
     protected void customizeField(EnumProperty property, FieldDefinition field) {
-        field.withCheck(new ValueInListCheck(Arrays.stream(((Class<Enum<?>>) property.getField()
-                                                                                     .getType()).getEnumConstants())
-                                                   .map(Enum::name)
-                                                   .toList()));
+        List<String> allowedValues = new ArrayList<>();
+        allowedValues.addAll(Arrays.stream(((Class<Enum<?>>) property.getField().getType()).getEnumConstants())
+                                   .map(Enum::name)
+                                   .toList());
+        allowedValues.addAll(Arrays.stream(((Class<Enum<?>>) property.getField().getType()).getEnumConstants())
+                                   .map(e -> "$" + e.getClass().getSimpleName() + "." + e.name())
+                                   .toList());
+        field.withCheck(new ValueInListCheck(allowedValues));
     }
 }

--- a/src/main/java/sirius/biz/importer/format/EnumPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/EnumPropertyTransformer.java
@@ -35,12 +35,10 @@ public class EnumPropertyTransformer extends BaseFieldDefinitionTransformer<Enum
     @SuppressWarnings("unchecked")
     protected void customizeField(EnumProperty property, FieldDefinition field) {
         List<String> allowedValues = new ArrayList<>();
-        allowedValues.addAll(Arrays.stream(((Class<Enum<?>>) property.getField().getType()).getEnumConstants())
-                                   .map(Enum::name)
-                                   .toList());
-        allowedValues.addAll(Arrays.stream(((Class<Enum<?>>) property.getField().getType()).getEnumConstants())
-                                   .map(e -> "$" + e.getClass().getSimpleName() + "." + e.name())
-                                   .toList());
+        Arrays.stream(((Class<Enum<?>>) property.getField().getType()).getEnumConstants()).forEach(enumValue -> {
+            allowedValues.add(enumValue.name());
+            allowedValues.add("$" + enumValue.getClass().getSimpleName() + "." + enumValue.name());
+        });
         field.withCheck(new ValueInListCheck(allowedValues));
     }
 }

--- a/src/main/java/sirius/biz/importer/format/FieldDefinition.java
+++ b/src/main/java/sirius/biz/importer/format/FieldDefinition.java
@@ -30,8 +30,6 @@ import java.util.stream.Collectors;
  */
 public class FieldDefinition {
 
-    private static final ValueInListCheck BOOLEAN_VALUES_CHECK = new ValueInListCheck("true", "false");
-
     protected String name;
     protected String type;
     protected String typeUrl;
@@ -162,7 +160,10 @@ public class FieldDefinition {
      * @return the newly created field
      */
     public static FieldDefinition booleanField(String name) {
-        return new FieldDefinition(name, typeBoolean()).withCheck(BOOLEAN_VALUES_CHECK);
+        return new FieldDefinition(name, typeBoolean()).withCheck(new ValueInListCheck("true",
+                                                                                       "false",
+                                                                                       "$" + NLS.CommonKeys.YES.key(),
+                                                                                       "$" + NLS.CommonKeys.NO.key()));
     }
 
     /**


### PR DESCRIPTION
### Description
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

For BooleanProperty this is already done in sirius.biz.importer.format.BooleanPropertyTransformer#customizeField but if you add one via FieldDefinition.booleanField we also want to add the translated value.

For Enum Values we also already import the translated value like in the export, so we simply also add it to the docu.

### Question:
This only adds the current language version in allowed values, maybe the translated values could also be added for all other possible active languages like in the headlines?


<img width="1611" alt="Bildschirmfoto 2025-01-29 um 14 01 52" src="https://github.com/user-attachments/assets/12b7dd06-9228-4053-a6b7-750103bb4c89" />
<img width="748" alt="Bildschirmfoto 2025-01-29 um 14 03 21" src="https://github.com/user-attachments/assets/2fae3b75-2caf-4b67-a934-4beef3d06754" />


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1047](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1047)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
