### PR TITLE
Upgrades the ClickHouse container to 25.5.9.14

### DIFF
--- a/develop.conf
+++ b/develop.conf
@@ -17,7 +17,7 @@ jdbc {
         clickhouse {
             profile = "clickhouse"
             user = "default"
-            password = ""
+            password = "secret"
             database = "test"
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,17 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
     hostname: mariadb
+
   clickhouse:
-    image: clickhouse/clickhouse-server:24.5.1-alpine
+    image: clickhouse/clickhouse-server:25.5.9.14-alpine
     ports:
       - "8123"
       - "9000"
     hostname: clickhouse
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: secret
+
   elasticsearch:
     image: elasticsearch:8.18.3
     ports:

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -24,12 +24,17 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
     hostname: mariadb
+
   clickhouse:
-    image: clickhouse/clickhouse-server:24.5.1-alpine
+    image: clickhouse/clickhouse-server:25.5.9.14-alpine
     ports:
       - "8123"
       - "9000"
     hostname: clickhouse
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: secret
+
   elasticsearch:
     image: elasticsearch:8.18.3
     ports:

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -41,7 +41,7 @@ jdbc {
         clickhouse {
             profile = "clickhouse"
             user = "default"
-            password = ""
+            password = "secret"
             database = "test"
         }
     }


### PR DESCRIPTION
### Description

Starting in V25, auth is required. We now set a dummy password in both container and config file. Production servers SHOULD BE already running with authentication password.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1086](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1086)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
