### PR TITLE
Invokes the BeforeLoadEvent in another load method

### DIFF
--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -127,6 +127,15 @@ public abstract class BaseImportHandler<E extends BaseEntity<?>> implements Impo
      * @return a newly created and not yet persisted entity with values loaded from <tt>data</tt>
      */
     protected E load(Context data, E entity, Mapping... mappings) {
+        if (context.getEventHandler().isActive()) {
+            BeforeLoadEvent<E> beforeLoadEvent = new BeforeLoadEvent<>(entity, data, context);
+            context.getEventHandler().handleEvent(beforeLoadEvent);
+            if (beforeLoadEvent.isAborted()) {
+                data.put(SCRIPT_ABORTED, true);
+                return null;
+            }
+        }
+
         Arrays.stream(mappings).forEach(mapping -> loadMapping(entity, mapping, data));
         enforcePostLoadConstraints(entity);
 

--- a/src/main/java/sirius/biz/importer/BeforeLoadEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeLoadEvent.java
@@ -10,15 +10,16 @@ package sirius.biz.importer;
 
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.Entity;
+import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Context;
 import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 /**
- * Triggered within {@link ImportHandler#load(Context, BaseEntity)} in order to update an entity
- * using the given context.
+ * Triggered within {@link ImportHandler#load(Context, BaseEntity)} and {@link BaseImportHandler#load(Context, BaseEntity, Mapping...)}
+ * in order to update an entity using the given context.
  * <p>
- * Note that this is triggered before actually loading the data into the entity. Therefore the context should
- * be modified by the entity shouldn't.
+ * Note that this is triggered before actually loading the data into the entity. Therefore, the context should
+ * be modified but the entity shouldn't.
  *
  * @param <E> the type of entity being updated
  */


### PR DESCRIPTION
### Description

This event was not consistently called across all load events. In this particular one, used to query an entity from the DB, changing a context's key via script field would not have any effect and the entity would be queried with the unmodified value.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12091](https://scireum.myjetbrains.com/youtrack/issue/OX-12091)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
