### PR TITLE
add missing setExpires to manually canceled and not completed processes.

### DIFF
--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -319,7 +319,7 @@ class ProcessEnvironment implements ProcessContext {
 
     @Override
     public void markErroneous() {
-        processes.markErrorneous(processId);
+        processes.markErroneous(processId);
     }
 
     @Override

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -543,7 +543,7 @@ public class Processes {
      * @param processId the process to update
      * @return <tt>true</tt> if the process was successfully modified, <tt>false</tt> otherwise
      */
-    protected boolean markErrorneous(String processId) {
+    protected boolean markErroneous(String processId) {
         return modify(processId,
                       process -> !process.isErrorneous() && process.getState() == ProcessState.RUNNING,
                       process -> {
@@ -799,7 +799,7 @@ public class Processes {
     public void log(String processId, ProcessLog logEntry) {
         try {
             if (logEntry.getType() == ProcessLogType.ERROR) {
-                markErrorneous(processId);
+                markErroneous(processId);
             } else if (logEntry.getType() == ProcessLogType.WARNING) {
                 markWarnings(processId);
             }


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

rare use-case: a process is in the queue, then the system will be restarted. The process zombie than will be killed manually after restart and gets no expiry-date.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1104](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1104)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
