### PR TITLE
Only use checksum validation when required by AWS

### DIFF
--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -23,6 +23,8 @@ import sirius.kernel.settings.PortMapper;
 import sirius.kernel.settings.Settings;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -181,6 +183,8 @@ public class ObjectStores {
         S3ClientBuilder clientBuilder = S3Client.builder()
                                                 .serviceConfiguration(serviceConfiguration)
                                                 .credentialsProvider(credentialsProvider)
+                                                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                                                .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
                                                 .httpClientBuilder(httpClientBuilder);
 
         try {
@@ -221,6 +225,8 @@ public class ObjectStores {
         S3AsyncClientBuilder clientBuilder = S3AsyncClient.builder()
                                                           .serviceConfiguration(serviceConfiguration)
                                                           .credentialsProvider(credentialsProvider)
+                                                          .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                                                          .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
                                                           .httpClientBuilder(httpClientBuilder);
         try {
             URI endpoint = new URI(extension.get(KEY_END_POINT).asString());


### PR DESCRIPTION
### Description

Always using checksum validation when supported by AWS SDK v2 causes problems on uploads to our ECS AWS-compatible storage.

It was introduced in 2.30.0 of the SDK: https://github.com/aws/aws-sdk-java-v2/discussions/5802

<img width="1616" height="954" alt="grafik" src="https://github.com/user-attachments/assets/34179648-d80f-41ed-99e8-07a5dc41f5ad" />

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1025](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1025)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
