### PR TITLE
Adds an admin job to scan for missing storage objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <url>https://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-44.4.0</sirius.kernel>
+        <sirius.kernel>dev-44.6.0</sirius.kernel>
         <sirius.web>dev-89.3.0</sirius.web>
         <sirius.db>dev-60.1.0</sirius.db>
     </properties>

--- a/src/main/java/sirius/biz/jobs/params/IntParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/IntParameter.java
@@ -18,6 +18,8 @@ import java.util.Optional;
  */
 public class IntParameter extends TextParameter<Integer, IntParameter> {
 
+    Integer defaultValue;
+
     /**
      * Creates a new parameter with the given name and label.
      *
@@ -28,8 +30,22 @@ public class IntParameter extends TextParameter<Integer, IntParameter> {
         super(name, label);
     }
 
+    /**
+     * Specifies the default value to use.
+     *
+     * @param defaultValue the default value to use
+     * @return the parameter itself for fluent method calls
+     */
+    public IntParameter withDefault(int defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+
     @Override
     protected String checkAndTransformValue(Value input) {
+        if (input.isNull() && defaultValue != null) {
+            return String.valueOf(defaultValue);
+        }
         Integer value = NLS.parseUserString(Integer.class, input.asString());
         return value != null ? String.valueOf(value) : null;
     }

--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
@@ -186,7 +186,9 @@ public class FSObjectStorageSpace extends ObjectStorageSpace {
         File file = getFile(objectKey);
 
         if (file.isHidden() || !file.exists() || !file.isFile()) {
-            failureHandler.accept(HttpResponseStatus.NOT_FOUND.code());
+            if (failureHandler != null) {
+                failureHandler.accept(HttpResponseStatus.NOT_FOUND.code());
+            }
             return;
         }
 

--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
@@ -115,6 +115,14 @@ public class FSObjectStorageSpace extends ObjectStorageSpace {
     }
 
     @Override
+    public boolean exists(String objectKey) throws IOException {
+        if (Strings.isEmpty(objectKey)) {
+            return false;
+        }
+        return getFile(objectKey).exists();
+    }
+
+    @Override
     protected void storePhysicalObject(String objectKey, File file) throws IOException {
         try (FileInputStream inputStream = new FileInputStream(file)) {
             storePhysicalObject(objectKey, inputStream, file.length());

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -482,6 +482,15 @@ public abstract class ObjectStorageSpace {
     }
 
     /**
+     * Determines if the requested object exists.
+     *
+     * @param objectKey the id of the object
+     * @return <tt>true</tt> if the object exists, <tt>false</tt> otherwise
+     * @throws IOException in case of an IO error
+     */
+    public abstract boolean exists(String objectKey) throws IOException;
+
+    /**
      * Provides the contents of the request object as input stream.
      *
      * @param objectKey the id of the object

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -484,7 +484,7 @@ public abstract class ObjectStorageSpace {
     /**
      * Determines if the requested object exists.
      *
-     * @param objectKey the id of the object
+     * @param objectKey the ID of the object
      * @return <tt>true</tt> if the object exists, <tt>false</tt> otherwise
      * @throws IOException in case of an IO error
      */

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
@@ -100,6 +100,11 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
     }
 
     @Override
+    public boolean exists(String objectKey) throws IOException {
+        return store.getClient().doesObjectExist(bucketName().getName(), objectKey);
+    }
+
+    @Override
     protected void storePhysicalObject(String objectKey, InputStream data, long size) throws IOException {
         if (size > 0) {
             store.upload(bucketName(), objectKey, data, size);

--- a/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.storage.util;
 
-import com.rometools.utils.Strings;
 import sirius.biz.jobs.StandardCategories;
 import sirius.biz.jobs.batch.file.ArchiveExportJob;
 import sirius.biz.jobs.params.BooleanParameter;
@@ -27,6 +26,7 @@ import sirius.db.mixing.BaseEntity;
 import sirius.kernel.async.ParallelTaskExecutor;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.CSVWriter;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.nls.NLS;
 

--- a/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
@@ -1,0 +1,130 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.util;
+
+import sirius.biz.jobs.StandardCategories;
+import sirius.biz.jobs.batch.file.ArchiveExportJob;
+import sirius.biz.jobs.params.Parameter;
+import sirius.biz.jobs.params.SelectStringParameter;
+import sirius.biz.process.PersistencePeriod;
+import sirius.biz.process.ProcessContext;
+import sirius.biz.storage.layer1.ObjectStorage;
+import sirius.biz.storage.layer1.ObjectStorageSpace;
+import sirius.kernel.commons.CSVWriter;
+import sirius.kernel.di.std.Part;
+
+import javax.annotation.Nullable;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * This job is used to verify the actual existence of physical IDs of blobs for the selected {@linkplain ObjectStorageSpace storage space}.
+ */
+public abstract class MissingBlobObjectCheckJob extends ArchiveExportJob {
+
+    @Part
+    private static ObjectStorage objectStorage;
+
+    /**
+     * The parameter name which specifies the storage space to be checked.
+     */
+    public static final String STORAGE_SPACE_PARAMETER = "space";
+
+    protected CSVWriter writer;
+    protected ObjectStorageSpace storageSpace;
+
+    /**
+     * Creates a new batch job for the given batch process.
+     * <p>
+     * As a batch job is created per execution, subclasses can define fields and fill those from parameters
+     * defined by their factory.
+     *
+     * @param process the context in which the process will be executed
+     */
+    protected MissingBlobObjectCheckJob(ProcessContext process) {
+        super(process);
+    }
+
+    @Override
+    protected String determineFilenameWithoutExtension() {
+        return getStorageSpaceName();
+    }
+
+    @Override
+    public void execute() throws Exception {
+        String spaceName = getStorageSpaceName();
+        storageSpace = objectStorage.getSpace(spaceName);
+        OutputStream outputStream = createEntry(spaceName + ".csv");
+        writer = new CSVWriter(new OutputStreamWriter(outputStream));
+        try {
+            writer.writeArray("id", "blobKey", "physicalObjectKey", "filename", "lastModified");
+        } finally {
+            writer.close();
+        }
+    }
+
+    private String getStorageSpaceName() {
+        return process.get(STORAGE_SPACE_PARAMETER).asString();
+    }
+
+    /**
+     * A factory which is used to create new instances of {@link MissingBlobObjectCheckJob}.
+     */
+    public abstract static class MissingBlobObjectCheckJobFactory extends ArchiveExportJob.ArchiveExportJobFactory {
+
+        @Part
+        private ObjectStorage objectStorage;
+
+        @Override
+        protected String createProcessTitle(Map<String, String> context) {
+            return getLabel() + ": " + context.get(MissingBlobObjectCheckJob.STORAGE_SPACE_PARAMETER);
+        }
+
+        @Override
+        protected PersistencePeriod getPersistencePeriod() {
+            return PersistencePeriod.ONE_YEAR;
+        }
+
+        @Override
+        protected void collectParameters(Consumer<Parameter<?>> parameterCollector) {
+            SelectStringParameter spaceParameter =
+                    new SelectStringParameter(MissingBlobObjectCheckJob.STORAGE_SPACE_PARAMETER,
+                                              "Storage Space").markRequired();
+            objectStorage.getSpaces()
+                         .stream()
+                         .map(ObjectStorageSpace::getName)
+                         .forEach(spaceName -> spaceParameter.withEntry(spaceName, spaceName));
+            parameterCollector.accept(spaceParameter.withDescription("Storage space to scan for missing objects.")
+                                                    .build());
+        }
+
+        @Override
+        protected void collectAcceptedFileExtensions(Consumer<String> fileExtensionConsumer) {
+            // not relevant
+        }
+
+        @Override
+        public String getCategory() {
+            return StandardCategories.SYSTEM_ADMINISTRATION;
+        }
+
+        @Override
+        public String getLabel() {
+            return "Missing storage space objects check";
+        }
+
+        @Nullable
+        @Override
+        public String getDescription() {
+            return "Checks if storage space objects associated to blobs are missing.";
+        }
+    }
+}

--- a/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
@@ -50,8 +50,19 @@ public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob<Mo
                                            .eq(MongoBlob.COMMITTED, true);
         if (Strings.isFilled(lastId)) {
             query.where(mango.filters().gt(MongoBlob.ID, lastId));
+        } else {
+            String startId = fetchStartId();
+            if (Strings.isFilled(startId)) {
+                // This is the first query, and we want to start from a specific ID
+                query.where(mango.filters().gte(MongoBlob.ID, startId));
+            }
         }
         return query.orderAsc(MongoBlob.ID).queryList();
+    }
+
+    @Override
+    protected String fetchStartId() {
+        return process.get(START_FROM_ID_PARAMETER).asString();
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
@@ -1,0 +1,55 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.util;
+
+import sirius.biz.process.ProcessContext;
+import sirius.biz.storage.layer2.mongo.MongoBlobStorage;
+import sirius.biz.tenants.TenantUserManager;
+import sirius.kernel.di.std.Framework;
+import sirius.kernel.di.std.Register;
+import sirius.web.security.Permission;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Implementation for the {@link MissingBlobObjectCheckJob} using the {@link MongoBlobStorage#FRAMEWORK_MONGO_BLOB_STORAGE}.
+ */
+public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob {
+    /**
+     * Creates a new batch job for the given batch process.
+     * <p>
+     * As a batch job is created per execution, subclasses can define fields and fill those from parameters
+     * defined by their factory.
+     *
+     * @param process the context in which the process will be executed
+     */
+    protected MissingMongoBlobObjectCheckJob(ProcessContext process) {
+        super(process);
+    }
+
+    /**
+     * Provides a factory to create instances of {@link MissingMongoBlobObjectCheckJob}.
+     */
+    @Register
+    @Framework(MongoBlobStorage.FRAMEWORK_MONGO_BLOB_STORAGE)
+    @Permission(TenantUserManager.PERMISSION_SYSTEM_ADMINISTRATOR)
+    public static class MissingMongoBlobObjectCheckJobFactory extends MissingBlobObjectCheckJobFactory {
+
+        @Override
+        protected MissingBlobObjectCheckJob createJob(ProcessContext process) {
+            return new MissingMongoBlobObjectCheckJob(process);
+        }
+
+        @Nonnull
+        @Override
+        public String getName() {
+            return "missing-mongo-blob-object-check";
+        }
+    }
+}

--- a/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
@@ -45,7 +45,7 @@ public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob<Mo
 
     @Override
     protected List<MongoBlob> fetchNextBlobBatch(String lastId) {
-        MongoQuery<MongoBlob> query = mango.select(MongoBlob.class)
+        MongoQuery<MongoBlob> query = mango.selectFromSecondary(MongoBlob.class)
                                            .eq(MongoBlob.SPACE_NAME, getStorageSpaceName())
                                            .eq(MongoBlob.DELETED, false)
                                            .eq(MongoBlob.COMMITTED, true);
@@ -63,7 +63,7 @@ public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob<Mo
 
     @Override
     protected List<MongoVariant> fetchVariants(MongoBlob blob) {
-        return mango.select(MongoVariant.class)
+        return mango.selectFromSecondary(MongoVariant.class)
                     .eq(MongoVariant.BLOB, blob.getId())
                     .eq(MongoVariant.QUEUED_FOR_CONVERSION, false)
                     .where(mango.filters().filled(MongoVariant.PHYSICAL_OBJECT_KEY))

--- a/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
@@ -13,6 +13,7 @@ import sirius.biz.storage.layer2.mongo.MongoBlob;
 import sirius.biz.storage.layer2.mongo.MongoBlobStorage;
 import sirius.biz.storage.layer2.mongo.MongoVariant;
 import sirius.biz.tenants.TenantUserManager;
+import sirius.db.mixing.query.BaseQuery;
 import sirius.db.mongo.Mango;
 import sirius.db.mongo.MongoQuery;
 import sirius.kernel.commons.Strings;
@@ -58,7 +59,7 @@ public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob<Mo
                 query.where(mango.filters().gte(MongoBlob.ID, startId));
             }
         }
-        return query.orderAsc(MongoBlob.ID).queryList();
+        return query.orderAsc(MongoBlob.ID).limit(BaseQuery.MAX_LIST_SIZE).queryList();
     }
 
     @Override
@@ -67,6 +68,7 @@ public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob<Mo
                     .eq(MongoVariant.BLOB, blob.getId())
                     .eq(MongoVariant.QUEUED_FOR_CONVERSION, false)
                     .where(mango.filters().filled(MongoVariant.PHYSICAL_OBJECT_KEY))
+                    .limit(BaseQuery.MAX_LIST_SIZE)
                     .queryList();
     }
 

--- a/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
@@ -11,6 +11,7 @@ package sirius.biz.storage.util;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.storage.layer2.mongo.MongoBlob;
 import sirius.biz.storage.layer2.mongo.MongoBlobStorage;
+import sirius.biz.storage.layer2.mongo.MongoVariant;
 import sirius.biz.tenants.TenantUserManager;
 import sirius.db.mongo.Mango;
 import sirius.db.mongo.MongoQuery;
@@ -25,7 +26,7 @@ import java.util.List;
 /**
  * Implementation for the {@link MissingBlobObjectCheckJob} using the {@link MongoBlobStorage#FRAMEWORK_MONGO_BLOB_STORAGE}.
  */
-public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob<MongoBlob, String> {
+public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob<MongoBlob, MongoVariant, String> {
 
     @Part
     private static Mango mango;
@@ -58,6 +59,15 @@ public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob<Mo
             }
         }
         return query.orderAsc(MongoBlob.ID).queryList();
+    }
+
+    @Override
+    protected List<MongoVariant> fetchVariants(MongoBlob blob) {
+        return mango.select(MongoVariant.class)
+                    .eq(MongoVariant.BLOB, blob.getId())
+                    .eq(MongoVariant.QUEUED_FOR_CONVERSION, false)
+                    .where(mango.filters().filled(MongoVariant.PHYSICAL_OBJECT_KEY))
+                    .queryList();
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
@@ -36,13 +36,12 @@ public class MissingMongoBlobObjectCheckJob extends MissingBlobObjectCheckJob {
     /**
      * Provides a factory to create instances of {@link MissingMongoBlobObjectCheckJob}.
      */
-    @Register
-    @Framework(MongoBlobStorage.FRAMEWORK_MONGO_BLOB_STORAGE)
+    @Register(framework = MongoBlobStorage.FRAMEWORK_MONGO_BLOB_STORAGE)
     @Permission(TenantUserManager.PERMISSION_SYSTEM_ADMINISTRATOR)
     public static class MissingMongoBlobObjectCheckJobFactory extends MissingBlobObjectCheckJobFactory {
 
         @Override
-        protected MissingBlobObjectCheckJob createJob(ProcessContext process) {
+        protected MissingMongoBlobObjectCheckJob createJob(ProcessContext process) {
             return new MissingMongoBlobObjectCheckJob(process);
         }
 

--- a/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
@@ -36,13 +36,12 @@ public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob {
     /**
      * Provides a factory to create instances of {@link MissingSqlBlobObjectCheckJob}.
      */
-    @Register
-    @Framework(SQLBlobStorage.FRAMEWORK_JDBC_BLOB_STORAGE)
+    @Register(framework = SQLBlobStorage.FRAMEWORK_JDBC_BLOB_STORAGE)
     @Permission(TenantUserManager.PERMISSION_SYSTEM_ADMINISTRATOR)
     public static class MissingMongoBlobObjectCheckJobFactory extends MissingBlobObjectCheckJobFactory {
 
         @Override
-        protected MissingBlobObjectCheckJob createJob(ProcessContext process) {
+        protected MissingSqlBlobObjectCheckJob createJob(ProcessContext process) {
             return new MissingSqlBlobObjectCheckJob(process);
         }
 

--- a/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
@@ -15,6 +15,7 @@ import sirius.biz.storage.layer2.jdbc.SQLVariant;
 import sirius.biz.tenants.TenantUserManager;
 import sirius.db.jdbc.OMA;
 import sirius.db.jdbc.SmartQuery;
+import sirius.db.mixing.query.BaseQuery;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
@@ -58,7 +59,7 @@ public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLB
                 query.where(oma.filters().gte(SQLBlob.ID, startId));
             }
         }
-        return query.orderAsc(SQLBlob.ID).queryList();
+        return query.orderAsc(SQLBlob.ID).limit(BaseQuery.MAX_LIST_SIZE).queryList();
     }
 
     @Override
@@ -67,6 +68,7 @@ public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLB
                   .eq(SQLVariant.SOURCE_BLOB, blob.getId())
                   .eq(SQLVariant.QUEUED_FOR_CONVERSION, false)
                   .where(oma.filters().filled(SQLBlob.PHYSICAL_OBJECT_KEY))
+                  .limit(BaseQuery.MAX_LIST_SIZE)
                   .queryList();
     }
 

--- a/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
@@ -50,8 +50,19 @@ public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLB
                                        .eq(SQLBlob.COMMITTED, true);
         if (Strings.isFilled(lastId)) {
             query.where(oma.filters().gt(SQLBlob.ID, lastId));
+        } else {
+            long startId = fetchStartId();
+            if (startId > 0L) {
+                // This is the first query, and we want to start from a specific ID
+                query.where(oma.filters().gte(SQLBlob.ID, startId));
+            }
         }
         return query.orderAsc(SQLBlob.ID).queryList();
+    }
+
+    @Override
+    protected Long fetchStartId() {
+        return process.get(START_FROM_ID_PARAMETER).asLong(0L);
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
@@ -11,6 +11,7 @@ package sirius.biz.storage.util;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.storage.layer2.jdbc.SQLBlob;
 import sirius.biz.storage.layer2.jdbc.SQLBlobStorage;
+import sirius.biz.storage.layer2.jdbc.SQLVariant;
 import sirius.biz.tenants.TenantUserManager;
 import sirius.db.jdbc.OMA;
 import sirius.db.jdbc.SmartQuery;
@@ -25,7 +26,7 @@ import java.util.List;
 /**
  * Implementation for the {@link MissingBlobObjectCheckJob} using the {@link SQLBlobStorage#FRAMEWORK_JDBC_BLOB_STORAGE}.
  */
-public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLBlob, Long> {
+public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLBlob, SQLVariant, Long> {
 
     @Part
     private static OMA oma;
@@ -58,6 +59,15 @@ public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLB
             }
         }
         return query.orderAsc(SQLBlob.ID).queryList();
+    }
+
+    @Override
+    protected List<SQLVariant> fetchVariants(SQLBlob blob) {
+        return oma.select(SQLVariant.class)
+                  .eq(SQLVariant.SOURCE_BLOB, blob.getId())
+                  .eq(SQLVariant.QUEUED_FOR_CONVERSION, false)
+                  .where(oma.filters().filled(SQLBlob.PHYSICAL_OBJECT_KEY))
+                  .queryList();
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
@@ -9,18 +9,27 @@
 package sirius.biz.storage.util;
 
 import sirius.biz.process.ProcessContext;
+import sirius.biz.storage.layer2.jdbc.SQLBlob;
 import sirius.biz.storage.layer2.jdbc.SQLBlobStorage;
 import sirius.biz.tenants.TenantUserManager;
-import sirius.kernel.di.std.Framework;
+import sirius.db.jdbc.OMA;
+import sirius.db.jdbc.SmartQuery;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.web.security.Permission;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Implementation for the {@link MissingBlobObjectCheckJob} using the {@link SQLBlobStorage#FRAMEWORK_JDBC_BLOB_STORAGE}.
  */
-public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob {
+public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLBlob, Long> {
+
+    @Part
+    private static OMA oma;
+
     /**
      * Creates a new batch job for the given batch process.
      * <p>
@@ -31,6 +40,18 @@ public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob {
      */
     protected MissingSqlBlobObjectCheckJob(ProcessContext process) {
         super(process);
+    }
+
+    @Override
+    protected List<SQLBlob> fetchNextBlobBatch(Long lastId) {
+        SmartQuery<SQLBlob> query = oma.select(SQLBlob.class)
+                                       .eq(SQLBlob.SPACE_NAME, getStorageSpaceName())
+                                       .eq(SQLBlob.DELETED, false)
+                                       .eq(SQLBlob.COMMITTED, true);
+        if (Strings.isFilled(lastId)) {
+            query.where(oma.filters().gt(SQLBlob.ID, lastId));
+        }
+        return query.orderAsc(SQLBlob.ID).queryList();
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
@@ -45,7 +45,7 @@ public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLB
 
     @Override
     protected List<SQLBlob> fetchNextBlobBatch(Long lastId) {
-        SmartQuery<SQLBlob> query = oma.select(SQLBlob.class)
+        SmartQuery<SQLBlob> query = oma.selectFromSecondary(SQLBlob.class)
                                        .eq(SQLBlob.SPACE_NAME, getStorageSpaceName())
                                        .eq(SQLBlob.DELETED, false)
                                        .eq(SQLBlob.COMMITTED, true);
@@ -63,7 +63,7 @@ public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob<SQLB
 
     @Override
     protected List<SQLVariant> fetchVariants(SQLBlob blob) {
-        return oma.select(SQLVariant.class)
+        return oma.selectFromSecondary(SQLVariant.class)
                   .eq(SQLVariant.SOURCE_BLOB, blob.getId())
                   .eq(SQLVariant.QUEUED_FOR_CONVERSION, false)
                   .where(oma.filters().filled(SQLBlob.PHYSICAL_OBJECT_KEY))

--- a/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
@@ -1,0 +1,55 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.util;
+
+import sirius.biz.process.ProcessContext;
+import sirius.biz.storage.layer2.jdbc.SQLBlobStorage;
+import sirius.biz.tenants.TenantUserManager;
+import sirius.kernel.di.std.Framework;
+import sirius.kernel.di.std.Register;
+import sirius.web.security.Permission;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Implementation for the {@link MissingBlobObjectCheckJob} using the {@link SQLBlobStorage#FRAMEWORK_JDBC_BLOB_STORAGE}.
+ */
+public class MissingSqlBlobObjectCheckJob extends MissingBlobObjectCheckJob {
+    /**
+     * Creates a new batch job for the given batch process.
+     * <p>
+     * As a batch job is created per execution, subclasses can define fields and fill those from parameters
+     * defined by their factory.
+     *
+     * @param process the context in which the process will be executed
+     */
+    protected MissingSqlBlobObjectCheckJob(ProcessContext process) {
+        super(process);
+    }
+
+    /**
+     * Provides a factory to create instances of {@link MissingSqlBlobObjectCheckJob}.
+     */
+    @Register
+    @Framework(SQLBlobStorage.FRAMEWORK_JDBC_BLOB_STORAGE)
+    @Permission(TenantUserManager.PERMISSION_SYSTEM_ADMINISTRATOR)
+    public static class MissingMongoBlobObjectCheckJobFactory extends MissingBlobObjectCheckJobFactory {
+
+        @Override
+        protected MissingBlobObjectCheckJob createJob(ProcessContext process) {
+            return new MissingSqlBlobObjectCheckJob(process);
+        }
+
+        @Nonnull
+        @Override
+        public String getName() {
+            return "missing-sql-blob-object-check";
+        }
+    }
+}

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -979,6 +979,9 @@ storage {
                 # This is empty as we stick with the default settings.
             }
         }
+
+        # Defines the number of parallel tasks used by the MissingBlobObjectCheckJob
+        missingBlobObjectCheckParallelTasks = 4
     }
 
     # Contains settings for the blob storage system.

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -979,9 +979,6 @@ storage {
                 # This is empty as we stick with the default settings.
             }
         }
-
-        # Defines the number of parallel tasks used by the MissingBlobObjectCheckJob
-        missingBlobObjectCheckParallelTasks = 4
     }
 
     # Contains settings for the blob storage system.


### PR DESCRIPTION
### Description

Over time, we have seen many blobs in the system pointing to non-existing physical objects. These could have been generated by previous bugs already fixed or still unknown ones.

Therefore as the first step we would like to list all blobs in such situation. This PR introduces an admin job responsible to scan that and attach a ZIP containing a CSV in the job itself (logging as process logs can potentially generate too many entries for large systems).

Later on, either this job will be enhanced to perform the actual clean-up or a new one which will parse the generated files.

#### Highlights
- compatible with Mongo and SQL Frameworks
- re-startable (although rudimentary)
- parallelism
- check variants
- check the replication space (if configured)

<img width="1027" alt="image" src="https://github.com/user-attachments/assets/b09eae30-81b7-47f7-b2cb-7f900e7afa2f" />

#### sample output for a blob and a variant
```csv
id;blobKey;physicalObjectKey;variant;filename;lastModified;foundInReplication
ANQTL7A67PODHMO7BFONJM811S;5VM60I2SL3FLF3PLBRJ8S0IKFK;3BCPJL4HNBS4EIEHU8SM0MJOD8;-;robot.jpg;2025-03-05 14:35:14;-
VH7SEQ1ROAHI4U58VQ8ND13CQG;5VM60I2SL3FLF3PLBRJ8S0IKFK;MF6ADMI9CKPVLFV6S4NPIEF4MK;user-large;-;2025-03-05 14:35:18;-
```

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-993](https://scireum.myjetbrains.com/youtrack/issue/SIRI-)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
