### PR TITLE
Import Jobs - Add generic template download

### DIFF
--- a/src/main/java/sirius/biz/jobs/JobFactory.java
+++ b/src/main/java/sirius/biz/jobs/JobFactory.java
@@ -202,4 +202,14 @@ public interface JobFactory extends Named, Priorized {
      * @return a JsonNode that can be handled by the JavaScript
      */
     JsonNode computeRequiredParameterUpdates(Map<String, String> ctx);
+
+    /**
+     * Generates a download URL or Data-URI for a template file (e.g. for imports).
+     *
+     * @return the URL/Data-URI of the template or null if no template is available
+     */
+    @Nullable
+    default String generateTemplateUrl() {
+        return null;
+    }
 }

--- a/src/main/java/sirius/biz/jobs/JobFactory.java
+++ b/src/main/java/sirius/biz/jobs/JobFactory.java
@@ -213,11 +213,11 @@ public interface JobFactory extends Named, Priorized {
     }
 
     /**
-     * Generates a template file and writes it to the given output stream.
+     * Generates a template file and responds to the given web context.
      *
-     * @param outputStream the stream to write the template to
+     * @param webContext the web context to respond to
      */
-    default void generateTemplate(java.io.OutputStream outputStream) {
+    default void respondWithTemplate(WebContext webContext) {
         throw new UnsupportedOperationException("This job does not provide a template.");
     }
 }

