### PR TITLE
Job Scheduler: Job Preselection

### DIFF
--- a/src/main/java/sirius/biz/jobs/Jobs.java
+++ b/src/main/java/sirius/biz/jobs/Jobs.java
@@ -21,6 +21,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -114,5 +116,39 @@ public class Jobs {
         }
 
         return (J) result;
+    }
+
+    /**
+     * Tries to resolve the job factory with the given name.
+     * <p>
+     * Note that this method does not check if the current user may invoke this job at all. {@linkplain
+     * Optional#filter(Predicate) Filter} the returned optional with
+     * {@link JobFactory#isAccessibleToCurrentUser()} if you need to check this.
+     *
+     * @param name the name of the job factory to resolve
+     * @return the job factory with the given name or an empty optional if no such factory exists
+     */
+    public Optional<JobFactory> tryFindFactory(String name) {
+        return tryFindFactory(name, JobFactory.class);
+    }
+
+    /**
+     * Tries to resolve the job factory with the given name and class.
+     * <p>
+     * Note that this method does not check if the current user may invoke this job at all. {@linkplain
+     * Optional#filter(Predicate) Filter} the returned optional with
+     * {@link JobFactory#isAccessibleToCurrentUser()} if you need to check this.
+     *
+     * @param name         the name of the job factory to resolve
+     * @param expectedType a type to cast the job factory to
+     * @param <J>          the generic value of <tt>expectedType</tt>
+     * @return the job factory with the given name or an empty optional if no such factory exists
+     */
+    public <J extends JobFactory> Optional<J> tryFindFactory(String name, Class<J> expectedType) {
+        try {
+            return Optional.ofNullable(findFactory(name, expectedType));
+        } catch (Exception _) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/resources/default/templates/biz/jobs/scheduler/entry.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/scheduler/entry.html.pasta
@@ -112,16 +112,19 @@
                          helpKey="SchedulerData.minute.help"
                          value="@entry.getSchedulerData().getMinute()"/>
         </div>
-        <t:heading labelKey="SchedulerController.parameters"/>
-        <div class="row">
-            <i:for type="sirius.biz.jobs.params.Parameter"
-                   var="param"
-                   items="entry.getJobConfigData().getJobFactory().getParameters()">
-                <i:dynamicInvoke template="@param.getTemplateName()"
-                                 param="@param"
-                                 context="@entry.getJobConfigData().asParameterContext()"/>
-            </i:for>
-        </div>
+
+        <i:if test="!entry.getJobConfigData().getJobFactory().getParameters().isEmpty()">
+            <t:heading labelKey="SchedulerController.parameters"/>
+            <div class="row">
+                <i:for type="sirius.biz.jobs.params.Parameter"
+                       var="param"
+                       items="entry.getJobConfigData().getJobFactory().getParameters()">
+                    <i:dynamicInvoke template="@param.getTemplateName()"
+                                     param="@param"
+                                     context="@entry.getJobConfigData().asParameterContext()"/>
+                </i:for>
+            </div>
+        </i:if>
 
         <t:formBar/>
     </t:editForm>


### PR DESCRIPTION
### Description

When creating a new job scheduler entry, a GET-parameter is now supported that preselects the job, like `/jobs/scheduler/entry/new?selectedJob=whatever-job-name`

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
