### PR TITLE
Update libraries to latest versions and link to change logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,14 @@
             <version>${sirius.db}</version>
         </dependency>
 
+        <!-- Changelog: https://github.com/mariadb-corporation/mariadb-connector-j/releases -->
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.4.1</version>
+            <version>3.5.2</version>
         </dependency>
+
+        <!-- Changelog: https://github.com/ClickHouse/clickhouse-java/releases -->
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
@@ -58,25 +61,21 @@
             <classifier>http</classifier>
         </dependency>
         <!-- Required for clickhouse-jdbc -->
+        <!-- Changelog: https://downloads.apache.org/httpcomponents/httpclient/RELEASE_NOTES-5.4.x.txt -->
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.4</version>
+            <version>5.4.2</version>
         </dependency>
 
-        <!-- Overrides the apache-mina embedded in org.apache.ftpserver due to https://osv.dev/vulnerability/GHSA-76h9-2vwh-w278 -->
-        <dependency>
-            <groupId>org.apache.mina</groupId>
-            <artifactId>mina-core</artifactId>
-            <version>2.1.10</version>
-        </dependency>
-
+        <!-- Changelog: https://mina.apache.org/ftpserver-project/download_1_2.html -->
         <dependency>
             <groupId>org.apache.ftpserver</groupId>
             <artifactId>ftpserver-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
 
+        <!-- Changelog: https://github.com/apache/mina-sshd/releases -->
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
@@ -93,16 +92,18 @@
             <version>2.14.0</version>
         </dependency>
 
+        <!-- Changelog: https://github.com/codelibs/jcifs/tags -->
         <dependency>
             <groupId>org.codelibs</groupId>
             <artifactId>jcifs</artifactId>
             <version>2.1.39</version>
         </dependency>
         <!-- Required as the version provided by jcifs has security issues -->
+        <!-- https://www.bouncycastle.org/news/?filter=gk_format%3Drelease%26gk_category%3Djava -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.78.1</version>
+            <version>1.80</version>
         </dependency>
 
         <dependency>
@@ -141,22 +142,29 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
         </dependency>
+
+        <!-- Changelog: https://commons.apache.org/proper/commons-net/changes-report.html -->
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>3.11.0</version>
+            <version>3.11.1</version>
         </dependency>
+
+        <!-- Changelog: https://github.com/rometools/rome/releases -->
         <dependency>
             <groupId>com.rometools</groupId>
             <artifactId>rome</artifactId>
             <version>2.1.0</version>
         </dependency>
+
+        <!-- Changelog: https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes -->
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
         </dependency>
 
+        <!-- Changelog: https://github.com/borisbrodski/sevenzipjbinding/blob/master/ChangeLog -->
         <dependency>
             <groupId>net.sf.sevenzipjbinding</groupId>
             <artifactId>sevenzipjbinding</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,12 +167,5 @@
             <artifactId>sevenzipjbinding-all-platforms</artifactId>
             <version>16.02-2.01</version>
         </dependency>
-
-        <!-- Used to render diagrams into SVG -->
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-all</artifactId>
-            <version>1.18</version>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <url>https://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-44.3.0</sirius.kernel>
-        <sirius.web>dev-89.1.2</sirius.web>
-        <sirius.db>dev-60.0.2</sirius.db>
+        <sirius.kernel>dev-44.4.0</sirius.kernel>
+        <sirius.web>dev-89.2.0</sirius.web>
+        <sirius.db>dev-60.1.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/FTPServer.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/FTPServer.java
@@ -189,7 +189,7 @@ public class FTPServer implements Startable, Stoppable, AdditionalRolesProvider 
         ssl.setKeystoreFile(new File(keystore));
         ssl.setKeystorePassword(keystorePassword);
         ssl.setKeyAlias(keyAlias);
-        ssl.setSslProtocol(tlsProtocol);
+        ssl.setSslProtocol(new String[]{tlsProtocol});
         factory.setSslConfiguration(ssl.createSslConfiguration());
         factory.setImplicitSsl(forceSSL);
     }


### PR DESCRIPTION
### Description

* mariadb-java-client: 3.4.1 -> 3.5.2
* httpclient5: 5.4 -> 5.4.2
* ftpserver-core: 1.2.0 -> 1.2.1
* bcprov-jdk18on: 1.78.1 -> 1.80
* commons-net: 3.11.0 -> 3.11.1
* snakeyaml: 2.2. -> 2.4

ClickHouse Driver also has a version upgrade available but will be done in a separate ticket, as historically these upgrade tend to cause problems.

Batik is removed from dependencies, as it is already defined in sirius-web. Web will be upgraded to include a version upgrade.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1071](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1071)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
