### PR TITLE
KBA - Use correct object fit mode for preview images in articles

### DIFF
--- a/src/main/resources/default/taglib/k/previewImage.html.pasta
+++ b/src/main/resources/default/taglib/k/previewImage.html.pasta
@@ -13,7 +13,7 @@
             <div class="d-flex flex-grow-1 flex-row">
                 <a onclick="openImageOverlay('@url')">
                     <img src="@url"
-                         class="img-fluid cursor-pointer sci-preview-image sci-object-fit-contain card card-hover-shadow card-border"
+                         class="img-fluid cursor-pointer sci-kba-preview-image card card-hover-shadow card-border"
                          alt="Preview"/>
                 </a>
                 <div class="w-75 m-4 flex-column align-content-center">
@@ -37,9 +37,10 @@
 </script>
 
 <style>
-    .sci-preview-image {
+    .sci-kba-preview-image {
         height: 110px;
         width: 200px;
+        object-fit: contain;
     }
 
     .sci-kba-image-overlay img {


### PR DESCRIPTION
### Description

The previous solution did not work as expected, as sirius CSS is not loaded in the backend (at least not on pages without an OXOMI integration), so `sci-object-fit-contain` had no effect.

**Before:**

![grafik](https://github.com/user-attachments/assets/6bb49625-9147-4f56-8333-97317c57cd3e)

**After:**

![grafik](https://github.com/user-attachments/assets/0e301b24-ef88-4dd3-a72b-bd17c63e1ba6)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
