### PR TITLE
Logs erroneous parameter exceptions ´

### DIFF
--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -26,6 +26,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Priorized;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
+import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
 import sirius.web.controller.Message;
 import sirius.web.http.QueryString;
@@ -278,11 +279,35 @@ public abstract class BasicJobFactory implements JobFactory {
     public String startInBackground(Function<String, Value> parameterProvider) {
         enforceAccessibility();
         setupTaskContext();
-        Map<String, String> context = buildAndVerifyContext(parameterProvider, true, (param, error) -> {
-            throw error;
-        });
 
-        return executeInBackground(context);
+        return executeInBackground(buildAndVerifyContext(parameterProvider));
+    }
+
+    /**
+     * Builds and verifies the context for this job execution based on the given parameter provider.
+     *
+     * @param parameterProvider provides the values for the parameters of this job
+     * @return a map containing the parameter names as keys and the transformed values as values
+     * @throws HandledException if any provided parameter value is invalid or required but missing.
+     * @implNote exceptions are logged extra as they are most likely unlogged handled exceptions which would otherwise
+     * lead to silent failures of job presets and scheduled jobs .
+     */
+    private Map<String, String> buildAndVerifyContext(Function<String, Value> parameterProvider) {
+        return buildAndVerifyContext(parameterProvider, true, (parameter, handledException) -> {
+            Exceptions.handle().to(Log.BACKGROUND).withSystemErrorMessage("""
+                                                                                  Starting background job failed for erroneous parameter:
+                                                                                   - Tenant: %s
+                                                                                   - Job: %s
+                                                                                   - Parameter: %s
+                                                                                   - Message: %s
+                                                                                  """,
+                                                                          UserContext.getCurrentUser().getTenantId(),
+                                                                          getName(),
+                                                                          parameter.getName(),
+                                                                          handledException.getMessage()).handle();
+
+            throw handledException;
+        });
     }
 
     /**


### PR DESCRIPTION
### Description

...when executing job presets via file system uploads or scheduled job execution.

This most likely happens if a new and required parameter is added to a job and not all systems are properly checked for existing presets or scheduled entries.

Note, that the exception handler re-throwing the exception leads to it being caught in the inner #buildAndVerify method again which invokes the exception handler a second time. This results in the exception being logged twice, which however is better than adding a more complex exception handling to avoid a rare edge case exception simply being logged twice.

Also note, that #startInBackground happens very late. Thus we do not know if we come from a job preset or scheduled entry (the logged stack trace however will indicate that). Also, user errors in the backend UI will be checked way earlier which is good as we don't want to log when a user forgets a parameter.

This will create error log entries like this:

![screencapture-localhost-9000-system-error-FN0SF08JBUPEH6GUBGI3IUSD10-2025-06-26-14_34_09](https://github.com/user-attachments/assets/af0fcb5c-2f8c-4557-ab38-8e862fe0678c)

Which are also shown in the system protocol like this:

![Bildschirmfoto 2025-06-26 um 14 35 06](https://github.com/user-attachments/assets/e32a49a2-36ce-4728-ae15-34977da78aa2)



### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-148](https://scireum.myjetbrains.com/youtrack/issue/SIRI-148)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
