### PR TITLE
Missing objects check job: use local counters

### DIFF
--- a/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
@@ -130,6 +130,10 @@ public abstract class MissingBlobObjectCheckJob<B extends BaseEntity<I> & Blob, 
                 process.tryUpdateState(buildStatusMessage());
             }
 
+            if (counters.get(COUNTER_MISSING_BLOBS) > 0 || counters.get(COUNTER_MISSING_VARIANTS) > 0) {
+                process.log(ProcessLog.warn().withMessage("Detected missing objects."));
+            }
+
             process.forceUpdateState(buildStatusMessage());
             if (!TaskContext.get().isActive() && firstIdInBlock != null) {
                 process.log(ProcessLog.warn()

--- a/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
@@ -29,7 +29,9 @@ import sirius.kernel.commons.CSVWriter;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.nls.NLS;
+import sirius.web.http.QueryString;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -281,6 +283,17 @@ public abstract class MissingBlobObjectCheckJob<B extends BaseEntity<I> & Blob, 
         }
 
         @Override
+        protected void computePresetFor(@Nonnull QueryString queryString,
+                                        @Nullable Object targetObject,
+                                        Map<String, Object> preset) {
+            fillPresetFromUrl(STORAGE_SPACE_PARAMETER, queryString, preset);
+            fillPresetFromUrl(INCLUDE_REPLICATION_SPACE_PARAMETER, queryString, preset);
+            fillPresetFromUrl(PARALLEL_TASKS_PARAMETER, queryString, preset);
+            fillPresetFromUrl(START_FROM_ID_PARAMETER, queryString, preset);
+            fillPresetFromUrl(CHECK_VARIANTS_PARAMETER, queryString, preset);
+        }
+
+        @Override
         public String getCategory() {
             return StandardCategories.SYSTEM_ADMINISTRATION;
         }
@@ -294,6 +307,10 @@ public abstract class MissingBlobObjectCheckJob<B extends BaseEntity<I> & Blob, 
         @Override
         public String getDescription() {
             return "Checks if storage space objects associated to blobs are missing.";
+        }
+
+        private void fillPresetFromUrl(String parameter, @Nonnull QueryString queryString, Map<String, Object> preset) {
+            queryString.get(parameter).asOptionalString().ifPresent(value -> preset.put(parameter, value));
         }
     }
 }


### PR DESCRIPTION
### Description

We are hitting a problem using process counters as these are propagated via redis and with increased number of parallel tasks, they are updated way too often.

We use local counters instead and print the results as process state more gracefully.

Drive-by: preset URL fill and warning state.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-993](https://scireum.myjetbrains.com/youtrack/issue/SIRI-993)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
