### PR TITLE
Processes - Mark complex delete as running when it is started

### DIFF
--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -461,6 +461,7 @@ public class BizController extends BasicController {
                                                                  PersistencePeriod.THREE_MONTHS,
                                                                  Collections.emptyMap());
         tasks.executor(COMPLEX_DELETION_EXECUTOR).fork(() -> processes.execute(processId, process -> {
+            process.markRunning();
             process.log(ProcessLog.info()
                                   .withNLSKey("BizController.startDelete")
                                   .withContext("entity", String.valueOf(entity)));


### PR DESCRIPTION
### Description

This has two effects:
- The process is filterable via the state "running" while it runs
- The process is filterable via the "started" time filter

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
