### PR TITLE
Fixes handling and rendering of blobs which ultimately failed conversion

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -421,7 +421,18 @@ public class URLBuilder {
      * @see #safeBuildURL(String)
      */
     public String buildImageURL() {
-        return safeBuildURL(IMAGE_FALLBACK_URI);
+        try {
+            UrlResult urlResult = buildUrlResult();
+            if (urlResult.urlType() == UrlType.EMPTY) {
+                return createBaseURL().append(IMAGE_FALLBACK_URI).toString();
+            } else {
+                return urlResult.url();
+            }
+        } catch (HandledException exception) {
+            // A handled exception here means we've exceeded the maximum number of attempts to convert the variant.
+            Exceptions.ignore(exception);
+            return createBaseURL().append(IMAGE_FAILED_URI).toString();
+        }
     }
 
     /**

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -17,6 +17,8 @@ import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.HandledException;
 import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nullable;
@@ -355,11 +357,17 @@ public class URLBuilder {
      */
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public Optional<String> buildURL() {
-        UrlResult urlResult = buildUrlResult();
-        if (urlResult.urlType() == UrlType.EMPTY) {
+        try {
+            UrlResult urlResult = buildUrlResult();
+            if (urlResult.urlType() == UrlType.EMPTY) {
+                return Optional.empty();
+            } else {
+                return Optional.of(urlResult.url);
+            }
+        } catch (HandledException exception) {
+            // A handled exception here means we've exceeded the maximum number of attempts to convert the variant.
+            Exceptions.ignore(exception);
             return Optional.empty();
-        } else {
-            return Optional.of(urlResult.url);
         }
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -420,10 +420,16 @@ public class URLBuilder {
      * Determines if a conversion for the given variant is expected.
      *
      * @return <tt>true</tt> if a variant is selected, for which no physical key is present. <tt>false</tt> if there
-     * already exists a physical key for the given variant.
+     * already exists a physical key for the given variant or a conversion ultimately failed.
      */
     public boolean isConversionExpected() {
-        return isFilled() && !Strings.areEqual(variant, VARIANT_RAW) && Strings.isEmpty(determinePhysicalKey());
+        try {
+            return isFilled() && !Strings.areEqual(variant, VARIANT_RAW) && Strings.isEmpty(determinePhysicalKey());
+        } catch (HandledException exception) {
+            // A handled exception here means we've exceeded the maximum number of attempts to convert the variant.
+            Exceptions.ignore(exception);
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
### Description

A blob which a variant exhausted the conversion attempts were causing a rendering error in `t:blobImage`.

Now we properly deter this and display the "broken image" placeholder.

<img width="414" alt="image" src="https://github.com/user-attachments/assets/86491dcc-ff14-4208-96f9-422e6da637d8" />

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1090](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1090)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
