### PR TITLE
Fixes the broken image symbol and not necessary retries

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -382,27 +382,6 @@ public class URLBuilder {
         return buildUrlResult(null);
     }
 
-    private UrlResult buildUrlResult(String alternativeFailedUrl) {
-        if (Strings.isEmpty(blobKey) || (blob != null && Strings.isEmpty(blob.getPhysicalObjectKey()))) {
-            if (Strings.isFilled(fallbackUri)) {
-                return new UrlResult(createBaseURL().append(fallbackUri).toString(), UrlType.FALLBACK);
-            }
-            return new UrlResult(null, UrlType.EMPTY);
-        }
-
-        if (suppressCache) {
-            // Manual cache control is only supported in virtual calls, not physical...
-            return new UrlResult(createVirtualDeliveryUrl(), UrlType.VIRTUAL);
-        }
-        if (delayResolve && !isPhysicalKeyReadilyAvailable()) {
-            // The caller specifically requested, that we do not forcefully compute the physical URL (which might
-            // require a lookup), but to rather use the virtual URL...
-            return new UrlResult(createVirtualDeliveryUrl(), UrlType.VIRTUAL);
-        }
-
-        return createPhysicalDeliveryUrlResult(alternativeFailedUrl);
-    }
-
     /**
      * Builds the URL and permits to specify a custom fallback URI to deliver if no blob or blob-key is available.
      *
@@ -471,6 +450,27 @@ public class URLBuilder {
         // If the raw file is requested and the blob object is available, we can easily determine the effective
         // physical key to serve.
         return Strings.areEqual(variant, VARIANT_RAW) && blob != null;
+    }
+
+    private UrlResult buildUrlResult(String alternativeFailedUrl) {
+        if (Strings.isEmpty(blobKey) || (blob != null && Strings.isEmpty(blob.getPhysicalObjectKey()))) {
+            if (Strings.isFilled(fallbackUri)) {
+                return new UrlResult(createBaseURL().append(fallbackUri).toString(), UrlType.FALLBACK);
+            }
+            return new UrlResult(null, UrlType.EMPTY);
+        }
+
+        if (suppressCache) {
+            // Manual cache control is only supported in virtual calls, not physical...
+            return new UrlResult(createVirtualDeliveryUrl(), UrlType.VIRTUAL);
+        }
+        if (delayResolve && !isPhysicalKeyReadilyAvailable()) {
+            // The caller specifically requested, that we do not forcefully compute the physical URL (which might
+            // require a lookup), but to rather use the virtual URL...
+            return new UrlResult(createVirtualDeliveryUrl(), UrlType.VIRTUAL);
+        }
+
+        return createPhysicalDeliveryUrlResult(alternativeFailedUrl);
     }
 
     private UrlResult createPhysicalDeliveryUrlResult(String alternativeFailedUrl) {

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -452,7 +452,7 @@ public class URLBuilder {
         return Strings.areEqual(variant, VARIANT_RAW) && blob != null;
     }
 
-    private UrlResult buildUrlResult(String alternativeFailedUrl) {
+    private UrlResult buildUrlResult(String alternativeFailedUri) {
         if (Strings.isEmpty(blobKey) || (blob != null && Strings.isEmpty(blob.getPhysicalObjectKey()))) {
             if (Strings.isFilled(fallbackUri)) {
                 return new UrlResult(createBaseURL().append(fallbackUri).toString(), UrlType.FALLBACK);
@@ -470,10 +470,10 @@ public class URLBuilder {
             return new UrlResult(createVirtualDeliveryUrl(), UrlType.VIRTUAL);
         }
 
-        return createPhysicalDeliveryUrlResult(alternativeFailedUrl);
+        return createPhysicalDeliveryUrlResult(alternativeFailedUri);
     }
 
-    private UrlResult createPhysicalDeliveryUrlResult(String alternativeFailedUrl) {
+    private UrlResult createPhysicalDeliveryUrlResult(String alternativeFailedUri) {
         StringBuilder result = createBaseURL();
 
         String physicalKey = null;
@@ -482,8 +482,8 @@ public class URLBuilder {
         } catch (Exception exception) {
             // The conversion ultimately failed. Return the fallback URL if specified, otherwise an empty result.
             Exceptions.ignore(exception);
-            if (Strings.isFilled(alternativeFailedUrl)) {
-                return new UrlResult(createBaseURL().append(alternativeFailedUrl).toString(), UrlType.EMPTY);
+            if (Strings.isFilled(alternativeFailedUri)) {
+                return new UrlResult(createBaseURL().append(alternativeFailedUri).toString(), UrlType.EMPTY);
             } else if (Strings.isFilled(fallbackUri)) {
                 return new UrlResult(createBaseURL().append(fallbackUri).toString(), UrlType.FALLBACK);
             } else {

--- a/src/main/resources/default/assets/scripts/images.js
+++ b/src/main/resources/default/assets/scripts/images.js
@@ -18,7 +18,7 @@ function loadImageLazily(_img) {
         fetch(mainUrl).then(function (response) {
             if (response.ok) {
                 return response.blob()
-            } else if (response.status === 500) {
+            } else if (response.status === 404 || response.status === 500) {
                 _container.innerHTML = '';
                 _img.src = failed;
                 _container.appendChild(_img);


### PR DESCRIPTION
### Description

- Fixes an issue where lazily loaded images would not react to a 404 response and keep trying
- Restores the "broken image" symbol which was no longer shown since the related fix
<img width="480" height="426" alt="image" src="https://github.com/user-attachments/assets/aeeb1d89-0d64-4394-aca3-088b57906272" />

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1136](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1136)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/2169

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
