### PR TITLE
t:blobImage - Implements additional attribute `alt` to be able to pass an alt text to the images

### DIFF
--- a/src/main/resources/default/taglib/t/blobImage.html.pasta
+++ b/src/main/resources/default/taglib/t/blobImage.html.pasta
@@ -5,6 +5,7 @@
        description="Determines the additional style to apply to the img object."/>
 <i:arg type="String" name="imgClass" default="" description="Contains additional classes to apply to the img."/>
 <i:arg type="String" name="class" default="" description="Contains additional classes to apply."/>
+<i:arg type="String" name="alt" default="" description="Contains the alt text for the image."/>
 <i:arg type="boolean" name="skipEmpty" default="false"
        description="If set to true, an empty blob will be skipped entirely, instead of rendering the fallback image."/>
 <i:arg type="String" name="fallbackUri" default="@sirius.biz.storage.layer2.URLBuilder.IMAGE_FALLBACK_URI"
@@ -21,12 +22,14 @@
         <i:if test="urlBuilder.isConversionExpected()">
             <img class="lazy-image-js @imgClass"
                  style="@imgStyle"
+                 @if (isFilled(alt)) { alt="@alt" }
                  src="@urlBuilder.createBaseURL().append(fallbackUri)"
                  data-src="@urlBuilder.buildImageURL()"
                  data-failed="@urlBuilder.createBaseURL().append(sirius.biz.storage.layer2.URLBuilder.IMAGE_FAILED_URI)"/>
             <i:else>
                 <img class="safe-image-js @imgClass"
                      style="@imgStyle"
+                     @if (isFilled(alt)) { alt="@alt" }
                      data-fallback="@urlBuilder.createBaseURL().append(fallbackUri)"
                      src="@urlBuilder.buildImageURL()"
                      data-failed="@urlBuilder.createBaseURL().append(sirius.biz.storage.layer2.URLBuilder.IMAGE_FAILED_URI)"/>


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12040](https://scireum.myjetbrains.com/youtrack/issue/OX-12040)
- This PR is related to PR: https://github.com/scireum/oxomi/pull/12297

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