--- a/src/main/java/sirius/biz/jobs/JobFactory.java
+++ b/src/main/java/sirius/biz/jobs/JobFactory.java
@@ -204,12 +204,20 @@ public interface JobFactory extends Named, Priorized {
     JsonNode computeRequiredParameterUpdates(Map<String, String> ctx);
 
     /**
-     * Generates a download URL or Data-URI for a template file (e.g. for imports).
+     * Determines if a template can be downloaded for this job.
      *
-     * @return the URL/Data-URI of the template or null if no template is available
+     * @return true if a template can be downloaded, false otherwise.
      */
-    @Nullable
-    default String generateTemplateUrl() {
-        return null;
+    default boolean canDownloadTemplate() {
+        return false;
+    }
+
+    /**
+     * Generates a template file and writes it to the given output stream.
+     *
+     * @param outputStream the stream to write the template to
+     */
+    default void generateTemplate(java.io.OutputStream outputStream) {
+        throw new UnsupportedOperationException("This job does not provide a template.");
     }
 }

--- a/src/main/java/sirius/biz/jobs/JobsController.java
+++ b/src/main/java/sirius/biz/jobs/JobsController.java
@@ -70,6 +70,27 @@ public class JobsController extends BizController {
     }
 
     /**
+     * Downloads the template for the given job.
+     *
+     * @param webContext the current request
+     * @param jobType    the name of the job to fetch the template for
+     */
+    @Routed("/job/:1/download-template")
+    @LoginRequired
+    public void downloadTemplate(WebContext webContext, String jobType) {
+        JobFactory job = jobs.findFactory(jobType, JobFactory.class);
+        if (job != null && job.canDownloadTemplate()) {
+            java.io.OutputStream out = webContext.respondWith()
+                                                 .download("template-" + jobType + ".csv")
+                                                 .outputStream(HttpResponseStatus.OK, null);
+
+            job.generateTemplate(out);
+        } else {
+            webContext.respondWith().direct(HttpResponseStatus.NOT_FOUND, "No template available");
+        }
+    }
+
+    /**
      * Launches the job with the given name.
      *
      * @param webContext the current request

--- a/src/main/java/sirius/biz/jobs/JobsController.java
+++ b/src/main/java/sirius/biz/jobs/JobsController.java
@@ -73,18 +73,14 @@ public class JobsController extends BizController {
      * Downloads the template for the given job.
      *
      * @param webContext the current request
-     * @param jobType    the name of the job to fetch the template for
+     * @param jobType    the name of the job to download the template for
      */
     @Routed("/job/:1/download-template")
     @LoginRequired
     public void downloadTemplate(WebContext webContext, String jobType) {
         JobFactory job = jobs.findFactory(jobType, JobFactory.class);
         if (job != null && job.canDownloadTemplate()) {
-            java.io.OutputStream out = webContext.respondWith()
-                                                 .download("template-" + jobType + ".csv")
-                                                 .outputStream(HttpResponseStatus.OK, null);
-
-            job.generateTemplate(out);
+            job.respondWithTemplate(webContext);
         } else {
             webContext.respondWith().direct(HttpResponseStatus.NOT_FOUND, "No template available");
         }

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
@@ -37,11 +37,21 @@ public abstract class DictionaryBasedImportJobFactory extends LineBasedImportJob
      */
     protected abstract ImportDictionary getDictionary();
 
+    /**
+     * Indicates whether a template download is supported for this job.
+     *
+     * @return true if a template can be downloaded, false otherwise
+     */
     @Override
     public boolean canDownloadTemplate() {
         return true;
     }
 
+    /**
+     * Responds with a template for this import job.
+     *
+     * @param webContext the web context for the response
+     */
     @Override
     public void respondWithTemplate(WebContext webContext) {
         try {

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.jobs.batch.file;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import sirius.biz.importer.format.FieldDefinition;
 import sirius.biz.importer.format.ImportDictionary;
 import sirius.biz.jobs.params.Parameter;
@@ -17,10 +16,8 @@ import sirius.kernel.commons.CSVWriter;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 
-import javax.annotation.Nullable;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.function.Consumer;
 
 /**
@@ -40,10 +37,13 @@ public abstract class DictionaryBasedImportJobFactory extends LineBasedImportJob
     protected abstract ImportDictionary getDictionary();
 
     @Override
-    @Nullable
-    public String generateTemplateUrl() {
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
-             OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+    public boolean canDownloadTemplate() {
+        return true;
+    }
+
+    @Override
+    public void generateTemplate(java.io.OutputStream outputStream) {
+        try (OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
              CSVWriter csvWriter = new CSVWriter(writer)) {
             csvWriter.writeUnicodeBOM();
             Object[] headers = getDictionary().getFields()
@@ -52,11 +52,8 @@ public abstract class DictionaryBasedImportJobFactory extends LineBasedImportJob
                                               .map(FieldDefinition::getLabel)
                                               .toArray();
             csvWriter.writeArray(headers);
-            writer.flush();
-            return "data:text/csv;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
         } catch (Exception exception) {
-            Exceptions.handle(Log.BACKGROUND, exception);
-            return null;
+            throw Exceptions.handle(Log.BACKGROUND, exception);
         }
     }
 

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
@@ -8,9 +8,19 @@
 
 package sirius.biz.jobs.batch.file;
 
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import sirius.biz.importer.format.FieldDefinition;
+import sirius.biz.importer.format.ImportDictionary;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
+import sirius.kernel.commons.CSVWriter;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.Log;
 
+import javax.annotation.Nullable;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.function.Consumer;
 
 /**
@@ -21,6 +31,34 @@ public abstract class DictionaryBasedImportJobFactory extends LineBasedImportJob
 
     @Override
     protected abstract DictionaryBasedImportJob createJob(ProcessContext process);
+
+    /**
+     * Creates the dictionary used by the import.
+     *
+     * @return the dictionary being used
+     */
+    protected abstract ImportDictionary getDictionary();
+
+    @Override
+    @Nullable
+    public String generateTemplateUrl() {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+             CSVWriter csvWriter = new CSVWriter(writer)) {
+            csvWriter.writeUnicodeBOM();
+            Object[] headers = getDictionary().getFields()
+                                              .stream()
+                                              .filter(field -> !field.isHidden())
+                                              .map(FieldDefinition::getLabel)
+                                              .toArray();
+            csvWriter.writeArray(headers);
+            writer.flush();
+            return "data:text/csv;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
+        } catch (Exception exception) {
+            Exceptions.handle(Log.BACKGROUND, exception);
+            return null;
+        }
+    }
 
     @Override
     protected void collectParameters(Consumer<Parameter<?>> parameterCollector) {

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
@@ -8,16 +8,17 @@
 
 package sirius.biz.jobs.batch.file;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.biz.importer.format.FieldDefinition;
 import sirius.biz.importer.format.ImportDictionary;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
-import sirius.kernel.commons.CSVWriter;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
+import sirius.web.data.ExcelExport;
+import sirius.web.http.WebContext;
 
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
 import java.util.function.Consumer;
 
 /**
@@ -42,16 +43,20 @@ public abstract class DictionaryBasedImportJobFactory extends LineBasedImportJob
     }
 
     @Override
-    public void generateTemplate(java.io.OutputStream outputStream) {
-        try (OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
-             CSVWriter csvWriter = new CSVWriter(writer)) {
-            csvWriter.writeUnicodeBOM();
+    public void respondWithTemplate(WebContext webContext) {
+        try {
+            OutputStream out = webContext.respondWith()
+                                         .download("template-" + getName() + ".xlsx")
+                                         .outputStream(HttpResponseStatus.OK, null);
+            ExcelExport export = ExcelExport.asStandardXLSX();
+
             Object[] headers = getDictionary().getFields()
                                               .stream()
                                               .filter(field -> !field.isHidden())
                                               .map(FieldDefinition::getLabel)
                                               .toArray();
-            csvWriter.writeArray(headers);
+            export.addArrayRow(headers);
+            export.writeToStream(out);
         } catch (Exception exception) {
             throw Exceptions.handle(Log.BACKGROUND, exception);
         }

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -21,6 +21,7 @@ import sirius.kernel.commons.CSVWriter;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
+
 import javax.annotation.Nullable;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -108,6 +108,26 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
     }
 
     @Override
+    public String generateTemplateUrl() {
+        try {
+            String headers = getDictionary().getFields().stream()
+                                            .filter(field -> !field.isHidden())
+                                            .map(sirius.biz.importer.format.FieldDefinition::getLabel)
+                                            .collect(java.util.stream.Collectors.joining(";"));
+
+            byte[] bom = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+            byte[] csvBytes = headers.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            byte[] fullContent = new byte[bom.length + csvBytes.length];
+            System.arraycopy(bom, 0, fullContent, 0, bom.length);
+            System.arraycopy(csvBytes, 0, fullContent, bom.length, csvBytes.length);
+            return "data:text/csv;base64," + java.util.Base64.getEncoder().encodeToString(fullContent);
+        } catch (Exception e) {
+            sirius.kernel.health.Exceptions.handle(sirius.kernel.health.Log.BACKGROUND, e);
+            return null;
+        }
+    }
+
+    @Override
     protected void collectParameters(Consumer<Parameter<?>> parameterCollector) {
         super.collectParameters(parameterCollector);
         parameterCollector.accept(createImportModeParameter());

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -8,24 +8,17 @@
 
 package sirius.biz.jobs.batch.file;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import sirius.biz.importer.ImportContext;
 import sirius.biz.importer.Importer;
-import sirius.biz.importer.format.FieldDefinition;
 import sirius.biz.importer.format.ImportDictionary;
 import sirius.biz.jobs.infos.JobInfoCollector;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
 import sirius.db.mixing.BaseEntity;
-import sirius.kernel.commons.CSVWriter;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 
-import javax.annotation.Nullable;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.function.Consumer;
 
 /**
@@ -112,26 +105,6 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
         super.collectJobInfos(collector);
         collector.addTranslatedCard("EntityImportJobFactory.automaticMappings");
         getDictionary().emitJobInfos(collector);
-    }
-
-    @Override
-    @Nullable
-    public String generateTemplateUrl() {
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
-             OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-             CSVWriter csvWriter = new CSVWriter(writer)) {
-            csvWriter.writeUnicodeBOM();
-            Object[] headers = getDictionary().getFields().stream()
-                                              .filter(field -> !field.isHidden())
-                                              .map(FieldDefinition::getLabel)
-                                              .toArray();
-            csvWriter.writeArray(headers);
-            writer.flush();
-            return "data:text/csv;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
-        } catch (Exception exception) {
-            Exceptions.handle(Log.BACKGROUND, exception);
-            return null;
-        }
     }
 
     @Override

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -18,7 +18,11 @@ import sirius.db.mixing.BaseEntity;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
-
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.stream.Collectors;
+import sirius.biz.importer.format.FieldDefinition;
 import java.util.function.Consumer;
 
 /**
@@ -108,21 +112,27 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
     }
 
     @Override
+    @Nullable
     public String generateTemplateUrl() {
         try {
+            // Collect all visible field labels from the dictionary and join them with a semicolon
             String headers = getDictionary().getFields().stream()
                                             .filter(field -> !field.isHidden())
-                                            .map(sirius.biz.importer.format.FieldDefinition::getLabel)
-                                            .collect(java.util.stream.Collectors.joining(";"));
+                                            .map(FieldDefinition::getLabel)
+                                            .collect(Collectors.joining(";"));
 
+            // Prepare the CSV content and add the UTF-8 Byte Order Mark (BOM) for Excel compatibility
             byte[] bom = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
-            byte[] csvBytes = headers.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            byte[] csvBytes = headers.getBytes(StandardCharsets.UTF_8);
             byte[] fullContent = new byte[bom.length + csvBytes.length];
+
             System.arraycopy(bom, 0, fullContent, 0, bom.length);
             System.arraycopy(csvBytes, 0, fullContent, bom.length, csvBytes.length);
-            return "data:text/csv;base64," + java.util.Base64.getEncoder().encodeToString(fullContent);
+
+            // Convert the combined byte array to a Base64 string and return it as a Data-URI
+            return "data:text/csv;base64," + Base64.getEncoder().encodeToString(fullContent);
         } catch (Exception e) {
-            sirius.kernel.health.Exceptions.handle(sirius.kernel.health.Log.BACKGROUND, e);
+            Exceptions.handle(Log.BACKGROUND, e);
             return null;
         }
     }

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.jobs.batch.file;
 
+import org.apache.commons.io.output.ByteArrayOutputStream;
 import sirius.biz.importer.ImportContext;
 import sirius.biz.importer.Importer;
 import sirius.biz.importer.format.ImportDictionary;
@@ -15,13 +16,14 @@ import sirius.biz.jobs.infos.JobInfoCollector;
 import sirius.biz.jobs.params.Parameter;
 import sirius.biz.process.ProcessContext;
 import sirius.db.mixing.BaseEntity;
+import sirius.kernel.commons.CSVWriter;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 import javax.annotation.Nullable;
+import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.stream.Collectors;
 import sirius.biz.importer.format.FieldDefinition;
 import java.util.function.Consumer;
 
@@ -114,23 +116,17 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
     @Override
     @Nullable
     public String generateTemplateUrl() {
-        try {
-            // Collect all visible field labels from the dictionary and join them with a semicolon
-            String headers = getDictionary().getFields().stream()
-                                            .filter(field -> !field.isHidden())
-                                            .map(FieldDefinition::getLabel)
-                                            .collect(Collectors.joining(";"));
-
-            // Prepare the CSV content and add the UTF-8 Byte Order Mark (BOM) for Excel compatibility
-            byte[] bom = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
-            byte[] csvBytes = headers.getBytes(StandardCharsets.UTF_8);
-            byte[] fullContent = new byte[bom.length + csvBytes.length];
-
-            System.arraycopy(bom, 0, fullContent, 0, bom.length);
-            System.arraycopy(csvBytes, 0, fullContent, bom.length, csvBytes.length);
-
-            // Convert the combined byte array to a Base64 string and return it as a Data-URI
-            return "data:text/csv;base64," + Base64.getEncoder().encodeToString(fullContent);
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+             CSVWriter csvWriter = new CSVWriter(writer)) {
+            csvWriter.writeUnicodeBOM();
+            Object[] headers = getDictionary().getFields().stream()
+                                              .filter(field -> !field.isHidden())
+                                              .map(FieldDefinition::getLabel)
+                                              .toArray();
+            csvWriter.writeArray(headers);
+            writer.flush();
+            return "data:text/csv;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
         } catch (Exception e) {
             Exceptions.handle(Log.BACKGROUND, e);
             return null;

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -11,6 +11,7 @@ package sirius.biz.jobs.batch.file;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import sirius.biz.importer.ImportContext;
 import sirius.biz.importer.Importer;
+import sirius.biz.importer.format.FieldDefinition;
 import sirius.biz.importer.format.ImportDictionary;
 import sirius.biz.jobs.infos.JobInfoCollector;
 import sirius.biz.jobs.params.Parameter;
@@ -24,7 +25,6 @@ import javax.annotation.Nullable;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import sirius.biz.importer.format.FieldDefinition;
 import java.util.function.Consumer;
 
 /**

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -61,6 +61,7 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
      *
      * @return the dictionary being used
      */
+    @Override
     protected ImportDictionary getDictionary() {
         try (Importer importer = new Importer("getDictionary")) {
             ImportDictionary dictionary = importer.getImportDictionary(getImportType());

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -127,8 +127,8 @@ public abstract class EntityImportJobFactory extends DictionaryBasedImportJobFac
             csvWriter.writeArray(headers);
             writer.flush();
             return "data:text/csv;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
-        } catch (Exception e) {
-            Exceptions.handle(Log.BACKGROUND, e);
+        } catch (Exception exception) {
+            Exceptions.handle(Log.BACKGROUND, exception);
             return null;
         }
     }

--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
@@ -91,6 +91,7 @@ public abstract class RelationalEntityImportJobFactory<E extends BaseEntity<?> &
      *
      * @return the dictionary being used
      */
+    @Override
     protected ImportDictionary getDictionary() {
         try (Importer importer = new Importer("getDictionary")) {
             ImportDictionary dictionary = importer.getImportDictionary(getImportType());

--- a/src/main/resources/biz_bg.properties
+++ b/src/main/resources/biz_bg.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Пропусната линия
 EntityImportJobFactory.automaticMappings = Заданията на колоните се определят автоматично въз основа на първия ред и имената на полетата (или алтернативни описания). Големи / малки букви и интервали се игнорират.
 EntityImportJobFactory.importMode = режим
 EntityImportJobFactory.importMode.help = Указва кои редове от файла са взети под внимание. Всички останали редове се пропускат.
+EntityImportJobFactory.downloadTemplate = Изтегляне на шаблон
 EntityImportSyncJobFactory.syncMode = режим
 EntityImportSyncJobFactory.syncMode.help = Моля, обърнете внимание, че режимът "Синхронизиране" изтрива елементи, които не са включени във файла за импортиране. Обърнете внимание на настройката <i> Изчистване </i> , за да укажете какви данни да се изчистят.
 EntityImportSyncJobFactory.syncSource = Източник

--- a/src/main/resources/biz_cs.properties
+++ b/src/main/resources/biz_cs.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Řádek přeskočen
 EntityImportJobFactory.automaticMappings = Přiřazení sloupců se automaticky určí na základě prvního řádku a názvů polí (nebo alternativních názvů). Velká / malá písmena a mezery jsou ignorovány.
 EntityImportJobFactory.importMode = Režim
 EntityImportJobFactory.importMode.help = Určuje, které řádky souboru budou brány v úvahu. Všechny ostatní řádky jsou přeskočeny.
+EntityImportJobFactory.downloadTemplate = Stáhnout šablonu
 EntityImportSyncJobFactory.syncMode = režimu
 EntityImportSyncJobFactory.syncMode.help = Vezměte prosím na vědomí, že režim "Synchronizovat" odstraní položky, které nejsou zahrnuty v importovaném souboru. Všimněte si nastavení <i> Purge </i> , abyste určili, která data se mají vymazat.
 EntityImportSyncJobFactory.syncSource = Zdroj

--- a/src/main/resources/biz_da.properties
+++ b/src/main/resources/biz_da.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Spring over linjen
 EntityImportJobFactory.automaticMappings = Kolonnetildelingerne bestemmes automatisk ud fra den første linje og feltnavne (eller alternative beskrivelser). Store og små bogstaver og mellemrum ignoreres.
 EntityImportJobFactory.importMode = mode
 EntityImportJobFactory.importMode.help = Angiver hvilke linjer i filen der tages i betragtning. Alle andre linjer springes over.
+EntityImportJobFactory.downloadTemplate = Download skabelon
 EntityImportSyncJobFactory.syncMode = mode
 EntityImportSyncJobFactory.syncMode.help = Bemærk venligst, at "Synkroniser"-tilstanden sletter elementer, der ikke er inkluderet i importfilen. Bemærk indstillingen <i> Rens </i> for at angive, hvilke data der skal renses.
 EntityImportSyncJobFactory.syncSource = Kilde

--- a/src/main/resources/biz_de.properties
+++ b/src/main/resources/biz_de.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Zeile übersprungen
 EntityImportJobFactory.automaticMappings = Die Spaltenzuordnungen werden automatisch anhand der ersten Zeile und der Feldnamen (bzw. alternativen Bezeichnungen) ermittelt. Hierbei werden Groß-/Kleinschreibung sowie Leerzeichen ignoriert.
 EntityImportJobFactory.importMode = Modus
 EntityImportJobFactory.importMode.help = Gibt an, welche Zeilen der Datei berücksichtigt werden. Alle anderen Zeilen werden übersprungen.
+EntityImportJobFactory.downloadTemplate = Vorlage herunterladen
 EntityImportSyncJobFactory.syncMode = Modus
 EntityImportSyncJobFactory.syncMode.help = Bitte beachten Sie, dass der Modus „Synchronisieren“ Elemente löscht, die nicht in der Importdatei enthalten sind. Beachten Sie die Einstellung <i> Bereinigen </i> , um anzugeben, welche Daten gelöscht werden sollen.
 EntityImportSyncJobFactory.syncSource = Quelle

--- a/src/main/resources/biz_en.properties
+++ b/src/main/resources/biz_en.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = line skipped
 EntityImportJobFactory.automaticMappings = The column assignments are determined automatically using the first line and the field names (or alternative descriptions). Upper/lower case and spaces are ignored.
 EntityImportJobFactory.importMode = Mode
 EntityImportJobFactory.importMode.help = Specifies which lines of the file are taken into account. All other lines are skipped.
+EntityImportJobFactory.downloadTemplate = Download template
 EntityImportSyncJobFactory.syncMode = mode
 EntityImportSyncJobFactory.syncMode.help = Please note that the "Synchronize" mode deletes items that are not included in the import file. Note the <i> Purge </i> setting to specify what data to purge.
 EntityImportSyncJobFactory.syncSource = Source

--- a/src/main/resources/biz_es.properties
+++ b/src/main/resources/biz_es.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Línea omitida
 EntityImportJobFactory.automaticMappings = Las asignaciones de columnas se determinan automáticamente en función de la primera línea y los nombres de los campos (o descripciones alternativas). Se ignoran las mayúsculas / minúsculas y los espacios.
 EntityImportJobFactory.importMode = modo
 EntityImportJobFactory.importMode.help = Especifica qué líneas del archivo se tienen en cuenta. Todas las demás líneas se omiten.
+EntityImportJobFactory.downloadTemplate = Descargar plantilla
 EntityImportSyncJobFactory.syncMode = modo
 EntityImportSyncJobFactory.syncMode.help = Tenga en cuenta que el modo "Sincronizar" elimina elementos que no están incluidos en el archivo de importación. Tenga en cuenta la configuración <i> Purgar </i> para especificar qué datos purgar.
 EntityImportSyncJobFactory.syncSource = Fuente

--- a/src/main/resources/biz_et.properties
+++ b/src/main/resources/biz_et.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = rida vahele jäetud
 EntityImportJobFactory.automaticMappings = Veergude määramine toimub automaatselt, kasutades esimest rida ja väljade nimesid (või alternatiivseid kirjeldusi). Suur-/väike- ja tühikuid ei võeta arvesse.
 EntityImportJobFactory.importMode = Režiim
 EntityImportJobFactory.importMode.help = Määrab, milliseid faili ridu võetakse arvesse. Kõik ülejäänud read jäetakse vahele.
+EntityImportJobFactory.downloadTemplate = Laadi mall alla
 EntityImportSyncJobFactory.syncMode = režiim
 EntityImportSyncJobFactory.syncMode.help = Pange tähele, et režiim "Sünkroniseeri" kustutab importfaili mittekuuluvad elemendid. Pange tähele seadet <i> Purge </i>, et määrata, milliseid andmeid puhastatakse.
 EntityImportSyncJobFactory.syncSource = Allikas

--- a/src/main/resources/biz_fi.properties
+++ b/src/main/resources/biz_fi.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Rivi ohitettu
 EntityImportJobFactory.automaticMappings = Sarakkeiden osoitukset määritetään automaattisesti ensimmäisen rivin ja kenttien nimien (tai vaihtoehtoisten nimitysten) perusteella. Isoja ja pieniä kirjaimia sekä välilyöntejä ei oteta huomioon.
 EntityImportJobFactory.importMode = Tila
 EntityImportJobFactory.importMode.help = Määrittää, mitkä tiedoston rivit otetaan huomioon. Kaikki muut rivit ohitetaan.
+EntityImportJobFactory.downloadTemplate = Lataa malli
 EntityImportSyncJobFactory.syncMode = Tila
 EntityImportSyncJobFactory.syncMode.help = Huomaa, että "Synkronoi"-tila poistaa kohteet, jotka eivät sisälly tuontitiedostoon. Huomaa <i> Purge </i> -asetus määrittääksesi tyhjennettävät tiedot.
 EntityImportSyncJobFactory.syncSource = Lähde

--- a/src/main/resources/biz_fr.properties
+++ b/src/main/resources/biz_fr.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = ligne sautée
 EntityImportJobFactory.automaticMappings = L'affectation des colonnes est déterminée automatiquement à l'aide de la première ligne et des noms des champs (ou des descriptions alternatives). Les majuscules, minuscules et espaces sont ignorés.
 EntityImportJobFactory.importMode = Mode
 EntityImportJobFactory.importMode.help = Précise quelles lignes du dossier sont prises en compte. Toutes les autres lignes sont sautées.
+EntityImportJobFactory.downloadTemplate = Télécharger le modèle
 EntityImportSyncJobFactory.syncMode = mode
 EntityImportSyncJobFactory.syncMode.help = Veuillez noter que le mode "Synchroniser" supprime les éléments qui ne sont pas inclus dans le fichier d'importation. Notez le paramètre <i> Purge </i> pour spécifier les données à purger.
 EntityImportSyncJobFactory.syncSource = Source

--- a/src/main/resources/biz_hr.properties
+++ b/src/main/resources/biz_hr.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Preskočeni red
 EntityImportJobFactory.automaticMappings = Dodjela stupaca se automatski određuje na temelju prvog retka i naziva polja (ili alternativnih oznaka). Velika/mala slova i razmaci se zanemaruju.
 EntityImportJobFactory.importMode = način rada
 EntityImportJobFactory.importMode.help = Određuje koji se redovi u datoteci uzimaju u obzir. Svi ostali redovi se preskaču.
+EntityImportJobFactory.downloadTemplate = Preuzmi predložak
 EntityImportSyncJobFactory.syncMode = način rada
 EntityImportSyncJobFactory.syncMode.help = Imajte na umu da način rada "Sinkroniziraj" briše stavke koje nisu uključene u datoteku za uvoz. Obratite pozornost na postavku <i> Čišćenje </i> kako biste odredili koje podatke želite obrisati.
 EntityImportSyncJobFactory.syncSource = Izvor

--- a/src/main/resources/biz_hu.properties
+++ b/src/main/resources/biz_hu.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Átugrott vonal
 EntityImportJobFactory.automaticMappings = Az oszlopkiosztásokat az első sor és a mezők neve (vagy alternatív leírás) alapján automatikusan meghatározzuk. A nagy / kisbetűket és a szóközöket figyelmen kívül hagyja.
 EntityImportJobFactory.importMode = mód
 EntityImportJobFactory.importMode.help = Megadja, hogy a fájl mely sorait veszik figyelembe. Az összes többi sort kihagyja.
+EntityImportJobFactory.downloadTemplate = Sablon letöltése
 EntityImportSyncJobFactory.syncMode = mód
 EntityImportSyncJobFactory.syncMode.help = Kérjük, vegye figyelembe, hogy a "Szinkronizálás" mód törli azokat az elemeket, amelyek nem szerepelnek az importfájlban. Jegyezze fel a <i> Purge </i> beállítást annak meghatározásához, hogy milyen adatokat kell törölni.
 EntityImportSyncJobFactory.syncSource = Forrás

--- a/src/main/resources/biz_it.properties
+++ b/src/main/resources/biz_it.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = linea saltata
 EntityImportJobFactory.automaticMappings = Le assegnazioni delle colonne vengono determinate automaticamente utilizzando la prima riga e i nomi dei campi (o descrizioni alternative). Le maiuscole e gli spazi sono ignorati.
 EntityImportJobFactory.importMode = Modalità
 EntityImportJobFactory.importMode.help = Specifica quali linee del file vengono prese in considerazione. Tutte le altre linee sono saltate.
+EntityImportJobFactory.downloadTemplate = Scarica il modello
 EntityImportSyncJobFactory.syncMode = modalità
 EntityImportSyncJobFactory.syncMode.help = Si prega di notare che la modalità "Sincronizza" elimina gli elementi che non sono inclusi nel file di importazione. Nota l'impostazione <i> Elimina </i> per specificare i dati da eliminare.
 EntityImportSyncJobFactory.syncSource = Fonte

--- a/src/main/resources/biz_lt.properties
+++ b/src/main/resources/biz_lt.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Praleista eilutė
 EntityImportJobFactory.automaticMappings = Stulpelių priskyrimai nustatomi automatiškai, remiantis pirmąja eilute ir laukų pavadinimais (arba alternatyviais pavadinimais). Didžiosios / mažosios raidės ir tarpai nepaisomi.
 EntityImportJobFactory.importMode = režimu
 EntityImportJobFactory.importMode.help = Nurodo, į kurias failo eilutes atsižvelgiama. Visos kitos eilutės praleidžiamos.
+EntityImportJobFactory.downloadTemplate = Atsisiųsti šabloną
 EntityImportSyncJobFactory.syncMode = režimu
 EntityImportSyncJobFactory.syncMode.help = Atminkite, kad režimas „Sinchronizuoti“ ištrina elementus, kurie neįtraukti į importo failą. Atkreipkite dėmesį į nustatymą <i> Išvalyti </i> , kad nurodytumėte, kokius duomenis išvalyti.
 EntityImportSyncJobFactory.syncSource = Šaltinis

--- a/src/main/resources/biz_lv.properties
+++ b/src/main/resources/biz_lv.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Izlaista rinda
 EntityImportJobFactory.automaticMappings = Kolonnu piešķiršana tiek noteikta automātiski, pamatojoties uz pirmo rindiņu un lauku nosaukumiem (vai alternatīviem apzīmējumiem). Lielie/mazie burti un atstarpes tiek ignorēti.
 EntityImportJobFactory.importMode = režīmā
 EntityImportJobFactory.importMode.help = Norāda, kuras faila rindas tiek ņemtas vērā. Visas pārējās rindas tiek izlaistas.
+EntityImportJobFactory.downloadTemplate = Lejupielādēt veidni
 EntityImportSyncJobFactory.syncMode = režīmā
 EntityImportSyncJobFactory.syncMode.help = Lūdzu, ņemiet vērā, ka režīms "Sinhronizācija" izdzēš vienumus, kas nav iekļauti importēšanas failā. Ievērojiet iestatījumu <i> Iztīrīt </i> , lai norādītu, kādus datus tīrīt.
 EntityImportSyncJobFactory.syncSource = Avots

--- a/src/main/resources/biz_nl.properties
+++ b/src/main/resources/biz_nl.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = lijn overgeslagen
 EntityImportJobFactory.automaticMappings = De kolomtoewijzingen worden automatisch bepaald aan de hand van de eerste regel en de veldnamen (of alternatieve beschrijvingen). Boven/onderkast en spaties worden genegeerd.
 EntityImportJobFactory.importMode = Modus
 EntityImportJobFactory.importMode.help = Geeft aan welke regels van het bestand in aanmerking worden genomen. Alle andere lijnen worden overgeslagen.
+EntityImportJobFactory.downloadTemplate = Sjabloon downloaden
 EntityImportSyncJobFactory.syncMode = modus
 EntityImportSyncJobFactory.syncMode.help = Houd er rekening mee dat de modus "Synchroniseren" items verwijdert die niet in het importbestand zijn opgenomen. Let op de instelling <i> Opschonen </i> om aan te geven welke gegevens moeten worden opgeschoond.
 EntityImportSyncJobFactory.syncSource = Bron

--- a/src/main/resources/biz_no.properties
+++ b/src/main/resources/biz_no.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Hoppet over køen
 EntityImportJobFactory.automaticMappings = Kolonnetilordningene bestemmes automatisk basert på den første linjen og feltnavnene (eller alternative betegnelser). Store/små bokstaver og mellomrom ignoreres.
 EntityImportJobFactory.importMode = modus
 EntityImportJobFactory.importMode.help = Angir hvilke linjer i filen det tas hensyn til. Alle andre linjer hoppes over.
+EntityImportJobFactory.downloadTemplate = Last ned mal
 EntityImportSyncJobFactory.syncMode = modus
 EntityImportSyncJobFactory.syncMode.help = Vær oppmerksom på at "Synkroniser"-modus sletter elementer som ikke er inkludert i importfilen. Legg merke til <i> Tøm </i> -innstillingen for å spesifisere hvilke data som skal tømmes.
 EntityImportSyncJobFactory.syncSource = Kilde

--- a/src/main/resources/biz_pl.properties
+++ b/src/main/resources/biz_pl.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = pominięta linia
 EntityImportJobFactory.automaticMappings = Przypisania do kolumn są określane automatycznie za pomocą pierwszego wiersza i nazw pól (lub alternatywnych opisów). Górna/dolna skrzynka i miejsca są ignorowane.
 EntityImportJobFactory.importMode = Tryb
 EntityImportJobFactory.importMode.help = Określa, które wiersze pliku są brane pod uwagę. Wszystkie inne linie są pomijane.
+EntityImportJobFactory.downloadTemplate = Pobierz szablon
 EntityImportSyncJobFactory.syncMode = tryb
 EntityImportSyncJobFactory.syncMode.help = Należy pamiętać, że tryb „Synchronizuj” usuwa elementy, których nie ma w pliku importu. Zwróć uwagę na ustawienie <i> Usuń </i> , aby określić, które dane mają zostać usunięte.
 EntityImportSyncJobFactory.syncSource = Źródło

--- a/src/main/resources/biz_pt.properties
+++ b/src/main/resources/biz_pt.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Linha saltada
 EntityImportJobFactory.automaticMappings = As atribuições das colunas são determinadas automaticamente com base na primeira linha e nos nomes dos campos (ou designações alternativas). As caixas superior/inferior e os espaços são ignorados.
 EntityImportJobFactory.importMode = Modo
 EntityImportJobFactory.importMode.help = Especifica que linhas do ficheiro são tidas em conta. Todas as outras linhas são ignoradas.
+EntityImportJobFactory.downloadTemplate = Descarregar modelo
 EntityImportSyncJobFactory.syncMode = Modo
 EntityImportSyncJobFactory.syncMode.help = Observe que o modo "Sincronizar" exclui itens que não estão incluídos no arquivo de importação. Observe a configuração <i> Purgar </i> para especificar quais dados limpar.
 EntityImportSyncJobFactory.syncSource = Fonte

--- a/src/main/resources/biz_ro.properties
+++ b/src/main/resources/biz_ro.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Sare peste linie
 EntityImportJobFactory.automaticMappings = Alocările coloanelor sunt determinate automat pe baza primei linii și a numelor câmpurilor (sau a descrierilor alternative). Majusculele / minusculele și spațiile sunt ignorate.
 EntityImportJobFactory.importMode = modul
 EntityImportJobFactory.importMode.help = Specifică care linii ale fișierului sunt luate în considerare. Toate celelalte rânduri sunt omise.
+EntityImportJobFactory.downloadTemplate = Descărcați șablonul
 EntityImportSyncJobFactory.syncMode = modul
 EntityImportSyncJobFactory.syncMode.help = Vă rugăm să rețineți că modul „Sincronizare” șterge elementele care nu sunt incluse în fișierul de import. Rețineți setarea <i> Purge </i> pentru a specifica ce date să curățați.
 EntityImportSyncJobFactory.syncSource = Sursă

--- a/src/main/resources/biz_ru.properties
+++ b/src/main/resources/biz_ru.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Линия пропущена
 EntityImportJobFactory.automaticMappings = Назначения столбцов определяются автоматически на основе первой строки и имен полей (или альтернативных имен). Верхний / нижний регистр и пробелы игнорируются.
 EntityImportJobFactory.importMode = Режим
 EntityImportJobFactory.importMode.help = Определяет, какие строки файла принимаются во внимание. Все остальные строки пропущены.
+EntityImportJobFactory.downloadTemplate = Скачать шаблон
 EntityImportSyncJobFactory.syncMode = Режим
 EntityImportSyncJobFactory.syncMode.help = Обратите внимание, что в режиме «Синхронизация» удаляются элементы, не включенные в файл импорта. Обратите внимание на параметр <i> Очистить </i> , чтобы указать, какие данные следует очистить.
 EntityImportSyncJobFactory.syncSource = Источник

--- a/src/main/resources/biz_sk.properties
+++ b/src/main/resources/biz_sk.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Řádek přeskočen
 EntityImportJobFactory.automaticMappings = Přiřazení sloupců se automaticky určí na základě prvního řádku a názvů polí (nebo alternativních názvů). Velká / malá písmena a mezery jsou ignorovány.
 EntityImportJobFactory.importMode = Režim
 EntityImportJobFactory.importMode.help = Určuje, které řádky souboru budou brány v úvahu. Všechny ostatní řádky jsou přeskočeny.
+EntityImportJobFactory.downloadTemplate = Stiahnuť šablónu
 EntityImportSyncJobFactory.syncMode = režim
 EntityImportSyncJobFactory.syncMode.help = Upozorňujeme, že režim „Synchronizovať“ vymaže položky, ktoré nie sú zahrnuté v importovanom súbore. Všimnite si nastavenie <i> Vyčistiť </i> , aby ste určili, ktoré údaje sa majú vymazať.
 EntityImportSyncJobFactory.syncSource = Zdroj

--- a/src/main/resources/biz_sl.properties
+++ b/src/main/resources/biz_sl.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Preskočena vrstica
 EntityImportJobFactory.automaticMappings = Dodelitve stolpcev se določijo samodejno na podlagi prve vrstice in imen polj (ali alternativnih oznak). Velike / male črke in presledki so prezrti.
 EntityImportJobFactory.importMode = način
 EntityImportJobFactory.importMode.help = Določa, katere vrstice v datoteki se upoštevajo. Vse druge vrstice so preskočene.
+EntityImportJobFactory.downloadTemplate = Prenesi predlogo
 EntityImportSyncJobFactory.syncMode = način
 EntityImportSyncJobFactory.syncMode.help = Upoštevajte, da način "Sinhroniziraj" izbriše elemente, ki niso vključeni v uvozno datoteko. Upoštevajte nastavitev <i> Čiščenje </i> , da določite, katere podatke želite izbrisati.
 EntityImportSyncJobFactory.syncSource = Vir

--- a/src/main/resources/biz_sr.properties
+++ b/src/main/resources/biz_sr.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Preskočena linija
 EntityImportJobFactory.automaticMappings = Dodeljivanje kolona se automatski određuje na osnovu prvog reda i naziva polja (ili alternativnih oznaka). Velika/mala slova i razmaci se zanemaruju.
 EntityImportJobFactory.importMode = Režim
 EntityImportJobFactory.importMode.help = Određuje koji se redovi u datoteci uzimaju u obzir. Svi ostali redovi se preskaču.
+EntityImportJobFactory.downloadTemplate = Preuzmi šablon
 EntityImportSyncJobFactory.syncMode = Režim
 EntityImportSyncJobFactory.syncMode.help = Imajte na umu da režim „Sinhronizuj“ briše stavke koje nisu uključene u datoteku za uvoz. Obratite pažnju na postavku <i> Purge </i> da biste odredili koje podatke želite da očistite.
 EntityImportSyncJobFactory.syncSource = Izvor

--- a/src/main/resources/biz_sv.properties
+++ b/src/main/resources/biz_sv.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Hoppad linje
 EntityImportJobFactory.automaticMappings = Kolumntilldelningarna bestäms automatiskt baserat på den första raden och fältnamnen (eller alternativa beteckningar). Stora / små bokstäver och mellanslag ignoreras.
 EntityImportJobFactory.importMode = läge
 EntityImportJobFactory.importMode.help = Anger vilka rader i filen som beaktas. Alla andra rader hoppas över.
+EntityImportJobFactory.downloadTemplate = Ladda ner mall
 EntityImportSyncJobFactory.syncMode = läge
 EntityImportSyncJobFactory.syncMode.help = Observera att läget "Synkronisera" tar bort objekt som inte ingår i importfilen. Notera inställningen <i> Rensa </i> för att ange vilken data som ska rensas.
 EntityImportSyncJobFactory.syncSource = Källa

--- a/src/main/resources/biz_tr.properties
+++ b/src/main/resources/biz_tr.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = satır atlandı
 EntityImportJobFactory.automaticMappings = Sütun atamaları, ilk satır ve alan adları (veya alternatif açıklamalar) kullanılarak otomatik olarak belirlenir. Büyük/küçük harf ve boşluklar dikkate alınmaz.
 EntityImportJobFactory.importMode = mod
 EntityImportJobFactory.importMode.help = Dosyanın hangi satırlarının dikkate alınacağını belirtir. Diğer tüm satırlar atlanır.
+EntityImportJobFactory.downloadTemplate = Şablonu indir
 EntityImportSyncJobFactory.syncMode = mod
 EntityImportSyncJobFactory.syncMode.help = Lütfen "Senkronize Et" modunun içe aktarma dosyasına dahil olmayan öğeleri sildiğini unutmayın. Hangi verilerin temizleneceğini belirtmek için <i> Temizle </i> ayarına dikkat edin.
 EntityImportSyncJobFactory.syncSource = Kaynak

--- a/src/main/resources/biz_uk.properties
+++ b/src/main/resources/biz_uk.properties
@@ -313,6 +313,7 @@ EntityImportJob.rowIgnored = Пропущений рядок
 EntityImportJobFactory.automaticMappings = Призначення стовпців визначаються автоматично на основі першого рядка та назв полів (або альтернативних позначень). Верхній / нижній регістр і пробіли ігноруються.
 EntityImportJobFactory.importMode = режим
 EntityImportJobFactory.importMode.help = Вказує, які рядки у файлі будуть враховані. Усі інші рядки пропускаються.
+EntityImportJobFactory.downloadTemplate = Завантажити шаблон
 EntityImportSyncJobFactory.syncMode = режим
 EntityImportSyncJobFactory.syncMode.help = Зверніть увагу, що режим «Синхронізувати» видаляє елементи, які не включені до файлу імпорту. Зверніть увагу на налаштування <i> Очистити </i> , щоб вказати, які дані потрібно очистити.
 EntityImportSyncJobFactory.syncSource = Джерело

--- a/src/main/resources/default/templates/biz/jobs/infos.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos.html.pasta
@@ -9,13 +9,10 @@
             <a href="/job/@job.getName()">@job.getLabel()</a>
         </li>
     </i:block>
-
     <t:pageHeader title="@job.getLabel()">
         <i:block name="actions">
-            <i:local name="templateUrl" value="job.generateTemplateUrl()" />
-            <i:if test="isFilled(templateUrl)">
-                <i:local name="fileName" value="@apply('job-template-%s.csv', job.getName())" />
-                <a href="@templateUrl" download="@fileName" class="btn btn-primary">
+            <i:if test="job.canDownloadTemplate()">
+                <a href="/job/@job.getName()/download-template" class="btn btn-primary">
                     <i class="fa-solid fa-download"></i> @i18n("EntityImportJobFactory.downloadTemplate")
                 </a>
             </i:if>

--- a/src/main/resources/default/templates/biz/jobs/infos.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos.html.pasta
@@ -10,7 +10,15 @@
         </li>
     </i:block>
 
-    <t:pageHeader title="@job.getLabel()"/>
+    <t:pageHeader title="@job.getLabel()">
+        <i:block name="actions">
+            <i:if test="isFilled(job.generateTemplateUrl())">
+                <a href="@job.generateTemplateUrl()" download="import_template.csv" class="btn btn-primary">
+                    <i class="fa-solid fa-download"></i> @i18n("EntityImportJobFactory.downloadTemplate")
+                </a>
+            </i:if>
+        </i:block>
+    </t:pageHeader>
     <i:for type="sirius.biz.jobs.infos.JobInfo" var="info" items="job.getJobInfos()">
         <i:dynamicInvoke template="@info.getTemplateName()" job="job" info="info"/>
     </i:for>

--- a/src/main/resources/default/templates/biz/jobs/infos.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos.html.pasta
@@ -14,7 +14,7 @@
         <i:block name="actions">
             <i:local name="templateUrl" value="job.generateTemplateUrl()" />
             <i:if test="isFilled(templateUrl)">
-                <a href="@templateUrl" download="import_template.csv" class="btn btn-primary">
+                <a href="@templateUrl" download="@(job.getLabel()).csv" class="btn btn-primary">
                     <i class="fa-solid fa-download"></i> @i18n("EntityImportJobFactory.downloadTemplate")
                 </a>
             </i:if>

--- a/src/main/resources/default/templates/biz/jobs/infos.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos.html.pasta
@@ -14,7 +14,8 @@
         <i:block name="actions">
             <i:local name="templateUrl" value="job.generateTemplateUrl()" />
             <i:if test="isFilled(templateUrl)">
-                <a href="@templateUrl" download="@(job.getLabel()).csv" class="btn btn-primary">
+                <i:local name="fileName" value="@apply('job-template-%s.csv', job.getName())" />
+                <a href="@templateUrl" download="@fileName" class="btn btn-primary">
                     <i class="fa-solid fa-download"></i> @i18n("EntityImportJobFactory.downloadTemplate")
                 </a>
             </i:if>

--- a/src/main/resources/default/templates/biz/jobs/infos.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/infos.html.pasta
@@ -12,8 +12,9 @@
 
     <t:pageHeader title="@job.getLabel()">
         <i:block name="actions">
-            <i:if test="isFilled(job.generateTemplateUrl())">
-                <a href="@job.generateTemplateUrl()" download="import_template.csv" class="btn btn-primary">
+            <i:local name="templateUrl" value="job.generateTemplateUrl()" />
+            <i:if test="isFilled(templateUrl)">
+                <a href="@templateUrl" download="import_template.csv" class="btn btn-primary">
                     <i class="fa-solid fa-download"></i> @i18n("EntityImportJobFactory.downloadTemplate")
                 </a>
             </i:if>


### PR DESCRIPTION
### BREAKING CHANGE

What changed: Added protected abstract ImportDictionary getDictionary(); to DictionaryBasedImportJobFactory.

Why: To centralize the generateTemplateUrl logic in the base class and avoid code duplication for all dictionary-based import jobs.

How to fix: All extending classes must implement the new getDictionary() method. As those subclasses of DictionaryBasedImportJobFactory will create DictionaryBasedImportJob instances internally, which requires the creation of an ImportDictionary, the mechanism or method creating the ImportDictionary should be moved into the new getDictionary() or be called from there. 

### Description

Added a generic way to download template files for import jobs directly from the UI.

**UI Integration (Button):**
<img width="1920" height="1859" alt="Anwender-importieren-SIRIUS-04-23-2026_11_14_PM" src="https://github.com/user-attachments/assets/b1765f18-b981-45d3-9532-61babc78dcee" />


**CSV Output:**
<img width="1130" height="417" alt="Bildschirmfoto 2026-04-23 um 23 15 21" src="https://github.com/user-attachments/assets/141398ac-5a40-4295-8043-0aff65675b7d" />




### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1194](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1194/Import-Jobs-Template-Datei-herunterladbar-machen)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
