### PR TITLE
File Explorer - Fixes folder descriptions from being inlined 

### DIFF
--- a/src/main/resources/default/templates/biz/storage/list.html.pasta
+++ b/src/main/resources/default/templates/biz/storage/list.html.pasta
@@ -122,7 +122,7 @@
                                                     </div>
                                                 </i:if>
                                             </a>
-                                            <small class="text-muted">
+                                            <small class="text-muted" style="display:table-caption;width: 300%;">
                                                 <i:if test="isFilled(child.htmlDescription())">
                                                     <i:raw>@child.htmlDescription()</i:raw>
                                                     <i:else>

--- a/src/main/resources/default/templates/biz/storage/list.html.pasta
+++ b/src/main/resources/default/templates/biz/storage/list.html.pasta
@@ -122,14 +122,16 @@
                                                     </div>
                                                 </i:if>
                                             </a>
-                                            <small class="text-muted" style="display:table-caption;width: 300%;">
-                                                <i:if test="isFilled(child.htmlDescription())">
-                                                    <i:raw>@child.htmlDescription()</i:raw>
-                                                    <i:else>
-                                                        @child.description()
-                                                    </i:else>
-                                                </i:if>
-                                            </small>
+                                            <div class="col-6">
+                                                <small class="text-muted">
+                                                    <i:if test="isFilled(child.htmlDescription())">
+                                                        <i:raw>@child.htmlDescription()</i:raw>
+                                                        <i:else>
+                                                            @child.description()
+                                                        </i:else>
+                                                    </i:if>
+                                                </small>
+                                            </div>
                                         </div>
                                     </td>
                                     <td class="text-end">


### PR DESCRIPTION
Fixes: 

### Description
Before:
![image](https://github.com/user-attachments/assets/1a9bca0f-79fb-4d06-9a94-2af8b1cd47f8)

After:
![image](https://github.com/user-attachments/assets/ead68f23-888d-40a8-9592-7cb29ae18cc8)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11700](https://scireum.myjetbrains.com/youtrack/issue/OX-11700)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
