### PR TITLE
Mark erroneous field in form when validator triggers

### DIFF
--- a/src/main/java/sirius/biz/tenants/EmailAddressValidator.java
+++ b/src/main/java/sirius/biz/tenants/EmailAddressValidator.java
@@ -8,11 +8,13 @@
 
 package sirius.biz.tenants;
 
+import sirius.db.mixing.InvalidFieldException;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyValidator;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
 import sirius.web.mails.Mails;
 
 import javax.annotation.Nonnull;
@@ -34,8 +36,12 @@ public class EmailAddressValidator implements PropertyValidator {
 
     @Override
     public void beforeSave(Property property, Object value) {
-        if (value instanceof String email && Strings.isFilled(email)) {
-            mails.failForInvalidEmail(email, null);
+        if (value instanceof String email && Strings.isFilled(email) && !mails.isValidMailAddress(email, null)) {
+            throw Exceptions.createHandled()
+                            .error(new InvalidFieldException(property.getName()))
+                            .withNLSKey("MailService.invalidAddress")
+                            .set("address", email)
+                            .handle();
         }
     }
 

--- a/src/main/java/sirius/biz/tenants/HttpsUrlValidator.java
+++ b/src/main/java/sirius/biz/tenants/HttpsUrlValidator.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.tenants;
 
+import sirius.db.mixing.InvalidFieldException;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyValidator;
 import sirius.kernel.commons.Strings;
@@ -40,6 +41,7 @@ public class HttpsUrlValidator implements PropertyValidator {
 
     private HandledException createInvalidHttpsUrlException(Property property, String value) {
         return Exceptions.createHandled()
+                         .error(new InvalidFieldException(property.getName()))
                          .withNLSKey("HttpsUrlValidator.invalidHttpsUrl")
                          .set("field", property.getLabel())
                          .set("value", value)

--- a/src/main/java/sirius/biz/tenants/PhoneNumberValidator.java
+++ b/src/main/java/sirius/biz/tenants/PhoneNumberValidator.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.tenants;
 
+import sirius.db.mixing.InvalidFieldException;
 import sirius.db.mixing.Property;
 import sirius.db.mixing.PropertyValidator;
 import sirius.kernel.commons.Strings;
@@ -54,6 +55,7 @@ public class PhoneNumberValidator implements PropertyValidator {
 
     private HandledException createInvalidPhoneException(Property property, String value) {
         return Exceptions.createHandled()
+                         .error(new InvalidFieldException(property.getName()))
                          .withNLSKey("ContactData.invalidPhone")
                          .set("field", property.getLabel())
                          .set("value", value)


### PR DESCRIPTION
### Description

Previously just a error message banner was displayed at the top of the form, but the field was not marked accordingly like when other field constraints are breached.

Jakob also suggested moving the validators to sirius-db, but only 2 of the 3 could be moved, as the `EmailAddressValidator` uses the `Mails` Part for validation, which resides in sirius-web.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1050](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1050)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
