### PR TITLE
Introduces a method to jupiter LRU cache for better cache handling

### DIFF
--- a/src/main/java/sirius/biz/jupiter/LRUCache.java
+++ b/src/main/java/sirius/biz/jupiter/LRUCache.java
@@ -13,6 +13,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Values;
 import sirius.kernel.di.std.Part;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -112,10 +113,11 @@ public class LRUCache {
      *
      * @param key           the key used to perform the lookup
      * @param valueComputer the computer used to provide a value if none is in the cache
+     * @param secondaryKeys optional secondary keys to invalidate cache entries via {@link #removeBySecondary(String)}
      * @return the cached value or the newly computed value if none was in the cache. Note that this value might
      * be stale if its <tt>softTTL</tt> has been reached but not its <tt>hardTTL</tt>
      */
-    public String extendedGet(String key, Supplier<String> valueComputer) {
+    public String extendedGet(String key, Supplier<String> valueComputer, String... secondaryKeys) {
         CacheResult cacheResult = connection.query(() -> Strings.apply("LRU.XGET %s", cache), jupiter -> {
             jupiter.sendCommand(CMD_EXTENDED_GET, cache, key);
             Values reply = Values.of(jupiter.getObjectMultiBulkReply());
@@ -132,7 +134,11 @@ public class LRUCache {
                 Jupiter.LOG.FINE("LRU.EXTENDED_GET in %s for %s returned no value - computing now!", cache, key);
             }
             String value = valueComputer.get();
-            put(key, value);
+            if (secondaryKeys == null) {
+                put(key, value);
+            } else {
+                put(key, value, secondaryKeys);
+            }
 
             return value;
         }
@@ -147,13 +153,35 @@ public class LRUCache {
                 Jupiter.LOG.INFO("Dropping computation of %s in cache %s", key, cache);
             }).fork(() -> {
                 String value = valueComputer.get();
-                put(key, value);
+                if (secondaryKeys == null) {
+                    put(key, value);
+                } else {
+                    put(key, value, secondaryKeys);
+                }
             });
         } else if (Jupiter.LOG.isFINE()) {
             Jupiter.LOG.FINE("LRU.EXTENDED_GET in %s for %s returned a valid value!", cache, key);
         }
 
         return cacheResult.getValue();
+    }
+
+    /**
+     * Fetches or computes a value to be used.
+     * <p>
+     * However, in contrast to {@link #computeIfAbsent(String, Supplier)} this will deliver a stale result from the
+     * cache and use the <tt>valueComputer</tt> to asynchronically compute a new value for the cache.
+     * <p>
+     * For situations in which using a stale cache value is acceptable, this provides a super low latency solution
+     * to cache data.
+     *
+     * @param key           the key used to perform the lookup
+     * @param valueComputer the computer used to provide a value if none is in the cache
+     * @return the cached value or the newly computed value if none was in the cache. Note that this value might
+     * be stale if its <tt>softTTL</tt> has been reached but not its <tt>hardTTL</tt>
+     */
+    public String extendedGet(String key, Supplier<String> valueComputer) {
+        return extendedGet(key, valueComputer, (String[]) null);
     }
 
     /**

--- a/src/main/java/sirius/biz/jupiter/LRUCache.java
+++ b/src/main/java/sirius/biz/jupiter/LRUCache.java
@@ -169,7 +169,7 @@ public class LRUCache {
      * Fetches or computes a value to be used.
      * <p>
      * However, in contrast to {@link #computeIfAbsent(String, Supplier)} this will deliver a stale result from the
-     * cache and use the <tt>valueComputer</tt> to asynchronically compute a new value for the cache.
+     * cache and use the <tt>valueComputer</tt> to asynchronously compute a new value for the cache.
      * <p>
      * For situations in which using a stale cache value is acceptable, this provides a super low latency solution
      * to cache data.

--- a/src/main/java/sirius/biz/jupiter/LRUCache.java
+++ b/src/main/java/sirius/biz/jupiter/LRUCache.java
@@ -13,7 +13,6 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Values;
 import sirius.kernel.di.std.Part;
 
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Supplier;
 

--- a/src/main/java/sirius/biz/jupiter/LRUCache.java
+++ b/src/main/java/sirius/biz/jupiter/LRUCache.java
@@ -246,7 +246,7 @@ public class LRUCache {
      */
     public void flush() {
         connection.exec(() -> Strings.apply("LRU.FLUSH %s", cache), jupiter -> {
-            jupiter.sendCommand(CMD_FLUSH);
+            jupiter.sendCommand(CMD_FLUSH, cache);
             jupiter.getStatusCodeReply();
         });
     }

--- a/src/test/kotlin/sirius/biz/jupiter/JupiterTest.kt
+++ b/src/test/kotlin/sirius/biz/jupiter/JupiterTest.kt
@@ -40,6 +40,76 @@ class JupiterTest {
     }
 
     @Test
+    fun `LRU get returns empty optional for missing key`() {
+        val cache = jupiter.getDefault().lru("test")
+        assertFalse { cache.get("nonexistent-key").isPresent }
+    }
+
+    @Test
+    fun `LRU computeIfAbsent computes value when absent`() {
+        val cache = jupiter.getDefault().lru("test")
+        cache.remove("compute-key")
+        val result = cache.computeIfAbsent("compute-key") { "computed" }
+        assertEquals("computed", result)
+        assertEquals("computed", cache.get("compute-key").get())
+    }
+
+    @Test
+    fun `LRU computeIfAbsent returns cached value when present`() {
+        val cache = jupiter.getDefault().lru("test")
+        cache.put("compute-existing", "existing-value")
+        val result = cache.computeIfAbsent("compute-existing") { "new-value" }
+        assertEquals("existing-value", result)
+    }
+
+    @Test
+    fun `LRU put overwrites existing value`() {
+        val cache = jupiter.getDefault().lru("test")
+        cache.put("overwrite-key", "first")
+        assertEquals("first", cache.get("overwrite-key").get())
+        cache.put("overwrite-key", "second")
+        assertEquals("second", cache.get("overwrite-key").get())
+    }
+
+    @Test
+    fun `LRU put with secondary keys and removeBySecondary works`() {
+        val cache = jupiter.getDefault().lru("test")
+        cache.put("sec-key-1", "val1", "group-a")
+        cache.put("sec-key-2", "val2", "group-a")
+        assertEquals("val1", cache.get("sec-key-1").get())
+        assertEquals("val2", cache.get("sec-key-2").get())
+
+        cache.removeBySecondary("group-a")
+        assertFalse { cache.get("sec-key-1").isPresent }
+        assertFalse { cache.get("sec-key-2").isPresent }
+    }
+
+    @Test
+    fun `LRU flush removes all entries`() {
+        val cache = jupiter.getDefault().lru("test")
+        cache.put("flush-1", "a")
+        cache.put("flush-2", "b")
+        assertEquals("a", cache.get("flush-1").get())
+        assertEquals("b", cache.get("flush-2").get())
+
+        cache.flush()
+        assertFalse { cache.get("flush-1").isPresent }
+        assertFalse { cache.get("flush-2").isPresent }
+    }
+
+    @Test
+    fun `LRU extendedGet with secondary keys works`() {
+        val cache = jupiter.getDefault().lru("test")
+        cache.remove("ext-key")
+        val result = cache.extendedGet("ext-key", { "ext-value" }, "ext-secondary")
+        assertEquals("ext-value", result)
+        assertEquals("ext-value", cache.get("ext-key").get())
+
+        cache.removeBySecondary("ext-secondary")
+        assertFalse { cache.get("ext-key").isPresent }
+    }
+
+    @Test
     fun `IDB show_tables works`() {
         val list = jupiter.getDefault().idb().showTables()
         assertEquals(1, list.size)


### PR DESCRIPTION
### Description
The extendedGet method can use stale data for efficiency, but in the past did not support a secondaryKeys parameter for improved cache entry flushing. this functionality gets added here.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15043](https://scireum.myjetbrains.com/youtrack/issue/SE-15043)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
