### PR TITLE
Cleanup of HeadRequestFileResolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     <url>https://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>dev-45.0.1</sirius.kernel>
-        <sirius.web>dev-90.0.0</sirius.web>
+        <sirius.kernel>dev-45.1.0</sirius.kernel>
+        <sirius.web>dev-90.0.2</sirius.web>
         <sirius.db>dev-62.0.0</sirius.db>
     </properties>
 

--- a/src/main/java/sirius/biz/storage/layer3/HeadRequestFileResolver.java
+++ b/src/main/java/sirius/biz/storage/layer3/HeadRequestFileResolver.java
@@ -77,6 +77,8 @@ public class HeadRequestFileResolver extends RemoteFileResolver {
                 return null;
             }
         } catch (HttpTimeoutException | URISyntaxException exception) {
+            // Exceptions are thrown if the server doesn't support HEAD requests, if the request times out or if the
+            // URI is malformed. In all cases we want to retry with a GET request.
             Exceptions.ignore(exception);
         }
 
@@ -179,6 +181,8 @@ public class HeadRequestFileResolver extends RemoteFileResolver {
                 return Tuple.create(file, false);
             }
         } catch (HttpTimeoutException | URISyntaxException exception) {
+            // Exceptions are thrown if the GET request fails or yields faulty data. We cannot do anything about it, so
+            // we just ignore it and return null, so that a lower-priority resolver can take over.
             Exceptions.ignore(exception);
         }
 

--- a/src/main/java/sirius/biz/storage/layer3/HeadRequestFileResolver.java
+++ b/src/main/java/sirius/biz/storage/layer3/HeadRequestFileResolver.java
@@ -107,13 +107,11 @@ public class HeadRequestFileResolver extends RemoteFileResolver {
         // we don't have a path yet, but we followed redirects, so we check the new URI
         if (Strings.isEmpty(path) && !uri.getPath().equals(lastConnectedURI.getPath())) {
             if (request.getResponseCode() == HttpResponseStatus.NOT_FOUND.code() && lastConnectedURI.toString()
-                                                                                                    .contains(
-                                                                                                                "Ã")) {
+                                                                                                    .contains("Ã")) {
                 // We followed a redirect header in UTF-8 that was interpreted as ISO-8859-1, indicated by 'Ã' in the url
                 // as the starting byte of two byte characters in UTF-8 will always be interpreted as 'Ã' in ISO-8859-1
-                lastConnectedURI =
-                        new URI(new String(lastConnectedURI.toString().getBytes(StandardCharsets.ISO_8859_1),
-                                           StandardCharsets.UTF_8));
+                lastConnectedURI = new URI(new String(lastConnectedURI.toString().getBytes(StandardCharsets.ISO_8859_1),
+                                                      StandardCharsets.UTF_8));
             }
 
             path = parsePathFromUri(lastConnectedURI, fileExtensionVerifier);


### PR DESCRIPTION
### Description

Refactors `HeadRequestFileResolver` such that:
- `Outcall` objects are created using a joint helper before specialisation
- `GET` requests also evaluate the last URL for a file name in case the `Content-Disposition` header is empty

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11816](https://scireum.myjetbrains.com/youtrack/issue/OX-11816)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
