### PR TITLE
Jupiter - Disable sending redis client info to jupiter server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>dev-45.1.0</sirius.kernel>
         <sirius.web>dev-90.0.2</sirius.web>
-        <sirius.db>dev-62.0.0</sirius.db>
+        <sirius.db>dev-63.0.0</sirius.db>
     </properties>
 
     <repositories>

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1881,6 +1881,7 @@ redis {
         # runs on port 2410.
         jupiter {
             port = 2410
+            enableClientInfo = false
         }
     }
 }


### PR DESCRIPTION
### Description

This prevents a problem mentioned in scireum/sirius-db#679 where jupiter seems to struggle with the way jedis sets up the connection when client info is enabled.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-971](https://scireum.myjetbrains.com/youtrack/issue/SIRI-971)
- This PR is related to PR: https://github.com/scireum/sirius-db/pull/679

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
