### PR TITLE
Update Docker containers to latest versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:7.4.2-alpine
+    image: redis:7.4.3-alpine
     ports:
       - "6379"
     hostname: redis

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:7.4.2-alpine
+    image: redis:7.4.3-alpine
     ports:
       - "6379"
     hostname: redis


### PR DESCRIPTION
### Description

- Redis: 7.4.2 -> 7.4.3
- ElasticSearch: via [Ticket](https://scireum.myjetbrains.com/youtrack/issue/DO-353)
- ClickHouse: via [Ticket](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1086)
- MariaDB: Ticket should be created for Upgrade to 11.7.2 if desired. Current LTS version is 11.4.x

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1077](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1077)

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Update Redis on production servers