### PR TITLE
Only call conversion failed handlers after all attempts were made

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/README.md
+++ b/src/main/java/sirius/biz/storage/layer2/README.md
@@ -129,7 +129,8 @@ flowchart TD
     invokeConversionPipelineAsync --> awaitConversionResultAndRetryToFindVariant
     awaitConversionResultAndRetryToFindVariant -->|retries - 1| attemptToFindOrCreateVariant
     tryFetchVariant -->|variant still converting| awaitConversionResultAndRetryToFindVariant
-    tryFetchVariant -->|exhausted conversion attempts| error[/ERROR/]
+    tryFetchVariant -->|exhausted conversion attempts| failedConversionHandlers[Invoke instances of FailedVariantConversionHandler]
+    failedConversionHandlers --> error[/ERROR/]
     invokeConversionPipelineAsync --> startConversion[convert]
     startConversion -->|conversion successful| success(set key and duration)
     startConversion -->|conversion failed| failure[no key set]


### PR DESCRIPTION
### Description

The handlers were sometimes called prematurely after the first failed or timed out conversion. These should only be called after all attempts exhausted.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11942](https://scireum.myjetbrains.com/youtrack/issue/OX-11942)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
