### PR TITLE
Migrate from AWS SDK V1 to V2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     hostname: es
 
   s3-system:
-    image: scireum/s3-ninja:8.6.0
+    image: scireum/s3-ninja:8.7.0
     ports:
       - "9000"
     hostname: s3ninja

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <sirius.kernel>50.1.0</sirius.kernel>
         <sirius.web>97.0.0</sirius.web>
         <sirius.db>66.0.0</sirius.db>
+        <aws.sdk>2.42.41</aws.sdk>
     </properties>
 
     <repositories>
@@ -113,19 +114,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.787</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${aws.sdk}</version>
         </dependency>
-        <!--
-         required by aws-java-sdk-s3, can't switch to jakarta.xml.bind-api as
-         aws sdk checks for the existence of javax.xml.bind.DatatypeConverter
-         https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/util/Base64.java#L42
-          -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3-transfer-manager</artifactId>
+            <version>${aws.sdk}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${aws.sdk}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <version>${aws.sdk}</version>
         </dependency>
 
         <!-- Changelog: https://commons.apache.org/proper/commons-net/changes-report.html -->

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
@@ -8,10 +8,6 @@
 
 package sirius.biz.storage.layer1;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.biz.storage.layer1.replication.ReplicationManager;
 import sirius.biz.storage.layer1.transformer.ByteBlockTransformer;
@@ -29,6 +25,13 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.settings.Extension;
 import sirius.web.http.Response;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -101,7 +104,17 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
 
     @Override
     public boolean exists(String objectKey) throws IOException {
-        return store.getClient().doesObjectExist(bucketName().getName(), objectKey);
+        try {
+            store.getClient()
+                 .headObject(HeadObjectRequest.builder().bucket(bucketName().getName()).key(objectKey).build());
+            return true;
+        } catch (S3Exception exception) {
+            if (exception.statusCode() == HttpResponseStatus.NOT_FOUND.code()) {
+                return false;
+            }
+
+            throw new IOException(exception);
+        }
     }
 
     @Override
@@ -229,25 +242,24 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
     @Nullable
     @Override
     protected InputStream getAsStream(String objectKey) throws IOException {
-        return getS3Object(objectKey).getObjectContent();
+        return getS3Object(objectKey);
     }
 
     @Nullable
     @Override
     protected InputStream getAsStream(String objectKey, ByteBlockTransformer transformer) throws IOException {
-        S3ObjectInputStream rawStream = getS3Object(objectKey).getObjectContent();
+        InputStream rawStream = getS3Object(objectKey);
         return new TransformingInputStream(rawStream, transformer);
     }
 
     @Override
     public void iterateObjects(Predicate<ObjectMetadata> objectHandler) throws IOException {
         store.listObjects(bucketName(), null, s3Object -> {
-            return objectHandler.test(new ObjectMetadata(s3Object.getKey(),
-                                                         s3Object.getLastModified()
-                                                                 .toInstant()
+            return objectHandler.test(new ObjectMetadata(s3Object.key(),
+                                                         s3Object.lastModified()
                                                                  .atZone(ZoneId.systemDefault())
                                                                  .toLocalDateTime(),
-                                                         s3Object.getSize()));
+                                                         s3Object.size()));
         });
     }
 
