### PR TITLE
Smart get the message type when logging them to the process log files

### DIFF
--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -581,7 +581,7 @@ class ProcessEnvironment implements ProcessContext {
                     lineLogged = true;
                     logCsvWriter.writeArray(LocalDateTime.now().format(formatter),
                                             logEntry.getType().name(),
-                                            logEntry.getMessageType(),
+                                            NLS.smartGet(logEntry.getMessageType()),
                                             logEntry.getMessage());
                 } catch (IOException exception) {
                     // Failure to create or write to the log file is not critical, so we ignore it.


### PR DESCRIPTION
### Description

As they can be provided as $SomeKeyName which are resolved from the translated resources (note that getMessage already compile the message which might come from a text or keys as well)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11992](https://scireum.myjetbrains.com/youtrack/issue/OX-11992)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
