### PR TITLE
Adds a new BeforeDeleteEvent scripting event

### DIFF
--- a/src/main/java/sirius/biz/importer/AfterCreateOrUpdateEvent.java
+++ b/src/main/java/sirius/biz/importer/AfterCreateOrUpdateEvent.java
@@ -50,6 +50,11 @@ public class AfterCreateOrUpdateEvent<E extends Entity> extends TypedScriptableE
                + ")";
     }
 
+    @Override
+    public void abort() {
+        throw new IllegalStateException(this + ": aborting is not supported since the entity has already been saved.");
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public Class<E> getType() {

--- a/src/main/java/sirius/biz/importer/BeforeCreateOrUpdateEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeCreateOrUpdateEvent.java
@@ -56,11 +56,6 @@ public class BeforeCreateOrUpdateEvent<E extends Entity> extends TypedScriptable
         return (Class<E>) entity.getClass();
     }
 
-    @Override
-    public void abort() {
-        throw new IllegalStateException(this + ": aborting is not supported since the entity has already been saved.");
-    }
-
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public ImporterContext getImporterContext() {
         return importerContext;

--- a/src/main/java/sirius/biz/importer/BeforeDeleteEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeDeleteEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.importer;
+
+import sirius.biz.scripting.TypedScriptableEvent;
+import sirius.db.mixing.Entity;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
+
+import java.util.function.Consumer;
+
+/**
+ * Triggered within {@link sirius.biz.importer.txn.ImportTransactionHelper#deleteUnmarked(Class, Consumer, Consumer)}
+ * before an entity is deleted.
+ *
+ * @param <E> the type of entity being deleted
+ */
+public class BeforeDeleteEvent<E extends Entity> extends TypedScriptableEvent<E> {
+    private final E entity;
+    private final ImporterContext importerContext;
+
+    /**
+     * Creates a new event for the given entity
+     *
+     * @param entity          the entity to update
+     * @param importerContext the import context which can be used to access other handlers / the importer itself
+     */
+    public BeforeDeleteEvent(E entity, ImporterContext importerContext) {
+        this.importerContext = importerContext;
+        this.entity = entity;
+    }
+
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
+    public E getEntity() {
+        return entity;
+    }
+
+    @Override
+    public String toString() {
+        return "BeforeDeleteEvent: "
+               + getType().getName()
+               + " with entity "
+               + entity
+               + "(ID: "
+               + entity.getIdAsString()
+               + ")";
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<E> getType() {
+        return (Class<E>) entity.getClass();
+    }
+
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
+    public ImporterContext getImporterContext() {
+        return importerContext;
+    }
+}

--- a/src/main/java/sirius/biz/importer/BeforeDeleteEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeDeleteEvent.java
@@ -27,7 +27,7 @@ public class BeforeDeleteEvent<E extends Entity> extends TypedScriptableEvent<E>
     /**
      * Creates a new event for the given entity
      *
-     * @param entity          the entity to update
+     * @param entity          the entity to delete
      * @param importerContext the import context which can be used to access other handlers / the importer itself
      */
     public BeforeDeleteEvent(E entity, ImporterContext importerContext) {


### PR DESCRIPTION
### Description

Allowing tenant scripts to process an entity prior to its deletion and take action over it. The event can be aborted which will in turn skip the entity deletion. 

**Drive-By**: makes the BeforeCreateOrUpdateEvent _"abortable"_

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12091](https://scireum.myjetbrains.com/youtrack/issue/OX-12091)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
