### PR TITLE
Permits to wait longer for a variant conversion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - ingest.geoip.downloader.enabled=false
     hostname: es
   s3-system:
-    image: scireum/s3-ninja:8.3.2
+    image: scireum/s3-ninja:8.4.0
     ports:
       - "9000"
     hostname: s3ninja

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1440,9 +1440,6 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
 
     /**
      * Creates the physical key for the given blob and variant.
-     * <p>
-     * This method should be used when {@link #tryCreatePhysicalKey(String, String)} yield no results and we want
-     * to trigger the conversion of the requested variant.
      *
      * @param blobKey     the blob for which the variant is to be resolved
      * @param variantName the variant of the blob to find

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -92,6 +92,12 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     private static int maxConversionAttempts;
 
     /**
+     * Specifies the total number of attempts to wait for a conversion result when requested to wait longer.
+     */
+    @ConfigValue("storage.layer2.conversion.maxLongConversionAttempts")
+    private static int maxLongConversionAttempts;
+
+    /**
      * Specifies the number of milliseconds to wait for a conversion.
      */
     @ConfigValue("storage.layer2.conversion.conversionRetryDelay")

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -178,7 +178,14 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
      */
     private static final String EXECUTOR_STORAGE_CONVERSION_DELIVERY = "storage-conversion-delivery";
 
+    /**
+     * Describes if the variant as obtained from cache, lookup or delegated (where a conversion was requested).
+     */
     private static final String HEADER_VARIANT_SOURCE = "X-VariantSource";
+
+    /**
+     * Contains the host which performed the conversion in case of delegated conversions.
+     */
     private static final String HEADER_VARIANT_COMPUTER = "X-VariantComputer";
 
     /**

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -185,7 +185,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     private static final String EXECUTOR_STORAGE_CONVERSION_DELIVERY = "storage-conversion-delivery";
 
     /**
-     * Describes if the variant as obtained from cache, lookup or delegated (where a conversion was requested).
+     * Describes if the variant was obtained from cache, lookup or delegated (where a conversion was requested).
      */
     private static final String HEADER_VARIANT_SOURCE = "X-VariantSource";
 