@@ -257,11 +269,18 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
         if (targetSpace instanceof S3ObjectStorageSpace s3ObjectStorageSpace && canCopyObject(s3ObjectStorageSpace)) {
             // We want to copy from S3 to S3 and the source and target buckets permits a server-side copy.
             store.getClient()
-                 .copyObject(bucketName().getName(),
-                             sourceObjectKey,
-                             s3ObjectStorageSpace.bucketName().getName(),
-                             targetObjectKey);
-            long size = store.getClient().getObjectMetadata(bucketName().getName(), sourceObjectKey).getContentLength();
+                 .copyObject(CopyObjectRequest.builder()
+                                              .sourceBucket(bucketName().getName())
+                                              .sourceKey(sourceObjectKey)
+                                              .destinationBucket(s3ObjectStorageSpace.bucketName().getName())
+                                              .destinationKey(targetObjectKey)
+                                              .build());
+            long size = store.getClient()
+                             .headObject(HeadObjectRequest.builder()
+                                                          .bucket(bucketName().getName())
+                                                          .key(sourceObjectKey)
+                                                          .build())
+                             .contentLength();
             replicationManager.notifyAboutUpdate(s3ObjectStorageSpace, targetObjectKey, size);
         } else {
             super.duplicatePhysicalObject(sourceObjectKey, targetObjectKey, targetStorageSpace);
@@ -283,12 +302,13 @@ public class S3ObjectStorageSpace extends ObjectStorageSpace {
         return !hasTransformer() && !s3ObjectStorageSpace.hasTransformer();
     }
 
-    private S3Object getS3Object(String objectKey) throws IOException {
+    private ResponseInputStream<GetObjectResponse> getS3Object(String objectKey) throws IOException {
         try {
-            return store.getClient().getObject(bucketName().getName(), objectKey);
-        } catch (AmazonClientException exception) {
-            if (exception instanceof AmazonS3Exception s3Exception
-                && s3Exception.getStatusCode() == HttpResponseStatus.NOT_FOUND.code()) {
+            return store.getClient().getObject(GetObjectRequest.builder().bucket(bucketName().getName()).key(objectKey)
+                            .build());
+        } catch (SdkException exception) {
+            if (exception instanceof S3Exception s3Exception
+                && s3Exception.statusCode() == HttpResponseStatus.NOT_FOUND.code()) {
                 throw new FileNotFoundException(Strings.apply("Layer 1: No object found for key '%s' in bucket '%s'",
                                                               objectKey,
                                                               bucketName()));

--- a/src/main/java/sirius/biz/storage/legacy/Storage.java
+++ b/src/main/java/sirius/biz/storage/legacy/Storage.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.storage.legacy;
 
-import com.amazonaws.internal.ResettableInputStream;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import sirius.biz.protocol.TraceData;
@@ -38,6 +37,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -405,7 +405,7 @@ public class Storage {
      */
     public void updateFile(@Nonnull StoredObject file, @Nonnull File data, @Nullable String filename) {
         try {
-            try (InputStream in = new ResettableInputStream(data)) {
+            try (InputStream in = new FileInputStream(data)) {
                 String md5 = calculateMd5(data);
                 updateFile(file, in, filename, md5, data.length());
             }

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -8,30 +8,6 @@
 
 package sirius.biz.storage.s3;
 
-import com.amazonaws.SdkClientException;
-import com.amazonaws.event.ProgressEvent;
-import com.amazonaws.event.ProgressEventType;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
-import com.amazonaws.services.s3.model.ListBucketsPaginatedRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PartETag;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.amazonaws.services.s3.model.UploadPartRequest;
-import com.amazonaws.services.s3.transfer.PersistableTransfer;
-import com.amazonaws.services.s3.transfer.TransferManager;
-import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
-import com.amazonaws.services.s3.transfer.Upload;
-import com.amazonaws.services.s3.transfer.internal.S3ProgressListener;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
@@ -49,6 +25,41 @@ import sirius.kernel.commons.Watch;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.FileUpload;
+import software.amazon.awssdk.transfer.s3.model.Upload;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
+import software.amazon.awssdk.transfer.s3.model.UploadRequest;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -62,7 +73,10 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 
 /**
@@ -99,8 +113,10 @@ public class ObjectStore {
 
     protected final ObjectStores stores;
     protected final String name;
-    protected final AmazonS3 client;
-    protected final TransferManager transferManager;
+    protected final S3Client client;
+    protected final S3AsyncClient asyncClient;
+    protected final S3TransferManager transferManager;
+    protected final S3Presigner presigner;
     protected final String bucketSuffix;
 
     @Part
@@ -109,42 +125,44 @@ public class ObjectStore {
     /**
      * Provides some bookkeeping and monitoring for S3 up- and downloads.
      */
-    private class MonitoringProgressListener implements S3ProgressListener {
+    private class MonitoringProgressListener implements TransferListener {
 
         private final Watch watch = Watch.start();
         private final boolean upload;
+        private long transferredBytes;
 
         MonitoringProgressListener(boolean upload) {
             this.upload = upload;
         }
 
         @Override
-        public void onPersistableTransfer(PersistableTransfer persistableTransfer) {
-            // NOOP
+        public void transferInitiated(Context.TransferInitiated context) {
+            watch.reset();
+            transferredBytes = 0;
         }
 
         @Override
-        public void progressChanged(ProgressEvent progressEvent) {
-            if (progressEvent.getEventType() == ProgressEventType.TRANSFER_STARTED_EVENT) {
-                watch.reset();
-            }
+        public void bytesTransferred(Context.BytesTransferred context) {
+            transferredBytes = context.progressSnapshot().transferredBytes();
+        }
 
-            if (progressEvent.getEventType() == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
-                if (upload) {
-                    stores.uploads.addValue(watch.elapsedMillis());
-                    stores.uploadedBytes.add(progressEvent.getBytesTransferred());
-                } else {
-                    stores.downloads.addValue(watch.elapsedMillis());
-                    stores.downloadedBytes.add(progressEvent.getBytesTransferred());
-                }
+        @Override
+        public void transferComplete(Context.TransferComplete context) {
+            if (upload) {
+                stores.uploads.addValue(watch.elapsedMillis());
+                stores.uploadedBytes.add(transferredBytes);
+            } else {
+                stores.downloads.addValue(watch.elapsedMillis());
+                stores.downloadedBytes.add(transferredBytes);
             }
+        }
 
-            if (progressEvent.getEventType() == ProgressEventType.TRANSFER_FAILED_EVENT) {
-                if (upload) {
-                    stores.failedUploads.inc();
-                } else {
-                    stores.failedDownloads.inc();
-                }
+        @Override
+        public void transferFailed(Context.TransferFailed context) {
+            if (upload) {
+                stores.failedUploads.inc();
+            } else {
+                stores.failedDownloads.inc();
             }
         }
     }
@@ -167,32 +185,39 @@ public class ObjectStore {
         }
 
         @Override
-        public void progressChanged(ProgressEvent progressEvent) {
-            super.progressChanged(progressEvent);
-            if (progressEvent.getEventType() == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
-                if (!promise.isCompleted()) {
-                    promise.success(FileHandle.temporaryFileHandle(file));
-                }
-            } else if (progressEvent.getEventType() == ProgressEventType.TRANSFER_FAILED_EVENT) {
-                Files.delete(file);
-                promise.fail(Exceptions.handle()
-                                       .to(ObjectStores.LOG)
-                                       .withSystemErrorMessage("An error occurred while trying to download: %s/%s",
-                                                               bucket,
-                                                               objectId)
-                                       .handle());
+        public void transferComplete(Context.TransferComplete context) {
+            super.transferComplete(context);
+            if (!promise.isCompleted()) {
+                promise.success(FileHandle.temporaryFileHandle(file));
             }
+        }
+
+        @Override
+        public void transferFailed(Context.TransferFailed context) {
+            super.transferFailed(context);
+            Files.delete(file);
+            promise.fail(Exceptions.handle()
+                                   .to(ObjectStores.LOG)
+                                   .withSystemErrorMessage("An error occurred while trying to download: %s/%s",
+                                                           bucket,
+                                                           objectId)
+                                   .handle());
         }
     }
 
-    protected ObjectStore(ObjectStores stores, String name, AmazonS3 client, String bucketSuffix) {
+    protected ObjectStore(ObjectStores stores,
+                          String name,
+                          S3Client client,
+                          S3AsyncClient asyncClient,
+                          S3Presigner presigner,
+                          String bucketSuffix) {
         this.stores = stores;
         this.name = name;
         this.client = client;
-        this.transferManager = TransferManagerBuilder.standard()
-                                                     .withExecutorFactory(() -> tasks.executorService(EXECUTOR_S3))
-                                                     .withS3Client(client)
-                                                     .build();
+        this.asyncClient = asyncClient;
+        this.presigner = presigner;
+        this.transferManager =
+                S3TransferManager.builder().executor(tasks.executorService(EXECUTOR_S3)).s3Client(asyncClient).build();
 
         if (Strings.isFilled(bucketSuffix) && bucketSuffix.contains(".") && !Files.isConsideredHidden(bucketSuffix)) {
             ObjectStores.LOG.WARN(
@@ -207,7 +232,7 @@ public class ObjectStore {
      *
      * @return the client used to talk to the S3 store
      */
-    public AmazonS3 getClient() {
+    public S3Client getClient() {
         return client;
     }
 
@@ -255,7 +280,7 @@ public class ObjectStore {
     public void ensureBucketExists(BucketName bucket) {
         if (!doesBucketExist(bucket)) {
             try {
-                client.createBucket(bucket.getName());
+                client.createBucket(CreateBucketRequest.builder().bucket(bucket.getName()).build());
             } catch (Exception exception) {
                 Exceptions.handle()
                           .to(ObjectStores.LOG)
@@ -292,11 +317,7 @@ public class ObjectStore {
      * @return a list of all buckets in the given store
      */
     public List<String> listBuckets() {
-        return getClient().listBuckets(new ListBucketsPaginatedRequest())
-                          .getBuckets()
-                          .stream()
-                          .map(Bucket::getName)
-                          .toList();
+        return getClient().listBuckets().buckets().stream().map(Bucket::name).toList();
     }
 
     /**
@@ -310,26 +331,28 @@ public class ObjectStore {
      * @param consumer the consumer to be supplied with each found object. As soon as <tt>false</tt> is returned,
      *                 the iteration stops.
      */
-    public void listObjects(BucketName bucket, @Nullable String prefix, Predicate<S3ObjectSummary> consumer) {
-        ObjectListing objectListing = null;
+    public void listObjects(BucketName bucket, @Nullable String prefix, Predicate<S3Object> consumer) {
+        ListObjectsV2Response objectListing;
+        String continuationToken = null;
         TaskContext taskContext = TaskContext.get();
 
         do {
             try (var _ = new Operation(() -> Strings.apply("S3: Fetching objects from %s (prefix: %s)",
                                                            bucket.getName(),
                                                            prefix), Duration.ofSeconds(10))) {
-                if (objectListing != null) {
-                    objectListing = getClient().listNextBatchOfObjects(objectListing);
-                } else {
-                    objectListing = getClient().listObjects(bucket.getName(), prefix);
-                }
+                objectListing = getClient().listObjectsV2(ListObjectsV2Request.builder()
+                                                                              .bucket(bucket.getName())
+                                                                              .prefix(prefix)
+                                                                              .continuationToken(continuationToken)
+                                                                              .build());
             }
 
-            for (S3ObjectSummary objectSummary : objectListing.getObjectSummaries()) {
+            for (S3Object objectSummary : objectListing.contents()) {
                 if (!consumer.test(objectSummary) || !taskContext.isActive()) {
                     return;
                 }
             }
+            continuationToken = objectListing.nextContinuationToken();
         } while (objectListing.isTruncated() && taskContext.isActive());
     }
 
@@ -342,7 +365,7 @@ public class ObjectStore {
     public void deleteObject(BucketName bucket, String objectId) {
         try (var _ = new Operation(() -> Strings.apply("S3: Deleting object %s from %s", objectId, bucket),
                                    Duration.ofMinutes(1))) {
-            getClient().deleteObject(bucket.getName(), objectId);
+            getClient().deleteObject(DeleteObjectRequest.builder().bucket(bucket.getName()).key(objectId).build());
         } catch (Exception exception) {
             throw Exceptions.handle()
                             .to(ObjectStores.LOG)
@@ -371,7 +394,12 @@ public class ObjectStore {
                                                        sourceObjectId,
                                                        targetBucket,
                                                        targetObjectId), Duration.ofMinutes(5))) {
-            getClient().copyObject(sourceBucket.getName(), sourceObjectId, targetBucket.getName(), targetObjectId);
+            getClient().copyObject(CopyObjectRequest.builder()
+                                                    .sourceBucket(sourceBucket.getName())
+                                                    .sourceKey(sourceObjectId)
+                                                    .destinationBucket(targetBucket.getName())
+                                                    .destinationKey(targetObjectId)
+                                                    .build());
         } catch (Exception exception) {
             throw Exceptions.handle()
                             .to(ObjectStores.LOG)
@@ -394,7 +422,7 @@ public class ObjectStore {
      */
     public void deleteBucket(BucketName bucket) {
         try (var _ = new Operation(() -> Strings.apply("S3: Deleting bucket %s", bucket), Duration.ofMinutes(1))) {
-            getClient().deleteBucket(bucket.getName());
+            getClient().deleteBucket(DeleteBucketRequest.builder().bucket(bucket.getName()).build());
             stores.bucketCache.remove(Tuple.create(name, bucket.getName()));
         } catch (Exception exception) {
             throw Exceptions.handle()
@@ -407,7 +435,22 @@ public class ObjectStore {
 
     private boolean checkExistence(BucketName bucket) {
         try {
-            return client.doesBucketExistV2(bucket.getName());
+            client.headBucket(HeadBucketRequest.builder().bucket(bucket.getName()).build());
+            return true;
+        } catch (NoSuchBucketException exception) {
+            return false;
+        } catch (S3Exception exception) {
+            if (exception.statusCode() == HttpResponseStatus.NOT_FOUND.code()) {
+                return false;
+            }
+
+            Exceptions.handle()
+                      .to(ObjectStores.LOG)
+                      .error(exception)
+                      .withSystemErrorMessage("Failed to check if %s exists: %s (%s)", bucket)
+                      .handle();
+
+            return false;
         } catch (SdkClientException exception) {
             Exceptions.handle()
                       .to(ObjectStores.LOG)
@@ -429,7 +472,9 @@ public class ObjectStore {
      * @return a download URL for the object
      */
     public String url(BucketName bucket, String objectId) {
-        return getClient().getUrl(bucket.getName(), objectId).toString();
+        return getClient().utilities()
+                          .getUrl(GetUrlRequest.builder().bucket(bucket.getName()).key(objectId).build())
+                          .toString();
     }
 
     /**
@@ -442,8 +487,14 @@ public class ObjectStore {
      * @return a pre-signed download URL for the object
      */
     public String objectUrl(BucketName bucket, String objectId) {
-        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket.getName(), objectId);
-        return getClient().generatePresignedUrl(request).toString();
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                                                                        .signatureDuration(Duration.ofMinutes(15))
+                                                                        .getObjectRequest(GetObjectRequest.builder()
+                                                                                                          .bucket(bucket.getName())
+                                                                                                          .key(objectId)
+                                                                                                          .build())
+                                                                        .build();
+        return presigner.presignGetObject(presignRequest).url().toExternalForm();
     }
 
     /**
@@ -462,9 +513,14 @@ public class ObjectStore {
                                    Duration.ofHours(4))) {
             dest = File.createTempFile("AMZS3", null);
             ensureBucketExists(bucket);
-            transferManager.download(new GetObjectRequest(bucket.getName(), objectId),
-                                     dest,
-                                     new MonitoringProgressListener(false)).waitForCompletion();
+            transferManager.downloadFile(DownloadFileRequest.builder()
+                                                            .getObjectRequest(GetObjectRequest.builder()
+                                                                                              .bucket(bucket.getName())
+                                                                                              .key(objectId)
+                                                                                              .build())
+                                                            .destination(dest)
+                                                            .addTransferListener(new MonitoringProgressListener(false))
+                                                            .build()).completionFuture().get();
             return dest;
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
@@ -478,9 +534,16 @@ public class ObjectStore {
                                     bucket,
                                     objectId)
                             .handle();
-        } catch (AmazonS3Exception exception) {
+        } catch (S3Exception exception) {
             Files.delete(dest);
-            if (exception.getStatusCode() == HttpResponseStatus.NOT_FOUND.code()) {
+            if (isNotFound(exception)) {
+                throw new FileNotFoundException(objectId);
+            } else {
+                throw handleDownloadError(bucket, objectId, exception);
+            }
+        } catch (ExecutionException exception) {
+            Files.delete(dest);
+            if (isNotFound(exception)) {
                 throw new FileNotFoundException(objectId);
             } else {
                 throw handleDownloadError(bucket, objectId, exception);
@@ -489,6 +552,18 @@ public class ObjectStore {
             Files.delete(dest);
             throw handleDownloadError(bucket, objectId, exception);
         }
+    }
+
+    private boolean isNotFound(Throwable throwable) {
+        if (throwable instanceof S3Exception s3Exception) {
+            return s3Exception.statusCode() == HttpResponseStatus.NOT_FOUND.code();
+        }
+
+        if (throwable instanceof ExecutionException || throwable instanceof CompletionException) {
+            return throwable.getCause() != null && isNotFound(throwable.getCause());
+        }
+
+        return false;
     }
 
     private HandledException handleDownloadError(BucketName bucket, String objectId, Exception exception) {
@@ -516,13 +591,15 @@ public class ObjectStore {
                                    Duration.ofSeconds(90))) {
             ensureBucketExists(bucket);
             try (ByteArrayOutputStream output = new ByteArrayOutputStream();
-                 InputStream input = getClient().getObject(new GetObjectRequest(bucket.getName(), objectId))
-                                                .getObjectContent()) {
+                 InputStream input = getClient().getObject(GetObjectRequest.builder()
+                                                                           .bucket(bucket.getName())
+                                                                           .key(objectId)
+                                                                           .build())) {
                 Streams.transfer(input, output);
                 return output.toByteArray();
             }
-        } catch (AmazonS3Exception exception) {
-            if (exception.getStatusCode() == HttpResponseStatus.NOT_FOUND.code()) {
+        } catch (S3Exception exception) {
+            if (exception.statusCode() == HttpResponseStatus.NOT_FOUND.code()) {
                 throw new FileNotFoundException(objectId);
             } else {
                 throw handleDownloadError(bucket, objectId, exception);
@@ -546,13 +623,21 @@ public class ObjectStore {
             dest = File.createTempFile("AMZS3", null);
             Promise<FileHandle> promise = new Promise<>();
             ensureBucketExists(bucket);
-            transferManager.download(new GetObjectRequest(bucket.getName(), objectId),
-                                     dest,
-                                     new AsyncDownloadListener(bucket.getName(), objectId, dest, promise));
+            transferManager.downloadFile(DownloadFileRequest.builder()
+                                                            .getObjectRequest(GetObjectRequest.builder()
+                                                                                              .bucket(bucket.getName())
+                                                                                              .key(objectId)
+                                                                                              .build())
+                                                            .destination(dest)
+                                                            .addTransferListener(new AsyncDownloadListener(bucket.getName(),
+                                                                                                           objectId,
+                                                                                                           dest,
+                                                                                                           promise))
+                                                            .build());
             return promise;
-        } catch (AmazonS3Exception exception) {
+        } catch (S3Exception exception) {
             Files.delete(dest);
-            if (exception.getStatusCode() == HttpResponseStatus.NOT_FOUND.code()) {
+            if (isNotFound(exception)) {
                 throw new FileNotFoundException(objectId);
             }
 
@@ -571,7 +656,7 @@ public class ObjectStore {
      * @param data     the data to upload
      * @return kind of a promise used to monitor the upload progress
      */
-    public Upload uploadAsync(BucketName bucket, String objectId, File data) {
+    public FileUpload uploadAsync(BucketName bucket, String objectId, File data) {
         return uploadAsync(bucket, objectId, data, null);
     }
 
@@ -584,11 +669,18 @@ public class ObjectStore {
      * @param metadata the metadata for the object
      * @return kind of a promise used to monitor the upload progress
      */
-    public Upload uploadAsync(BucketName bucket, String objectId, File data, @Nullable ObjectMetadata metadata) {
+    public FileUpload uploadAsync(BucketName bucket, String objectId, File data, @Nullable Map<String, String> metadata) {
         try {
             ensureBucketExists(bucket);
-            return transferManager.upload(new PutObjectRequest(bucket.getName(), objectId, data).withMetadata(metadata),
-                                          new MonitoringProgressListener(true));
+            return transferManager.uploadFile(UploadFileRequest.builder()
+                                                               .putObjectRequest(PutObjectRequest.builder()
+                                                                                                 .bucket(bucket.getName())
+                                                                                                 .key(objectId)
+                                                                                                 .metadata(metadata)
+                                                                                                 .build())
+                                                               .source(data)
+                                                               .addTransferListener(new MonitoringProgressListener(true))
+                                                               .build());
         } catch (Exception exception) {
             throw Exceptions.handle()
                             .to(ObjectStores.LOG)
@@ -619,10 +711,10 @@ public class ObjectStore {
      * @param data     the data to upload
      * @param metadata the metadata for the object
      */
-    public void upload(BucketName bucket, String objectId, File data, @Nullable ObjectMetadata metadata) {
-        try (var _ = new Operation(() -> Strings.apply("S3: Uploading object % to %s", objectId, bucket),
+    public void upload(BucketName bucket, String objectId, File data, @Nullable Map<String, String> metadata) {
+        try (var _ = new Operation(() -> Strings.apply("S3: Uploading object %s to %s", objectId, bucket),
                                    Duration.ofHours(4))) {
-            uploadAsync(bucket, objectId, data, metadata).waitForUploadResult();
+            uploadAsync(bucket, objectId, data, metadata).completionFuture().get();
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             throw Exceptions.handle()
@@ -630,6 +722,15 @@ public class ObjectStore {
                             .error(exception)
                             .withSystemErrorMessage(
                                     "Got interrupted while waiting for an upload to complete: %s/%s - %s (%s)",
+                                    bucket,
+                                    objectId)
+                            .handle();
+        } catch (ExecutionException exception) {
+            throw Exceptions.handle()
+                            .to(ObjectStores.LOG)
+                            .error(exception)
+                            .withSystemErrorMessage(
+                                    "An error occurred while waiting for an upload to complete: %s/%s - %s (%s)",
                                     bucket,
                                     objectId)
                             .handle();
@@ -663,17 +764,21 @@ public class ObjectStore {
                               String objectId,
                               InputStream inputStream,
                               long contentLength,
-                              @Nullable ObjectMetadata metadata) {
-        if (metadata == null) {
-            metadata = new ObjectMetadata();
-        }
-
-        metadata.setContentLength(contentLength);
+                              @Nullable Map<String, String> metadata) {
         try {
             ensureBucketExists(bucket);
-            PutObjectRequest putObjectRequest = new PutObjectRequest(bucket.getName(), objectId, inputStream, metadata);
-            putObjectRequest.getRequestClientOptions().setReadLimit(MAXIMAL_LOCAL_AGGREGATION_BUFFER_SIZE);
-            return transferManager.upload(putObjectRequest, new MonitoringProgressListener(true));
+            return transferManager.upload(UploadRequest.builder()
+                                                       .putObjectRequest(PutObjectRequest.builder()
+                                                                                         .bucket(bucket.getName())
+                                                                                         .key(objectId)
+                                                                                         .metadata(metadata)
+                                                                                         .build())
+                                                       .requestBody(AsyncRequestBody.fromInputStream(inputStream,
+                                                                                                     contentLength,
+                                                                                                     tasks.executorService(
+                                                                                                             EXECUTOR_S3)))
+                                                       .addTransferListener(new MonitoringProgressListener(true))
+                                                       .build());
         } catch (Exception exception) {
             throw Exceptions.handle()
                             .to(ObjectStores.LOG)
@@ -710,13 +815,13 @@ public class ObjectStore {
                        String objectId,
                        InputStream inputStream,
                        long contentLength,
-                       @Nullable ObjectMetadata metadata) {
+                       @Nullable Map<String, String> metadata) {
         if (contentLength == 0 || contentLength >= MAXIMAL_LOCAL_AGGREGATION_BUFFER_SIZE) {
             upload(bucket, objectId, inputStream);
         } else {
-            try (var _ = new Operation(() -> Strings.apply("S3: Uploading object % to %s", objectId, bucket),
+            try (var _ = new Operation(() -> Strings.apply("S3: Uploading object %s to %s", objectId, bucket),
                                        Duration.ofMinutes(30))) {
-                uploadAsync(bucket, objectId, inputStream, contentLength, metadata).waitForUploadResult();
+                uploadAsync(bucket, objectId, inputStream, contentLength, metadata).completionFuture().get();
             } catch (InterruptedException exception) {
                 Thread.currentThread().interrupt();
                 throw Exceptions.handle()
@@ -724,6 +829,15 @@ public class ObjectStore {
                                 .error(exception)
                                 .withSystemErrorMessage(
                                         "Got interrupted while waiting for an upload to complete: %s/%s - %s (%s)",
+                                        bucket,
+                                        objectId)
+                                .handle();
+            } catch (ExecutionException exception) {
+                throw Exceptions.handle()
+                                .to(ObjectStores.LOG)
+                                .error(exception)
+                                .withSystemErrorMessage(
+                                        "An error occurred while waiting for an upload to complete: %s/%s - %s (%s)",
                                         bucket,
                                         objectId)
                                 .handle();
@@ -744,11 +858,14 @@ public class ObjectStore {
      */
     public void upload(BucketName bucket, String objectId, InputStream inputStream) {
         ensureBucketExists(bucket);
-        InitiateMultipartUploadResult multipartUpload =
-                getClient().initiateMultipartUpload(new InitiateMultipartUploadRequest(bucket.getName(), objectId));
+        CreateMultipartUploadResponse multipartUpload =
+                getClient().createMultipartUpload(CreateMultipartUploadRequest.builder()
+                                                                              .bucket(bucket.getName())
+                                                                              .key(objectId)
+                                                                              .build());
         try (var _ = new Operation(() -> Strings.apply("S3: Multipart upload of object %s to %s", objectId, bucket),
                                    Duration.ofHours(4))) {
-            List<PartETag> eTags = uploadInChunks(bucket, objectId, inputStream, multipartUpload.getUploadId());
+            List<CompletedPart> eTags = uploadInChunks(bucket, objectId, inputStream, multipartUpload.uploadId());
 
             if (ObjectStores.LOG.isFINE()) {
                 ObjectStores.LOG.FINE("Completing upload of %s to %s using %s parts...",
@@ -761,12 +878,18 @@ public class ObjectStore {
                 // If the input stream had no contents, attempting to complete the multipart upload will error out.
                 // Therefore, we abort it and put an empty string, creating an object with 0 bytes
                 abortMultipartUpload(bucket, objectId, multipartUpload);
-                getClient().putObject(bucket.getName(), objectId, "");
+                getClient().putObject(PutObjectRequest.builder().bucket(bucket.getName()).key(objectId).build(),
+                                      RequestBody.fromString(""));
             } else {
-                getClient().completeMultipartUpload(new CompleteMultipartUploadRequest(bucket.getName(),
-                                                                                       objectId,
-                                                                                       multipartUpload.getUploadId(),
-                                                                                       eTags));
+                getClient().completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+                                                                                  .bucket(bucket.getName())
+                                                                                  .key(objectId)
+                                                                                  .uploadId(multipartUpload.uploadId())
+                                                                                  .multipartUpload(
+                                                                                          CompletedMultipartUpload.builder()
+                                                                                                                  .parts(eTags)
+                                                                                                                  .build())
+                                                                                  .build());
             }
         } catch (Exception exception) {
             abortMultipartUpload(bucket, objectId, multipartUpload);
@@ -790,22 +913,28 @@ public class ObjectStore {
 
     private void abortMultipartUpload(BucketName bucket,
                                       String objectId,
-                                      InitiateMultipartUploadResult multipartUpload) {
-        getClient().abortMultipartUpload(new AbortMultipartUploadRequest(bucket.getName(),
-                                                                         objectId,
-                                                                         multipartUpload.getUploadId()));
+                                      CreateMultipartUploadResponse multipartUpload) {
+        if (multipartUpload == null) {
+            return;
+        }
+
+        getClient().abortMultipartUpload(AbortMultipartUploadRequest.builder()
+                                                                    .bucket(bucket.getName())
+                                                                    .key(objectId)
+                                                                    .uploadId(multipartUpload.uploadId())
+                                                                    .build());
     }
 
     @Nonnull
-    protected List<PartETag> uploadInChunks(BucketName bucket,
-                                            String objectId,
-                                            InputStream inputStream,
-                                            String multipartUploadId) throws IOException {
+    protected List<CompletedPart> uploadInChunks(BucketName bucket,
+                                                 String objectId,
+                                                 InputStream inputStream,
+                                                 String multipartUploadId) throws IOException {
         if (ObjectStores.LOG.isFINE()) {
             ObjectStores.LOG.FINE("Uploading %s to %s", objectId, bucket);
         }
 
-        List<PartETag> eTags = new ArrayList<>();
+        List<CompletedPart> eTags = new ArrayList<>();
         int partNumber = 1;
 
         ByteBuf localAggregationBuffer = Unpooled.buffer(INITIAL_LOCAL_AGGREGATION_BUFFER_SIZE);
@@ -832,11 +961,11 @@ public class ObjectStore {
         return eTags;
     }
 
-    protected PartETag uploadChunk(BucketName bucket,
-                                   String objectId,
-                                   String multipartUploadId,
-                                   ByteBuf buffer,
-                                   int partNumber) {
+    protected CompletedPart uploadChunk(BucketName bucket,
+                                        String objectId,
+                                        String multipartUploadId,
+                                        ByteBuf buffer,
+                                        int partNumber) {
         if (ObjectStores.LOG.isFINE()) {
             ObjectStores.LOG.FINE("Uploading %s bytes (part %s) for %s to %s",
                                   buffer.readableBytes(),
@@ -845,13 +974,16 @@ public class ObjectStore {
                                   bucket);
         }
 
-        UploadPartRequest request = new UploadPartRequest().withBucketName(bucket.getName())
-                                                           .withKey(objectId)
-                                                           .withUploadId(multipartUploadId)
-                                                           .withPartNumber(partNumber)
-                                                           .withPartSize(buffer.readableBytes())
-                                                           .withInputStream(new ByteBufInputStream(buffer));
-        return getClient().uploadPart(request).getPartETag();
+        UploadPartRequest request = UploadPartRequest.builder()
+                                                     .bucket(bucket.getName())
+                                                     .key(objectId)
+                                                     .uploadId(multipartUploadId)
+                                                     .partNumber(partNumber)
+                                                     .build();
+        String eTag = getClient().uploadPart(request,
+                                            RequestBody.fromInputStream(new ByteBufInputStream(buffer),
+                                                                        buffer.readableBytes())).eTag();
+        return CompletedPart.builder().partNumber(partNumber).eTag(eTag).build();
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -184,7 +184,7 @@ public class ObjectStores {
                                                 .httpClientBuilder(httpClientBuilder);
 
         try {
-            URI endpoint = URI.create(extension.get(KEY_END_POINT).asString());
+            URI endpoint = new URI(extension.get(KEY_END_POINT).asString());
             int defaultPort =
                     PROTOCOL_HTTPS.equalsIgnoreCase(endpoint.getScheme()) ? DEFAULT_PORT_HTTPS : DEFAULT_PORT_HTTP;
             clientBuilder.endpointOverride(mapEndpoint(name, endpoint, defaultPort))
@@ -223,7 +223,7 @@ public class ObjectStores {
                                                           .credentialsProvider(credentialsProvider)
                                                           .httpClientBuilder(httpClientBuilder);
         try {
-            URI endpoint = URI.create(extension.get(KEY_END_POINT).asString());
+            URI endpoint = new URI(extension.get(KEY_END_POINT).asString());
             int defaultPort =
                     PROTOCOL_HTTPS.equalsIgnoreCase(endpoint.getScheme()) ? DEFAULT_PORT_HTTPS : DEFAULT_PORT_HTTP;
             clientBuilder.endpointOverride(mapEndpoint(name, endpoint, defaultPort))
@@ -249,7 +249,7 @@ public class ObjectStores {
                                               .serviceConfiguration(serviceConfiguration)
                                               .credentialsProvider(credentialsProvider);
         try {
-            URI endpoint = URI.create(extension.get(KEY_END_POINT).asString());
+            URI endpoint = new URI(extension.get(KEY_END_POINT).asString());
             int defaultPort =
                     PROTOCOL_HTTPS.equalsIgnoreCase(endpoint.getScheme()) ? DEFAULT_PORT_HTTPS : DEFAULT_PORT_HTTP;
             presignerBuilder.endpointOverride(mapEndpoint(name, endpoint, defaultPort))

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -69,7 +69,7 @@ public class ObjectStores {
     private static final String PROTOCOL_HTTPS = "https";
     private static final String SERVICE_PREFIX_S3 = "s3-";
     private static final String NAME_SYSTEM_STORE = "system";
-    private static final Region DEFAULT_REGION = Region.US_EAST_1;
+    private static final Region DEFAULT_REGION = Region.EU_CENTRAL_1;
 
     private ObjectStore store;
     private final ConcurrentHashMap<String, ObjectStore> stores = new ConcurrentHashMap<>();

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -8,17 +8,10 @@
 
 package sirius.biz.storage.s3;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.util.AwsHostNameUtils;
 import sirius.kernel.Sirius;
 import sirius.kernel.cache.Cache;
 import sirius.kernel.cache.CacheManager;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Average;
@@ -28,6 +21,18 @@ import sirius.kernel.health.Log;
 import sirius.kernel.settings.Extension;
 import sirius.kernel.settings.PortMapper;
 import sirius.kernel.settings.Settings;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner.Builder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -64,6 +69,7 @@ public class ObjectStores {
     private static final String PROTOCOL_HTTPS = "https";
     private static final String SERVICE_PREFIX_S3 = "s3-";
     private static final String NAME_SYSTEM_STORE = "system";
+    private static final Region DEFAULT_REGION = Region.US_EAST_1;
 
     private ObjectStore store;
     private final ConcurrentHashMap<String, ObjectStore> stores = new ConcurrentHashMap<>();
@@ -135,47 +141,54 @@ public class ObjectStores {
             throw Exceptions.handle().to(LOG).withSystemErrorMessage("Unknown object store: %s", name).handle();
         }
 
-        AmazonS3 newClient = createClient(name, extension);
-        result = new ObjectStore(this, name, newClient, extension.get(KEY_BUCKET_SUFFIX).asString());
+        S3Client newClient = createClient(name, extension);
+        S3AsyncClient newAsyncClient = createAsyncClient(name, extension);
+        S3Presigner newPresigner = createPresigner(name, extension);
+        result = new ObjectStore(this,
+                                 name,
+                                 newClient,
+                                 newAsyncClient,
+                                 newPresigner,
+                                 extension.get(KEY_BUCKET_SUFFIX).asString());
 
         stores.put(name, result);
 
         return result;
     }
 
-    protected AmazonS3 createClient(String name, Settings extension) {
-        ClientConfiguration config =
-                new ClientConfiguration().withSocketTimeout((int) extension.getDuration(KEY_SOCKET_TIMEOUT).toMillis())
-                                         .withConnectionTimeout((int) extension.getDuration(KEY_CONNECTION_TIMEOUT)
-                                                                               .toMillis())
-                                         .withMaxConnections(extension.getInt(KEY_MAX_CONNECTIONS));
+    protected S3Client createClient(String name, Settings extension) {
+        if (!extension.get(KEY_SIGNER).isEmptyString()) {
+            LOG.WARN("Ignoring legacy signer override '%s' for object store '%s'. AWS SDK v2 uses SigV4 by default.",
+                     extension.get(KEY_SIGNER).asString(),
+                     name);
+        }
+
+        StaticCredentialsProvider credentialsProvider = createCredentialsProvider(extension);
+        S3Configuration serviceConfiguration =
+                S3Configuration.builder().pathStyleAccessEnabled(extension.get(KEY_PATH_STYLE_ACCESS).asBoolean()).build();
+        ApacheHttpClient.Builder httpClientBuilder = ApacheHttpClient.builder()
+                                                                     .socketTimeout(extension.getDuration(
+                                                                             KEY_SOCKET_TIMEOUT))
+                                                                     .connectionTimeout(extension.getDuration(
+                                                                             KEY_CONNECTION_TIMEOUT))
+                                                                     .maxConnections(extension.getInt(
+                                                                             KEY_MAX_CONNECTIONS));
         Duration connectionTTL = extension.getDuration(KEY_CONNECTION_TTL);
         if (connectionTTL.isPositive()) {
-            config.setConnectionTTL(connectionTTL.toMillis());
+            httpClientBuilder.connectionTimeToLive(connectionTTL);
         }
 
-        if (!extension.get(KEY_SIGNER).isEmptyString()) {
-            config.withSignerOverride(extension.get(KEY_SIGNER).asString());
-        }
-
-        AmazonS3ClientBuilder clientBuilder = AmazonS3ClientBuilder.standard()
-                                                                   .withPathStyleAccessEnabled(extension.get(
-                                                                           KEY_PATH_STYLE_ACCESS).asBoolean())
-                                                                   .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(
-                                                                           extension.get(KEY_ACCESS_KEY).asString(),
-                                                                           extension.get(KEY_SECRET_KEY).asString())))
-                                                                   .withClientConfiguration(config);
+        S3ClientBuilder clientBuilder = S3Client.builder()
+                                                .serviceConfiguration(serviceConfiguration)
+                                                .credentialsProvider(credentialsProvider)
+                                                .httpClientBuilder(httpClientBuilder);
 
         try {
             URI endpoint = URI.create(extension.get(KEY_END_POINT).asString());
             int defaultPort =
                     PROTOCOL_HTTPS.equalsIgnoreCase(endpoint.getScheme()) ? DEFAULT_PORT_HTTPS : DEFAULT_PORT_HTTP;
-            clientBuilder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(mapEndpoint(name,
-                                                                                                           endpoint,
-                                                                                                           defaultPort),
-                                                                                               AwsHostNameUtils.parseRegion(
-                                                                                                       endpoint.getHost(),
-                                                                                                       AmazonS3Client.S3_SERVICE_NAME)));
+            clientBuilder.endpointOverride(mapEndpoint(name, endpoint, defaultPort))
+                         .region(determineRegion(endpoint));
         } catch (URISyntaxException exception) {
             throw Exceptions.handle()
                             .error(exception)
@@ -189,7 +202,105 @@ public class ObjectStores {
         return clientBuilder.build();
     }
 
-    private String mapEndpoint(String name, URI endpoint, int defaultPort) throws URISyntaxException {
+    protected S3AsyncClient createAsyncClient(String name, Settings extension) {
+        StaticCredentialsProvider credentialsProvider = createCredentialsProvider(extension);
+        S3Configuration serviceConfiguration =
+                S3Configuration.builder().pathStyleAccessEnabled(extension.get(KEY_PATH_STYLE_ACCESS).asBoolean()).build();
+        NettyNioAsyncHttpClient.Builder httpClientBuilder = NettyNioAsyncHttpClient.builder()
+                                                                                   .readTimeout(extension.getDuration(
+                                                                                           KEY_SOCKET_TIMEOUT))
+                                                                                   .connectionTimeout(extension.getDuration(
+                                                                                           KEY_CONNECTION_TIMEOUT))
+                                                                                   .maxConcurrency(extension.getInt(
+                                                                                           KEY_MAX_CONNECTIONS));
+        Duration connectionTTL = extension.getDuration(KEY_CONNECTION_TTL);
+        if (connectionTTL.isPositive()) {
+            httpClientBuilder.connectionTimeToLive(connectionTTL);
+        }
+
+        S3AsyncClientBuilder clientBuilder = S3AsyncClient.builder()
+                                                          .serviceConfiguration(serviceConfiguration)
+                                                          .credentialsProvider(credentialsProvider)
+                                                          .httpClientBuilder(httpClientBuilder);
+        try {
+            URI endpoint = URI.create(extension.get(KEY_END_POINT).asString());
+            int defaultPort =
+                    PROTOCOL_HTTPS.equalsIgnoreCase(endpoint.getScheme()) ? DEFAULT_PORT_HTTPS : DEFAULT_PORT_HTTP;
+            clientBuilder.endpointOverride(mapEndpoint(name, endpoint, defaultPort))
+                         .region(determineRegion(endpoint));
+        } catch (URISyntaxException exception) {
+            throw Exceptions.handle()
+                            .error(exception)
+                            .to(LOG)
+                            .withSystemErrorMessage("Invalid endpoint for object store %s: %s - %s (%s)",
+                                                    name,
+                                                    extension.get(KEY_END_POINT).asString())
+                            .handle();
+        }
+
+        return clientBuilder.build();
+    }
+
+    protected S3Presigner createPresigner(String name, Settings extension) {
+        StaticCredentialsProvider credentialsProvider = createCredentialsProvider(extension);
+        S3Configuration serviceConfiguration =
+                S3Configuration.builder().pathStyleAccessEnabled(extension.get(KEY_PATH_STYLE_ACCESS).asBoolean()).build();
+        Builder presignerBuilder = S3Presigner.builder()
+                                              .serviceConfiguration(serviceConfiguration)
+                                              .credentialsProvider(credentialsProvider);
+        try {
+            URI endpoint = URI.create(extension.get(KEY_END_POINT).asString());
+            int defaultPort =
+                    PROTOCOL_HTTPS.equalsIgnoreCase(endpoint.getScheme()) ? DEFAULT_PORT_HTTPS : DEFAULT_PORT_HTTP;
+            presignerBuilder.endpointOverride(mapEndpoint(name, endpoint, defaultPort))
+                            .region(determineRegion(endpoint));
+        } catch (URISyntaxException exception) {
+            throw Exceptions.handle()
+                            .error(exception)
+                            .to(LOG)
+                            .withSystemErrorMessage("Invalid endpoint for object store %s: %s - %s (%s)",
+                                                    name,
+                                                    extension.get(KEY_END_POINT).asString())
+                            .handle();
+        }
+
+        return presignerBuilder.build();
+    }
+
+    private StaticCredentialsProvider createCredentialsProvider(Settings extension) {
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create(extension.get(KEY_ACCESS_KEY).asString(),
+                                                                          extension.get(KEY_SECRET_KEY).asString()));
+    }
+
+    private Region determineRegion(URI endpoint) {
+        String host = endpoint.getHost();
+        if (host == null) {
+            return DEFAULT_REGION;
+        }
+
+        if (host.startsWith("s3.")) {
+            String region = extractRegion(host, "s3.".length());
+            return Strings.isFilled(region) && !Strings.areEqual(region, "amazonaws") ? Region.of(region) : DEFAULT_REGION;
+        }
+
+        if (host.startsWith("s3-")) {
+            String region = extractRegion(host, "s3-".length());
+            return Strings.isFilled(region) ? Region.of(region) : DEFAULT_REGION;
+        }
+
+        return DEFAULT_REGION;
+    }
+
+    private String extractRegion(String host, int start) {
+        int end = host.indexOf('.', start);
+        if (end < 0) {
+            return null;
+        }
+
+        return host.substring(start, end);
+    }
+
+    private URI mapEndpoint(String name, URI endpoint, int defaultPort) throws URISyntaxException {
         Tuple<String, Integer> hostAndPort = PortMapper.mapPort(SERVICE_PREFIX_S3 + name,
                                                                 endpoint.getHost(),
                                                                 endpoint.getPort() < 0 ?
@@ -202,6 +313,6 @@ public class ObjectStores {
                        Integer.valueOf(defaultPort).equals(hostAndPort.getSecond()) ? -1 : hostAndPort.getSecond(),
                        endpoint.getPath(),
                        endpoint.getQuery(),
-                       endpoint.getFragment()).toString();
+                       endpoint.getFragment());
     }
 }

--- a/src/main/java/sirius/biz/storage/util/SearchOrphanS3ObjectsJob.java
+++ b/src/main/java/sirius/biz/storage/util/SearchOrphanS3ObjectsJob.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.storage.util;
 
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import sirius.biz.jobs.StandardCategories;
 import sirius.biz.jobs.batch.file.ArchiveExportJob;
 import sirius.biz.jobs.params.IntParameter;
@@ -19,7 +18,6 @@ import sirius.biz.process.ProcessContext;
 import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.storage.s3.BucketName;
 import sirius.biz.storage.s3.ObjectStores;
-import sirius.biz.tenants.TenantUserManager;
 import sirius.kernel.async.ParallelTaskExecutor;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.CSVWriter;
@@ -27,7 +25,7 @@ import sirius.kernel.commons.NumberFormat;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
-import sirius.web.security.UserContext;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -93,7 +91,7 @@ public abstract class SearchOrphanS3ObjectsJob extends ArchiveExportJob {
             writeLine("bucketName", "physicalObjectId", "date", "size");
             // Creates a BucketName object. The suffix is already listed in the parameter.
             BucketName bucketName = new BucketName(getBucketName(), "");
-            Queue<S3ObjectSummary> queue = new LinkedList<>();
+            Queue<S3Object> queue = new LinkedList<>();
             objectStores.store().listObjects(bucketName, null, object -> {
                 process.tryUpdateState("Total: " + total.getAndIncrement());
                 queue.add(object);
@@ -118,10 +116,10 @@ public abstract class SearchOrphanS3ObjectsJob extends ArchiveExportJob {
         }
     }
 
-    private void drainQueue(Queue<S3ObjectSummary> queue, int parallelTasks) {
+    private void drainQueue(Queue<S3Object> queue, int parallelTasks) {
         ParallelTaskExecutor executor = new ParallelTaskExecutor(parallelTasks);
         while (!queue.isEmpty()) {
-            S3ObjectSummary object = queue.poll();
+            S3Object object = queue.poll();
             executor.submitTask(() -> checkObject(object));
         }
         executor.shutdownWhenDone();
@@ -131,20 +129,20 @@ public abstract class SearchOrphanS3ObjectsJob extends ArchiveExportJob {
 
     protected abstract boolean variantExists(String physicalObjectKey);
 
-    private void checkObject(S3ObjectSummary object) {
-        String physicalObjectKey = object.getKey();
+    private void checkObject(S3Object object) {
+        String physicalObjectKey = object.key();
         if (blobExists(physicalObjectKey) || variantExists(physicalObjectKey)) {
             return;
         }
 
         try {
             missingCount.incrementAndGet();
-            missingSize.addAndGet(object.getSize());
+            missingSize.addAndGet(object.size());
             writeLine(getBucketName(),
                       physicalObjectKey,
-                      LocalDateTime.ofInstant(object.getLastModified().toInstant(), ZoneId.systemDefault())
+                      LocalDateTime.ofInstant(object.lastModified(), ZoneId.systemDefault())
                                    .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
-                      object.getSize());
+                      object.size());
         } catch (IOException exception) {
             process.handle(exception);
         }

--- a/src/test/kotlin/sirius/biz/codelists/CodeListsTest.kt
+++ b/src/test/kotlin/sirius/biz/codelists/CodeListsTest.kt
@@ -55,7 +55,7 @@ class CodeListsTest {
     @Test
     fun `tryGetValue auto-creates if possible and reports correctly otherwise`() {
         TenantsHelper.installTestTenant()
-        assertTrue(codeLists.tryGetValue("test", "unknownCode").isPresent())
-        assertTrue(codeLists.tryGetValue("hard-test", "unknownCode").isEmpty())
+        assertTrue(codeLists.tryGetValue("test", "unknownCode").isPresent)
+        assertTrue(codeLists.tryGetValue("hard-test", "unknownCode").isEmpty)
     }
 }

--- a/src/test/kotlin/sirius/biz/storage/layer1/ObjectStorageTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer1/ObjectStorageTest.kt
@@ -76,15 +76,15 @@ class ObjectStorageTest {
     fun `storing and fetching data works as expected`(length: Int, space: String) {
 
         val testData = generateRandomData(length)
-        val objectName = "test-data-" + length
+        val objectName = "test-data-$length"
         val objectSpace = storage.getSpace(space)
 
         objectSpace.upload(objectName, ByteArrayInputStream(testData), testData.size.toLong())
 
         val downloaded = objectSpace.download(objectName)
 
-        assertTrue { downloaded.isPresent() }
-        assertTrue { testData.contentEquals(Files.readAllBytes(downloaded.get().getFile().toPath())) }
+        assertTrue { downloaded.isPresent }
+        assertTrue { testData.contentEquals(Files.readAllBytes(downloaded.get().file.toPath())) }
         assertTrue { testData.contentEquals(Streams.toByteArray(objectSpace.getInputStream(objectName).get())) }
     }
 
@@ -102,8 +102,8 @@ class ObjectStorageTest {
 
         val downloadedAfterDelete = objectSpace.download("delete-test")
 
-        assertTrue { downloadedBeforeDelete.isPresent() }
-        assertFalse { downloadedAfterDelete.isPresent() }
+        assertTrue { downloadedBeforeDelete.isPresent }
+        assertFalse { downloadedAfterDelete.isPresent }
 
     }
 
@@ -113,9 +113,9 @@ class ObjectStorageTest {
         private lateinit var storage: ObjectStorage
 
         private fun generateRandomData(length: Int): ByteArray {
-            val rnd = Random()
+            val random = Random()
             val result = ByteArray(length)
-            rnd.nextBytes(result)
+            random.nextBytes(result)
             return result
         }
     }

--- a/src/test/kotlin/sirius/biz/storage/layer1/ReplicationTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer1/ReplicationTest.kt
@@ -35,12 +35,12 @@ class ReplicationTest {
     fun `Updates are replicated correctly`() {
         val testData = "test".toByteArray(StandardCharsets.UTF_8)
         storage.getSpace("repl-primary")
-                .upload("repl-update-test", ByteArrayInputStream(testData), testData.size.toLong())
+            .upload("repl-update-test", ByteArrayInputStream(testData), testData.size.toLong())
         awaitReplication()
         val downloaded = storage.getSpace("reply-secondary").download("repl-update-test")
-        assertTrue { downloaded.isPresent() }
+        assertTrue { downloaded.isPresent }
 
-        assertEquals("test", InputStreamReader(downloaded.get().getInputStream(), StandardCharsets.UTF_8).readText())
+        assertEquals("test", InputStreamReader(downloaded.get().inputStream, StandardCharsets.UTF_8).readText())
     }
 
     @Test
@@ -48,13 +48,13 @@ class ReplicationTest {
 
         val testData = "test".toByteArray(StandardCharsets.UTF_8)
         storage.getSpace("repl-primary")
-                .upload("repl-delete-test", ByteArrayInputStream(testData), testData.size.toLong())
+            .upload("repl-delete-test", ByteArrayInputStream(testData), testData.size.toLong())
 
         awaitReplication()
         storage.getSpace("repl-primary").delete("repl-delete-test")
         awaitReplication()
         val downloaded = storage.getSpace("reply-secondary").download("repl-delete-test")
-        assertFalse { downloaded.isPresent() }
+        assertFalse { downloaded.isPresent }
     }
 
     companion object {
@@ -64,7 +64,7 @@ class ReplicationTest {
 
         fun awaitReplication() {
             BackgroundLoop.nextExecution(
-                    ReplicationBackgroundLoop::class.java
+                ReplicationBackgroundLoop::class.java
             ).await(Duration.ofMinutes(1))
             // Give the sync some time to actually complete its tasks...
             Wait.seconds(10.0)

--- a/src/test/kotlin/sirius/biz/storage/layer2/BlobUriParserTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer2/BlobUriParserTest.kt
@@ -29,7 +29,7 @@ class BlobUriParserTest {
             download: Boolean,
             filename: String
     ) {
-        val blobUri = BlobUriParser.parseBlobUri(uri).orElse(null)
+        val blobUri = BlobUriParser.parseBlobUri(uri).orElse(null)!!
 
         Assertions.assertEquals(blobUri.isLargeFileExpected, largeFileExpected)
         Assertions.assertEquals(blobUri.isPhysical, true)
@@ -60,7 +60,7 @@ class BlobUriParserTest {
             cacheable: Boolean,
             filename: String
     ) {
-        val blobUri = BlobUriParser.parseBlobUri(uri).orElse(null)
+        val blobUri = BlobUriParser.parseBlobUri(uri).orElse(null)!!
 
         Assertions.assertEquals(blobUri.isLargeFileExpected, largeFileExpected)
         Assertions.assertEquals(blobUri.isPhysical, false)

--- a/src/test/kotlin/sirius/biz/storage/layer2/SQLBlobEntityMappingTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer2/SQLBlobEntityMappingTest.kt
@@ -1,17 +1,16 @@
 package sirius.biz.storage.layer2
 
 
-import org.junit.jupiter.api.extension.ExtendWith
-import sirius.kernel.SiriusExtension
 import org.junit.jupiter.api.Test
-
-
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.biz.storage.layer2.jdbc.SQLBlob
 import sirius.biz.tenants.TenantsHelper
 import sirius.db.jdbc.OMA
+import sirius.kernel.SiriusExtension
 import sirius.kernel.di.std.Part
 import java.nio.file.Paths
-import org.junit.jupiter.api.assertDoesNotThrow
-import sirius.biz.storage.layer2.jdbc.SQLBlob
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExtendWith(SiriusExtension::class)
@@ -21,17 +20,17 @@ class SQLBlobEntityMappingTest {
         val blob = blobStorage.getSpace("blob-files").createTemporaryBlob()
         var testEntity = BlobRefEntity()
         assertTrue { blob.isTemporary() }
-        testEntity.getBlobHardRef().setBlob(blob)
+        testEntity.blobHardRef.setBlob(blob)
         oma.update(testEntity)
         testEntity = oma.refreshOrFail(testEntity)
-        assertTrue { !testEntity.getBlobHardRef().getBlob()!!.isTemporary() }
+        assertTrue { !testEntity.blobHardRef.getBlob()!!.isTemporary() }
     }
 
     @Test
     fun `store entity with unchanged blob hard ref must not fail`() {
         val testEntity = BlobRefEntity()
         val blob = blobStorage.getSpace("blob-files").createTemporaryBlob()
-        testEntity.getBlobHardRef().setBlob(blob)
+        testEntity.blobHardRef.setBlob(blob)
         oma.update(testEntity)
         val loadedEntity = oma.findOrFail(BlobRefEntity::class.java, testEntity.getId())
         assertDoesNotThrow { oma.update(loadedEntity) }
@@ -43,7 +42,7 @@ class SQLBlobEntityMappingTest {
         val testEntity = BlobRefEntity()
         val testFilePath = Paths.get("src/test/resources/test-data/test4blob.txt")
         val blob = blobStorage.getSpace("blob-files").findOrCreateByPath(testFilePath.toString())
-        testEntity.getBlobSoftRef().setBlob(blob)
+        testEntity.blobSoftRef.setBlob(blob)
         oma.update(testEntity)
         val loadedEntity = oma.findOrFail(BlobRefEntity::class.java, testEntity.getId())
         assertDoesNotThrow { oma.update(loadedEntity) }
@@ -53,15 +52,15 @@ class SQLBlobEntityMappingTest {
     fun `delete entity with blob hard ref must mark the blob for deletion`() {
         val testEntity = BlobRefEntity()
         val blob = blobStorage.getSpace("blob-files").createTemporaryBlob()
-        testEntity.getBlobHardRef().setBlob(blob)
+        testEntity.blobHardRef.setBlob(blob)
         oma.update(testEntity)
-        val Blob: SQLBlob? = blobStorage.getSpace("blob-files").findByBlobKey(blob.getBlobKey()).get() as? SQLBlob
-        if (Blob != null) {
-            assertTrue { !Blob.isDeleted() }
+        val sqlBlob: SQLBlob? = blobStorage.getSpace("blob-files").findByBlobKey(blob.getBlobKey()).get() as? SQLBlob
+        if (sqlBlob != null) {
+            assertFalse { sqlBlob.isDeleted }
         }
-        assertTrue { Blob != null }
+        assertTrue { sqlBlob != null }
         oma.delete(testEntity)
-        assertTrue { !blobStorage.getSpace("blob-files").findByBlobKey(blob.getBlobKey()).isPresent() }
+        assertFalse { blobStorage.getSpace("blob-files").findByBlobKey(blob.getBlobKey()).isPresent }
     }
 
     companion object {

--- a/src/test/kotlin/sirius/biz/storage/s3/ObjectStoresTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/s3/ObjectStoresTest.kt
@@ -56,7 +56,7 @@ class ObjectStoresTest {
         stores.store().upload(stores.store().getBucketName("test"), "test", file, null)
         val download = stores.store().download(stores.store().getBucketName("test"), "test")
         val c = URI(
-                stores.store().objectUrl(stores.store().getBucketName("test"), "test")
+            stores.store().objectUrl(stores.store().getBucketName("test"), "test")
         ).toURL().openConnection()
 
         val expectedContents = files_.readString(file.toPath(), StandardCharsets.UTF_8)
@@ -74,19 +74,19 @@ class ObjectStoresTest {
         stores.store().ensureBucketExists(stores.store().getBucketName("exists"))
         stores.store().doesBucketExist(stores.store().getBucketName("exists"))
         stores.bucketCache.get(
-                Tuple.create(
-                        stores.store().name,
-                        stores.store().getBucketName("exists").getName()
-                )
+            Tuple.create(
+                stores.store().name,
+                stores.store().getBucketName("exists").getName()
+            )
         )
         !stores.store().doesBucketExist(stores.store().getBucketName("not-exists"))
         assertEquals(
-                null, stores.bucketCache.get(
+            null, stores.bucketCache.get(
                 Tuple.create(
-                        stores.store().name,
-                        stores.store().getBucketName("not-exists").getName()
+                    stores.store().name,
+                    stores.store().getBucketName("not-exists").getName()
                 )
-        )
+            )
         )
     }
 
@@ -97,12 +97,12 @@ class ObjectStoresTest {
         stores.store().deleteBucket(stores.store().getBucketName("deleted"))
         assertFalse { stores.store().doesBucketExist(stores.store().getBucketName("deleted")) }
         assertEquals(
-                null, stores.bucketCache.get(
+            null, stores.bucketCache.get(
                 Tuple.create(
-                        stores.store().name,
-                        stores.store().getBucketName("deleted").getName()
+                    stores.store().name,
+                    stores.store().getBucketName("deleted").name
                 )
-        )
+            )
         )
     }
 

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     hostname: es
 
   s3-system:
-    image: scireum/s3-ninja:8.6.0
+    image: scireum/s3-ninja:8.7.0
     ports:
       - "9000"
     hostname: s3ninja


### PR DESCRIPTION
### BREAKING CHANGES

- Direct usages of AWS SKD v1 (like creating an AWS client, ...) need to be adapted or replaced by usages of the storage framework
- Latest version of S3Ninja should be used

### Description

The logic adaptations where mainly done based on:
1. [Official migration guide](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-whats-different.html)
2. [OpenRewrite recipe](https://docs.openrewrite.org/recipes/software/amazon/awssdk/v2migration/awssdkjavav1tov2)
3. AI assistance
4. Manual cleanup

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1025](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1025)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
