### PR TITLE
Adds a cell format for displaying lines of data (e.g. addresses).

### DIFF
--- a/src/main/java/sirius/biz/analytics/reports/Cells.java
+++ b/src/main/java/sirius/biz/analytics/reports/Cells.java
@@ -116,6 +116,18 @@ public class Cells {
     }
 
     /**
+     * Creates a cell which contains a list of lines.
+     *
+     * @param values the values to render
+     * @return a cell containing the given values
+     */
+    public Cell lines(List<String> values) {
+        return new Cell(Json.createObject()
+                            .put(KEY_TYPE, LinesCellFormat.TYPE)
+                            .set(LinesCellFormat.KEY_VALUES, Json.createArray(values)));
+    }
+
+    /**
      * Generates a green cell.
      *
      * @param value the value to output

--- a/src/main/java/sirius/biz/analytics/reports/LinesCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/LinesCellFormat.java
@@ -1,0 +1,52 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.analytics.reports;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import sirius.kernel.commons.Json;
+import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nonnull;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Provides a cell format which renders the content as a list of lines.
+ */
+@Register(classes = {LinesCellFormat.class, CellFormat.class})
+public class LinesCellFormat implements CellFormat {
+
+    protected static final String TYPE = "lines";
+    protected static final String KEY_VALUES = "values";
+
+    @Override
+    public String format(ObjectNode data) {
+        return format(data, "<br>");
+    }
+
+    @Override
+    public String rawValue(ObjectNode data) {
+        return format(data, ", ");
+    }
+
+    private String format(ObjectNode data, String delimiter) {
+        return Json.tryGetArray(data, KEY_VALUES)
+                   .map(Json::streamEntries)
+                   .orElseGet(Stream::empty)
+                   .map(JsonNode::asText)
+                   .collect(Collectors.joining(delimiter));
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return TYPE;
+    }
+}


### PR DESCRIPTION
### Description

Adds a simple cell format that we need in our case for addresses.

Example in a table with heading and test data:

![Bildschirmfoto 2025-03-20 um 12 14 25](https://github.com/user-attachments/assets/a1035c54-bc13-4ff6-83a8-1ff327a93148)

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14365](https://scireum.myjetbrains.com/youtrack/issue/SE-14365)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