--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
@@ -88,6 +88,19 @@ public class BlobDispatcher implements WebDispatcher {
      */
     public static final String FLAG_CACHEABLE = "c";
 
+    /**
+     * Signalizes that the caller is ready to wait longer for a response.
+     * <p>
+     * This is especially used when the variant retrieved will be converted on-the-fly, and you want to increase the
+     * chance of getting one without having to implement a client-side retry mechanism.
+     */
+    public static final String WAIT_LONGER_PARAMETER = "waitLonger";
+
+    /**
+     * Header set to signalize that the caller is ready to wait longer for a response.
+     */
+    public static final String HEADER_WAIT_LONGER = "X-Wait-Longer";
+
     private static final String PARAM_HOOK = "hook";
     private static final String PARAM_PAYLOAD = "payload";
 
@@ -276,6 +289,10 @@ public class BlobDispatcher implements WebDispatcher {
             response.download(filename);
         } else {
             response.named(filename);
+        }
+
+        if (request.get(WAIT_LONGER_PARAMETER).asBoolean()) {
+            response.addHeader(HEADER_WAIT_LONGER, true);
         }
 
         storageSpace.deliver(blobKey,

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
@@ -62,7 +62,7 @@ public interface BlobStorageSpace {
     /**
      * Provides the <tt>kba</tt> if present in the config block.
      *
-     * @returns the code of the {@link sirius.biz.tycho.kb.KnowledgeBase kba} to show when browsing this space.
+     * @return the code of the {@link sirius.biz.tycho.kb.KnowledgeBase kba} to show when browsing this space.
      */
     @Nullable
     String getKnowledgeBaseArticleCode();
@@ -87,7 +87,7 @@ public interface BlobStorageSpace {
      * Returns the root directory for the given tenant.
      * <p>
      * Note that {@link Tenants#getSystemTenantId()} can be used for system related files (as long as the
-     * <tt>tenants</tt> framework is used.
+     * <tt>tenants</tt> framework is used).
      *
      * @param tenantId the tenant to determine the directory for
      * @return the root directory for the given tenant
@@ -99,7 +99,7 @@ public interface BlobStorageSpace {
      * Resolves the given path into a blob.
      * <p>
      * Note that {@link Tenants#getSystemTenantId()} can be used for system related files (as long as the
-     * <tt>tenants</tt> framework is used.
+     * <tt>tenants</tt> framework is used).
      *
      * @param tenantId the tenant which owns the directory structure to search in
      * @param path     the path to resolve (may start with a "/" but not with the space name itself)
@@ -121,7 +121,7 @@ public interface BlobStorageSpace {
      * Note that all intermediate directories will be auto-created.
      * <p>
      * Note that {@link Tenants#getSystemTenantId()} can be used for system related files (as long as the
-     * <tt>tenants</tt> framework is used.
+     * <tt>tenants</tt> framework is used).
      *
      * @param tenantId the tenant which owns the directory structure to search in
      * @param path     the path to resolve (may start with a "/" but not with the space name itself)
@@ -146,7 +146,7 @@ public interface BlobStorageSpace {
      * deleted. It is made permanent as soon as the referencing entity is saved, otherwise it will be deleted
      * automatically.
      * <p>
-     * Note that there is almost no use-case to directly call this method (outside of {@link BlobHardRef}.
+     * Note that there is almost no use-case to directly call this method outside of {@link BlobHardRef}.
      *
      * @return the newly created temporary blob. To make this blob permanent, it has to be stored in a
      * {@link BlobHardRef} and the referencing entity has to be persisted.
@@ -312,7 +312,7 @@ public interface BlobStorageSpace {
     /**
      * Resolves the filename of the given blob.
      *
-     * @param blobKey the blob to lookup the filename for
+     * @param blobKey the blob to look up the filename for
      * @return the filename if present or an empty optional if non was found
      */
     Optional<String> resolveFilename(@Nonnull String blobKey);

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
@@ -301,12 +301,13 @@ public interface BlobStorageSpace {
     /**
      * Downloads and provides the contents of the requested blob with the given variant.
      *
-     * @param blobKey the blob key of the blob to download
-     * @param variant the variant of the blob to download. Use {@link URLBuilder#VARIANT_RAW} to download the blob itself
+     * @param blobKey    the blob key of the blob to download
+     * @param variant    the variant of the blob to download. Use {@link URLBuilder#VARIANT_RAW} to download the blob itself
+     * @param waitLonger whether to wait longer for the conversion to complete
      * @return a handle to the given object wrapped as optional or an empty one if the object doesn't exist or couldn't
      * be converted
      */
-    Optional<FileHandle> download(String blobKey, String variant);
+    Optional<FileHandle> download(String blobKey, String variant, boolean waitLonger);
 
     /**
      * Resolves the filename of the given blob.

--- a/src/main/java/sirius/biz/storage/layer2/README.md
+++ b/src/main/java/sirius/biz/storage/layer2/README.md
@@ -49,7 +49,7 @@ various nodes in the cluster and even the conversion itself, which can be delega
 A virtual delivery means that a file is being requested via a `/dasd/` served by
 our [BlobDispatcher](BlobDispatcher.java).
 
-In both cases, the main flow follows this pattern:
+The following diagram displays the main flow of the virtual delivery process:
 
 ```mermaid
 flowchart TD

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -13,6 +13,7 @@ import sirius.biz.storage.util.StorageUtils;
 import sirius.kernel.commons.Files;
 import sirius.kernel.commons.StringCleanup;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
@@ -562,13 +563,15 @@ public class URLBuilder {
             return blob.getPhysicalObjectKey();
         }
 
-        if (cachedPhysicalKey != null) {
-            return cachedPhysicalKey;
+        if (cachedPhysicalKey == null) {
+            Tuple<String, Boolean> physicalKey =
+                    ((BasicBlobStorageSpace<?, ?, ?>) space).tryFetchPhysicalKey(blobKey, variant);
+            if (physicalKey != null) {
+                this.cachedPhysicalKey = physicalKey.getFirst();
+            }
         }
 
-        Optional<String> physicalKey = ((BasicBlobStorageSpace<?, ?, ?>) space).tryResolvePhysicalKey(blobKey, variant);
-        physicalKey.ifPresent(key -> this.cachedPhysicalKey = key);
-        return physicalKey.orElse(null);
+        return cachedPhysicalKey;
     }
 
     private String computeAccessToken(String authToken) {

--- a/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
+++ b/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
@@ -72,7 +72,7 @@ public class BlobPdfReplaceHandler extends PdfReplaceHandler {
 
         BlobStorageSpace space = storage.getSpace(spaceKey);
         Optional<FileHandle> optionalFileHandle =
-                tryResolveVariant(variantOrPhysicalKey).flatMap(variant -> space.download(blobKey, variant))
+                tryResolveVariant(variantOrPhysicalKey).flatMap(variant -> space.download(blobKey, variant, true))
                                                        .or(() -> tryResolvePhysicalKey(variantOrPhysicalKey).flatMap(
                                                                physicalKey -> space.getPhysicalSpace()
                                                                                    .download(physicalKey)));

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -999,6 +999,19 @@ storage {
             # forwarding a request.
             hosts = []
 
+            # Specifies the total number of attempts for the optimistic locking for conversion.
+            # This basically controls parallel requests to convert the same blob in the same node.
+            maxOptimisticLockAttempts = 5
+
+            # Specifies the total number of attempts to wait for a conversion result.
+            maxConversionAttempts = 4
+
+            # Specifies the number of milliseconds to wait between conversion attempts (maxConversionAttempts)
+            conversionRetryDelay = 500ms
+
+            # Specifies the interval after which likely hanging conversion is retried for a given blob variant.
+            hangingConversionRetryInterval = 45m
+
             variants {
                 # Provides a simple variant which uses the identity converter. This is mostly used as a test
                 # of the conversion framework as it doesn't provide any actual benefit.

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1006,6 +1006,9 @@ storage {
             # Specifies the total number of attempts to wait for a conversion result.
             maxConversionAttempts = 4
 
+            # Specifies the total number of attempts to wait for a conversion result when requested to wait longer.
+            maxLongConversionAttempts = 12
+
             # Specifies the number of milliseconds to wait between conversion attempts (maxConversionAttempts)
             conversionRetryDelay = 500ms
 

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1000,7 +1000,7 @@ storage {
             hosts = []
 
             # Specifies the total number of attempts for the optimistic locking for conversion.
-            # This basically controls parallel requests to convert the same blob in the same node.
+            # This basically controls parallel requests to database operations (creating or updating blobs and variants).
             maxOptimisticLockAttempts = 5
 
             # Specifies the total number of attempts to wait for a conversion result.

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - ingest.geoip.downloader.enabled=false
     hostname: es
   s3-system:
-    image: scireum/s3-ninja:8.3.2
+    image: scireum/s3-ninja:8.4.0
     ports:
       - "9000"
     hostname: s3ninja


### PR DESCRIPTION
### Description

The main purpose of this PR is to:
- permit several hard-coded settings such as retry delay and number of attempts to be customized (same values used as before, so the standard config is non-breaking)
- permits to wait longer for a conversion to finish. Previously we would return a HTTP 503 after around 2s for any successful conversion which could take longer than that. Now we support the `/dasd/...?waitLonger=true` parameter to makes the server retry a few more times (obviously customizable). Defaulting to 3x the normal amount.

One use case for this ALREADY IMPLEMENTED is the conversion for embedding in PDF (BlobPdfReplaceHandler).

To achieve this, the BlobStorageSpace has been refactored (thus BREAKING), in order to remove a *god* method which based on a single flag took various complex code paths. I now hope this is more cleaner to understand. By the way, the [layer2's README.md](https://github.com/scireum/sirius-biz/blob/ili/OX-11845/src/main/java/sirius/biz/storage/layer2/README.md) of the storage framework has been enhanced with hopefully useful diagrams to better help understand how the whole thing fits together.

Note that the URLBuilder has been enhanced with a `waitLonger` builder-method in order to create URLs with the extra setting. Also note that this class should be **refactored to use the kernel's URLBuilder**, but this would require even more refactoring, so maybe another time.

BREAKING changes:
- BlobStorageSpace
  - OLD: `Optional<FileHandle> download(String blobKey, String variant);`
  - NEW: `Optional<FileHandle> download(String blobKey, String variant, boolean waitLonger);`

- BasicBlobStorageSpace
  - A protected method called `tryResolvePhysicalKey` has been removed, in case it has been overwritten (*very unlikely*).

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11848](https://scireum.myjetbrains.com/youtrack/issue/OX-11848)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
