### PR TITLE
Adds constant for a broadly used code

### DIFF
--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -56,6 +56,11 @@ import java.util.stream.Stream;
  */
 public abstract class LookupTable {
 
+    /**
+     * Defines the code used to represent texts valid in all languages.
+     */
+    public static final String FALLBACK_LANGUAGE_CODE = "xx";
+
     private static final int MAX_SUGGESTIONS = 25;
     private static final String CONFIG_KEY_CODE_CASE_MODE = "codeCase";
     public static final String CONFIG_KEY_MAPPING_FIELD = "mappingsField";
@@ -620,10 +625,10 @@ public abstract class LookupTable {
                                    .stream()
                                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asText()));
             } else {
-                return Collections.singletonMap("xx", translations.asText());
+                return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, translations.asText());
             }
         }).orElseGet(() -> {
-            return Collections.singletonMap("xx", "");
+            return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, "");
         });
     }
 
@@ -643,7 +648,7 @@ public abstract class LookupTable {
             return Optional.of(result);
         }
 
-        return Optional.ofNullable(table.get("xx"));
+        return Optional.ofNullable(table.get(FALLBACK_LANGUAGE_CODE));
     }
 
     /**


### PR DESCRIPTION
### Description

We are seeing this `xx` code being used more and more over products, so lets us stop being lazy and set a constant for it. 🤓

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11991](https://scireum.myjetbrains.com/youtrack/issue/OX-11991)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
