### PR TITLE
SE-14786 Allow setting the SSL protocol in the FTPS uplink

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
@@ -12,6 +12,7 @@ import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPSClient;
 import sirius.biz.storage.util.StorageUtils;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.health.Exceptions;
 
@@ -25,14 +26,29 @@ import java.util.function.Function;
  */
 class FTPSUplinkConnectorConfig extends FTPUplinkConnectorConfig {
 
+    /**
+     * Specifies which SSL protocol to use.
+     *
+     * @see <a href="https://docs.oracle.com/en/java/javase/24/docs/specs/security/standard-names.html#sslcontext-algorithms">list of possible values</a>
+     */
+    public static final String CONFIG_SSL_PROTOCOL = "sslProtocol";
+
+    private final String sslProtocol;
+
     protected FTPSUplinkConnectorConfig(String id, Function<String, Value> config) {
         super(id, config);
+        this.sslProtocol = config.apply(CONFIG_SSL_PROTOCOL).asString();
     }
 
     @Override
     protected FTPClient create() {
         try {
             FTPSClient client = new FTPSClient();
+
+            if (Strings.isFilled(sslProtocol)) {
+                client.setEnabledProtocols(new String[]{sslProtocol});
+            }
+
             client.setConnectTimeout(connectTimeoutMillis);
             client.setDataTimeout(Duration.ofMillis(readTimeoutMillis));
             client.setDefaultTimeout(readTimeoutMillis);

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
@@ -12,6 +12,7 @@ import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import sirius.biz.storage.layer3.uplink.util.UplinkConnectorConfig;
 import sirius.biz.storage.util.StorageUtils;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Value;
 import sirius.kernel.health.Exceptions;
 
@@ -46,6 +47,8 @@ class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {
     }
 
     @Override
+    @SuppressWarnings("java:S5332")
+    @Explain("A FTP uplink of course uses insecure FTP, which is not an issue with this code.")
     protected FTPClient create() {
         try {
             FTPClient client = new FTPClient();

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1163,7 +1163,7 @@ storage {
 
             # Defines a file system uplink which mounts a CIFS share into the VFS
             # cifs {
-            #     # Contains the name of the virtual directory
+            #    # Contains the name of the virtual directory
             #    name = "MyShare"
             #    # Contains an optional short description of the mount point
             #    description = "Some words of caution"
@@ -1189,7 +1189,7 @@ storage {
 
             # Defines a file system uplink which mounts a remote SFTP server into the VFS
             # sftp {
-            #     # Contains the name of the virtual directory
+            #    # Contains the name of the virtual directory
             #    name = "MyShare"
             #
             #    # Contains an optional short description of the mount point
@@ -1239,10 +1239,10 @@ storage {
             #    # maxWaitMillis = 10000
             #
             # }
-            #
+
             # Defines a file system uplink which mounts a remote FTP server into the VFS
             # ftp {
-            #     # Contains the name of the virtual directory
+            #    # Contains the name of the virtual directory
             #    name = "MyShare"
             #    # Contains an optional short description of the mount point
             #    description = "Some words of caution"
@@ -1292,7 +1292,6 @@ storage {
             #    # Specifies the wait time in milliseconds. If the connection pool is exhaused, the is the maximal
             #    # duration we wait for a connection to become available. (Default is 10000 = 10s)
             #    # maxWaitMillis = 10000
-            #
             # }
 
             # Defines a file system uplink which mounts a remote FTP server with TLS/SSL into the VFS

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1294,6 +1294,65 @@ storage {
             #    # maxWaitMillis = 10000
             #
             # }
+
+            # Defines a file system uplink which mounts a remote FTP server with TLS/SSL into the VFS
+            # ftps {
+            #    # Contains the name of the virtual directory
+            #    name = "MyShare"
+            #    # Contains an optional short description of the mount point
+            #    description = "Some words of caution"
+            #
+            #    # Defines the type of the uplink
+            #    type = "ftps"
+            #
+            #    # Determines if the directory is mounted readonly (Default is false)
+            #    readonly = true
+            #
+            #    # Determines the host to connect to
+            #    host = "hostname"
+            #
+            #    # Determines the port to use (Default is 21)
+            #    port = 21
+            #
+            #    # Determines the uername used to login
+            #    user = "username"
+            #
+            #    # Determines the password used to authenticate
+            #    password = "secretPassword"
+            #
+            #    # Contains the base path to mount (Default is "/")
+            #    basePath = "/data/somewhere"
+            #
+            #    # Determines the encoding to use for the control connection (Default is UTF-8)
+            #    encoding = "UTF-8"
+            #
+            #    # Specifies the maximal number of idle connections kept in the pool (Default is 1)
+            #    # maxIdle = 1
+            #
+            #    # Specifies the maximal number of active connections (Default is 5)
+            #    # maxActive = 5
+            #
+            #    # Specifies the connect timeout in milliseconds (Default is 10000)
+            #    # connectTimeoutMillis = 10000
+            #
+            #    # Specifies the read / IO timeout in milliseconds (Default is 615000 = 10min 15s)
+            #    # Note that this should be higher than the idle timeout esp. for SFTP as otherwise
+            #    # the implementation gets royally confused...
+            #    # readTimeoutMillis = 615000
+            #
+            #    # Specifies the idle timeout in milliseconds. This is the maximal duration for with an unused
+            #    # connection is kept open. (Default is 600_000 = 600s = 10 min)
+            #    # idleTimeoutMillis = 600000
+            #
+            #    # Specifies the wait time in milliseconds. If the connection pool is exhaused, the is the maximal
+            #    # duration we wait for a connection to become available. (Default is 10000 = 10s)
+            #    # maxWaitMillis = 10000
+            #
+            #    # Specifies the SSL protocol to use. By default, we negotiate the most current supported version
+            #    # with the server. See https://docs.oracle.com/en/java/javase/24/docs/specs/security/standard-names.html#sslcontext-algorithms
+            #    # for supported values.
+            #    # sslProtocol = "TLSv1.2"
+            # }
         }
 
         downlink {


### PR DESCRIPTION
### Description
Some server implementations of TLS 1.3 are incompatible with Apache MINA. This allows specifying the protocol to use.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14786](https://scireum.myjetbrains.com/youtrack/issue/SE-14786)
- Maybe someday java is going to fix the not required by standard usage of user_canceled with ticket: https://bugs.openjdk.org/browse/JDK-8323517 
### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
