### PR TITLE
Improves handling of the ultimately failed conversion

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1545,7 +1545,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     }
 
     private void throwExhaustedConversionAttemptsException(String blobKey, String variantName) {
-        throw Exceptions.handle()
+        throw Exceptions.createHandled()
                         .to(StorageUtils.LOG)
                         .withSystemErrorMessage(
                                 "Layer2: Exhausted conversion attempts for variant '%s' and blobKey '%s'",

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1105,7 +1105,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             }
 
             return getPhysicalSpace().download(physicalKey.getFirst());
-        } catch (Exception exception) {
+        } catch (Exception _) {
             return Optional.empty();
         }
     }
@@ -1359,7 +1359,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
             }
         } catch (IllegalArgumentException exception) {
             response.notCached().error(HttpResponseStatus.BAD_REQUEST, exception.getMessage());
-        } catch (Exception exception) {
+        } catch (Exception _) {
             response.notCached().error(HttpResponseStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -1933,7 +1933,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
                                             Boolean.TRUE.equals(physicalKey.getSecond()) ? "cache" : "computed");
                          getPhysicalSpace().deliver(response, physicalKey.getFirst(), false);
                      }
-                 } catch (Exception exception) {
+                 } catch (Exception _) {
                      response.notCached().error(HttpResponseStatus.INTERNAL_SERVER_ERROR);
                  }
              });

--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
@@ -280,6 +280,11 @@ public class BlobDispatcher implements WebDispatcher {
             response.notCached();
         }
 
+        if (urlResult.urlType() == URLBuilder.UrlType.EMPTY) {
+            response.error(HttpResponseStatus.NOT_FOUND);
+            return;
+        }
+
         String filename = blobUri.getFilename();
 
         if (blobUri.isDownload()) {
@@ -319,6 +324,13 @@ public class BlobDispatcher implements WebDispatcher {
             urlBuilder.markAsLargeFile();
         }
 
-        return urlBuilder.buildUrlResult();
+        try {
+            return urlBuilder.buildUrlResult();
+        } catch (Exception exception) {
+            // Conversion ultimately failed. The error has already been logged during conversion, all we need is to
+            // return an empty result so that a 404 is returned to the caller.
+            Exceptions.ignore(exception);
+            return new URLBuilder.UrlResult(null, URLBuilder.UrlType.EMPTY);
+        }
     }
 }

--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
@@ -158,7 +158,7 @@ public class BlobDispatcher implements WebDispatcher {
             if (dispatcherHook != null) {
                 dispatcherHook.hook(payload);
             }
-        } catch (Exception exception) {
+        } catch (Exception _) {
             Exceptions.handle()
                       .to(StorageUtils.LOG)
                       .withSystemErrorMessage(

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -479,7 +479,19 @@ public class URLBuilder {
     private UrlResult createPhysicalDeliveryUrlResult() {
         StringBuilder result = createBaseURL();
 
-        String physicalKey = determinePhysicalKey();
+        String physicalKey = null;
+        try {
+            physicalKey = determinePhysicalKey();
+        } catch (Exception exception) {
+            // The conversion ultimately failed. Return the fallback URL if specified, otherwise an empty result.
+            Exceptions.ignore(exception);
+            if (Strings.isFilled(fallbackUri)) {
+                return new UrlResult(createBaseURL().append(fallbackUri).toString(), UrlType.FALLBACK);
+            } else {
+                return new UrlResult(null, UrlType.EMPTY);
+            }
+        }
+
         if (Strings.isEmpty(physicalKey)) {
             return new UrlResult(createVirtualDeliveryUrl(), UrlType.VIRTUAL);
         }

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -242,8 +242,8 @@ public class ConversionEngine {
                                               String message) {
         processContext.log(ProcessLog.error()
                                      .withNLSKey("ConversionEngine.conversionError")
-                                     .withContext("variantName", conversionProcess.getVariantName())
-                                     .withContext("filename", conversionProcess.getBlobToConvert().getFilename())
+                                     .withContext("variantName", NLS.quote(conversionProcess.getVariantName()))
+                                     .withContext("filename", NLS.quote(conversionProcess.getBlobToConvert().getFilename()))
                                      .withContext("message", message));
     }
 

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -209,7 +209,7 @@ public class ConversionEngine {
 
                 throw Exceptions.createHandled()
                                 .withSystemErrorMessage(Strings.apply(
-                                        "The conversion engine created an empty result for variant %s of %s (%s)",
+                                        "The conversion engine created an empty result for variant '%s' of '%s' (blobKey: %s)",
                                         conversionProcess.getVariantName(),
                                         conversionProcess.getBlobToConvert().getFilename(),
                                         conversionProcess.getBlobToConvert().getBlobKey()))


### PR DESCRIPTION
### Description

- Only invoke failed handlers when really converting. They were called also when just checking if a variant exists.
- Fixes an issue where every call to `throwExhaustedConversionAttemptsException` prematurely logged errors (most of them were already caught by the caller)
- Improves the URL builder to not fail when a file cannot be converted, but delivers the fallback or empty result instead
- Delivers a 404 when attempting to redirect a virtual URL to a physical which cannot be converted

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1036](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1036)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
