### PR TITLE
Allows Canceling the TaskContext of Scripts

### DIFF
--- a/src/main/java/sirius/biz/scripting/JobTaskContextAdapter.java
+++ b/src/main/java/sirius/biz/scripting/JobTaskContextAdapter.java
@@ -25,6 +25,7 @@ class JobTaskContextAdapter implements TaskContextAdapter {
     private final String jobNumber;
     private final RateLimit logLimiter;
     private final RateLimit stateLimiter;
+    private boolean cancelled;
 
     protected JobTaskContextAdapter(Scripting scripting, String jobNumber) {
         this.scripting = scripting;
@@ -89,11 +90,11 @@ class JobTaskContextAdapter implements TaskContextAdapter {
 
     @Override
     public void cancel() {
-        // unsupported by this adapter.
+        cancelled = true;
     }
 
     @Override
     public boolean isActive() {
-        return true;
+        return !cancelled;
     }
 }

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -496,6 +496,7 @@ public abstract class Tenants<I extends Serializable, T extends BaseEntity<I> & 
                                                                          Collections.emptyMap());
                 processes.execute(processId, processContext -> {
                     try {
+                        processContext.markRunning();
                         task.invoke(processContext);
                     } catch (Exception exception) {
                         processContext.handle(exception);


### PR DESCRIPTION
### Description

Our KBA already mentions a way to cancel scripts. This however only worked for scripts which created a process. Now it also works for e.g. database queries executed directly inside the scripts environment.

Plus a small drive-by for marking admin processes as running.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1053](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1053)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
