### PR TITLE
Upgrades the mongo-container to 7.0.16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     hostname: redis-jupiter
 
   mongo:
-    image: mongo:6.0.13
+    image: mongo:7.0.16
     ports:
       - "27017"
     hostname: mongo

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     hostname: redis-jupiter
 
   mongo:
-    image: mongo:6.0.13
+    image: mongo:7.0.16
     ports:
       - "27017"
     hostname: mongo


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-](https://scireum.myjetbrains.com/youtrack/issue/SIRI-)
- This PR is related to PR: https://github.com/scireum/sirius-db/pull/671

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
  - *Before Upgrade*: make sure the FCV ist set to 6.0
  - *After Upgrade*: set the FCV to 7.0

FCV stands for *Feature Compatibility Mode*. To check it, enter the interactive shell in your container (easily done via Docker Desktop) and type `mongosh` to enter the mongo shell. Than you can check and set the values with these commands:
`db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )`
`db.adminCommand( { setFeatureCompatibilityVersion: "7.0", confirm:true } )`

<img width="1275" alt="image" src="https://github.com/user-attachments/assets/033e9b91-2bf2-4df1-bc3e-70c78497201e" />
