### PR TITLE
Changes response status when conversion finally failed

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1360,7 +1360,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
         } catch (IllegalArgumentException exception) {
             response.notCached().error(HttpResponseStatus.BAD_REQUEST, exception.getMessage());
         } catch (Exception _) {
-            response.notCached().error(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+            response.notCached().error(HttpResponseStatus.NOT_FOUND);
         }
     }
 
@@ -1934,7 +1934,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
                          getPhysicalSpace().deliver(response, physicalKey.getFirst(), false);
                      }
                  } catch (Exception _) {
-                     response.notCached().error(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                     response.notCached().error(HttpResponseStatus.NOT_FOUND);
                  }
              });
     }


### PR DESCRIPTION
### Description

The previous response (500 - Internal Server Error) is thrown internally by response.tunnel() when connection errors happen. *This code puts a conversion node in black list for 5 minutes.*

Failing to convert a variant does not mean the host is down, so we will return 404 not found as a more appropriate code in this case.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1136](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1136)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
