### PR TITLE
Switch to more secure hashing for storage URL signatures

### DIFF
--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -628,7 +628,7 @@ public class URLBuilder {
         return cachedPhysicalKey;
     }
 
-    private String computeAccessToken(String authToken) {
+    String computeAccessToken(String authToken) {
         if (eternallyValid) {
             return utils.computeEternallyValidHash(authToken);
         } else {

--- a/src/main/java/sirius/biz/storage/legacy/Storage.java
+++ b/src/main/java/sirius/biz/storage/legacy/Storage.java
@@ -21,12 +21,10 @@ import sirius.kernel.Sirius;
 import sirius.kernel.async.Tasks;
 import sirius.kernel.cache.Cache;
 import sirius.kernel.cache.CacheManager;
-import sirius.kernel.commons.Hasher;
 import sirius.kernel.commons.StringCleanup;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Urls;
 import sirius.kernel.di.GlobalContext;
-import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
@@ -43,9 +41,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.SQLException;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -109,10 +104,8 @@ public class Storage {
     @Part
     private GlobalContext context;
 
-    @ConfigValue("storage.sharedSecret")
-    @Nullable
-    private String sharedSecret;
-    private String safeSharedSecret;
+    @Part
+    private StorageUtils utils;
 
     private Map<String, BucketInfo> buckets;
 
@@ -518,24 +511,7 @@ public class Storage {
      * @return <tt>true</tt> if the hash verifies the given object key, <tt>false</tt> otherwise
      */
     protected boolean verifyHash(String key, String hash) {
-        // Check for a hash for today...
-        if (Strings.areEqual(hash, computeHash(key, 0))) {
-            return true;
-        }
-
-        // Check for an eternally valid hash...
-        if (Strings.areEqual(hash, computeEternallyValidHash(key))) {
-            return true;
-        }
-
-        // Check for hashes up to two days of age...
-        for (int i = 1; i < 3; i++) {
-            if (Strings.areEqual(hash, computeHash(key, -i)) || Strings.areEqual(hash, computeHash(key, i))) {
-                return true;
-            }
-        }
-
-        return false;
+        return utils.verifyHash(key, hash, StorageUtils.DEFAULT_URL_VALIDITY_DAYS).isPresent();
     }
 
     /**
@@ -626,9 +602,9 @@ public class Storage {
         result.append(downloadBuilder.getBucket());
         result.append("/");
         if (downloadBuilder.isEternallyValid()) {
-            result.append(computeEternallyValidHash(downloadBuilder.getPhysicalKey()));
+            result.append(utils.computeEternallyValidHash(downloadBuilder.getPhysicalKey()));
         } else {
-            result.append(computeHash(downloadBuilder.getPhysicalKey(), 0));
+            result.append(utils.computeHash(downloadBuilder.getPhysicalKey(), 0));
         }
         result.append("/");
         String addonText = downloadBuilder.getAddonText();
@@ -647,50 +623,5 @@ public class Storage {
         }
 
         return result.toString();
-    }
-
-    /**
-     * Computes an authentication hash for the given physical storage key and the offset in days (from the current).
-     *
-     * @param physicalKey the key to authenticate
-     * @param offsetDays  the offset from the current day
-     * @return a hash valid for the given day and key
-     */
-    private String computeHash(String physicalKey, int offsetDays) {
-        return Hasher.md5().hash(physicalKey + getTimestampOfDay(offsetDays) + getSharedSecret()).toHexString();
-    }
-
-    /**
-     * Computes an authentication hash which is eternally valid.
-     *
-     * @param physicalKey the key to authenticate
-     * @return a hash valid forever
-     */
-    private String computeEternallyValidHash(String physicalKey) {
-        return Hasher.md5().hash(physicalKey + getSharedSecret()).toHexString();
-    }
-
-    /**
-     * Generates a timestamp for the day plus the provided day offset.
-     *
-     * @param day the offset from the current day
-     * @return the effective timestamp (number of days since 01.01.1970) in days
-     */
-    private String getTimestampOfDay(int day) {
-        Instant midnight = LocalDate.now().plusDays(day).atStartOfDay(ZoneId.systemDefault()).toInstant();
-        return String.valueOf(midnight.toEpochMilli());
-    }
-
-    /**
-     * Determines the shared secret to use.
-     *
-     * @return the shared secret to use, taken from <tt>storage.sharedSecret</tt> in the system config
-     */
-    private String getSharedSecret() {
-        if (safeSharedSecret == null) {
-            safeSharedSecret = StorageUtils.requireSharedSecret(sharedSecret);
-        }
-
-        return safeSharedSecret;
     }
 }

--- a/src/main/java/sirius/biz/storage/util/StorageUtils.java
+++ b/src/main/java/sirius/biz/storage/util/StorageUtils.java
@@ -23,16 +23,22 @@ import sirius.kernel.settings.Extension;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.text.Normalizer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -60,6 +66,31 @@ public class StorageUtils implements Startable {
      * Represents the central logger for the whole storage framework.
      */
     public static final Log LOG = Log.get("storage");
+
+    /**
+     * Names the JCA algorithm used to sign storage URLs.
+     */
+    private static final String HMAC_SHA_256 = "HmacSHA256";
+
+    /**
+     * Domain separator for storage URL signatures to prevent reusing tokens in a different signing context.
+     */
+    private static final String HMAC_PAYLOAD_PREFIX = "sirius-biz-storage-url";
+
+    /**
+     * Marks a signature payload bound to a concrete day.
+     */
+    private static final String HMAC_PAYLOAD_MODE_DAY = "day";
+
+    /**
+     * Marks a signature payload that deliberately has no date component.
+     */
+    private static final String HMAC_PAYLOAD_MODE_ETERNAL = "eternal";
+
+    /**
+     * Stable placeholder used as the timestamp field for eternally valid signature payloads.
+     */
+    private static final String HMAC_PAYLOAD_ETERNAL_TIMESTAMP = HMAC_PAYLOAD_MODE_ETERNAL;
 
     /**
      * Pattern for cleaning up consecutive slashes and removing backslashes.
@@ -120,24 +151,59 @@ public class StorageUtils implements Startable {
      */
     public Optional<Integer> verifyHash(String key, String hash, int validityDays) {
         // Check for a hash for today...
-        if (Strings.areEqual(hash, computeHash(key, 0))) {
+        if (constantTimeEquals(hash, computeHash(key, 0))) {
             return Optional.of(0);
         }
 
         // Check for an eternally valid hash...
-        if (Strings.areEqual(hash, computeEternallyValidHash(key))) {
+        if (constantTimeEquals(hash, computeEternallyValidHash(key))) {
             return Optional.of(Integer.MAX_VALUE);
         }
 
         // Check for hashes up to X days into the past...
         for (int i = 1; i <= validityDays; i++) {
-            if (Strings.areEqual(hash, computeHash(key, -i))) {
+            if (constantTimeEquals(hash, computeHash(key, -i))) {
                 return Optional.of(-i);
             }
         }
         // Check for hashes up to two days into the future...
         for (int i = 1; i <= DEFAULT_URL_VALIDITY_DAYS; i++) {
-            if (Strings.areEqual(hash, computeHash(key, i))) {
+            if (constantTimeEquals(hash, computeHash(key, i))) {
+                return Optional.of(i);
+            }
+        }
+
+        return verifyLegacyMd5Hash(key, hash, validityDays);
+    }
+
+    /**
+     * Verifies a token using the legacy MD5 scheme for already issued URLs.
+     *
+     * @param key          the storage key to authenticate
+     * @param hash         the legacy hash to verify
+     * @param validityDays the number of days the hash should be valid into the past
+     * @return the matching day offset or an empty optional if the hash is invalid
+     */
+    private Optional<Integer> verifyLegacyMd5Hash(String key, String hash, int validityDays) {
+        // Check for a hash for today...
+        if (constantTimeEquals(hash, computeLegacyMd5Hash(key, 0))) {
+            return Optional.of(0);
+        }
+
+        // Check for an eternally valid hash...
+        if (constantTimeEquals(hash, computeLegacyMd5EternallyValidHash(key))) {
+            return Optional.of(Integer.MAX_VALUE);
+        }
+
+        // Check for hashes up to X days into the past...
+        for (int i = 1; i <= validityDays; i++) {
+            if (constantTimeEquals(hash, computeLegacyMd5Hash(key, -i))) {
+                return Optional.of(-i);
+            }
+        }
+        // Check for hashes up to two days into the future...
+        for (int i = 1; i <= DEFAULT_URL_VALIDITY_DAYS; i++) {
+            if (constantTimeEquals(hash, computeLegacyMd5Hash(key, i))) {
                 return Optional.of(i);
             }
         }
@@ -153,7 +219,7 @@ public class StorageUtils implements Startable {
      * @return a hash valid for the given day and key
      */
     public String computeHash(String key, int offsetDays) {
-        return Hasher.md5().hash(key + getTimestampOfDay(offsetDays) + getSharedSecret()).toHexString();
+        return computeHmac(HMAC_PAYLOAD_MODE_DAY, key, getTimestampOfDay(offsetDays));
     }
 
     /**
@@ -163,7 +229,76 @@ public class StorageUtils implements Startable {
      * @return a hash valid forever
      */
     public String computeEternallyValidHash(String key) {
+        return computeHmac(HMAC_PAYLOAD_MODE_ETERNAL, key, HMAC_PAYLOAD_ETERNAL_TIMESTAMP);
+    }
+
+    /**
+     * Computes the Base64URL encoded HMAC for a canonical storage URL payload.
+     *
+     * @param mode      the signature mode, e.g. day-bound or eternal
+     * @param key       the storage key to authenticate
+     * @param timestamp the day timestamp or eternal placeholder included in the signed payload
+     * @return the URL-safe HMAC token without padding
+     */
+    private String computeHmac(String mode, String key, String timestamp) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA_256);
+            mac.init(new SecretKeySpec(getSharedSecret().getBytes(StandardCharsets.UTF_8), HMAC_SHA_256));
+
+            byte[] digest = mac.doFinal(createHmacPayload(mode, key, timestamp).getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+        } catch (GeneralSecurityException exception) {
+            throw Exceptions.handle()
+                            .to(LOG)
+                            .error(exception)
+                            .withSystemErrorMessage("Cannot compute storage URL HMAC.")
+                            .handle();
+        }
+    }
+
+    /**
+     * Builds the canonical payload that is authenticated by the HMAC.
+     *
+     * @param mode      the signature mode, e.g. day-bound or eternal
+     * @param key       the storage key to authenticate
+     * @param timestamp the day timestamp or eternal placeholder included in the signed payload
+     * @return the canonical storage URL signature payload
+     */
+    private String createHmacPayload(String mode, String key, String timestamp) {
+        return HMAC_PAYLOAD_PREFIX + ":" + mode + ":" + key + ":" + timestamp;
+    }
+
+    /**
+     * Computes a legacy day-bound MD5 hash for fallback verification.
+     *
+     * @param key        the storage key to authenticate
+     * @param offsetDays the offset from the current day
+     * @return the legacy MD5 token for the given day
+     */
+    private String computeLegacyMd5Hash(String key, int offsetDays) {
+        return Hasher.md5().hash(key + getTimestampOfDay(offsetDays) + getSharedSecret()).toHexString();
+    }
+
+    /**
+     * Computes a legacy eternally valid MD5 hash for fallback verification.
+     *
+     * @param key the storage key to authenticate
+     * @return the legacy MD5 token without a day component
+     */
+    private String computeLegacyMd5EternallyValidHash(String key) {
         return Hasher.md5().hash(key + getSharedSecret()).toHexString();
+    }
+
+    /**
+     * Compares two token strings without short-circuiting on the first mismatching character.
+     *
+     * @param left  the provided token
+     * @param right the expected token
+     * @return <tt>true</tt> if both tokens are equal, <tt>false</tt> otherwise
+     */
+    private boolean constantTimeEquals(String left, String right) {
+        return left != null && right != null && MessageDigest.isEqual(left.getBytes(StandardCharsets.UTF_8),
+                                                                      right.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -182,6 +317,7 @@ public class StorageUtils implements Startable {
      *
      * @return the shared secret to use, taken from <tt>storage.sharedSecret</tt> in the system config
      */
+    @Nonnull
     private String getSharedSecret() {
         if (safeSharedSecret == null) {
             safeSharedSecret = requireSharedSecret(sharedSecret);

--- a/src/test/kotlin/sirius/biz/storage/legacy/StorageSigningTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/legacy/StorageSigningTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.legacy
+
+import io.mockk.every
+import io.mockk.spyk
+import org.junit.jupiter.api.Test
+import sirius.biz.storage.util.StorageUtils
+import sirius.kernel.commons.Hasher
+import sirius.kernel.di.std.Part
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests storage URL signing compatibility for deprecated [Storage] URLs.
+ *
+ * Verifies that legacy storage URLs are now signed through [StorageUtils] using HMAC tokens while still accepting
+ * existing MD5-signed URLs as fallback.
+ */
+@Suppress("DEPRECATION")
+class StorageSigningTest {
+
+    @Test
+    fun verifiesHmacAndLegacyMd5Hashes() {
+        assertTrue(storage.verifyHash("physical-key", utils.computeHash("physical-key", 0)))
+
+        val legacyToken = Hasher.md5().hash("physical-key$SHARED_SECRET").toHexString()
+        assertTrue(storage.verifyHash("physical-key", legacyToken))
+    }
+
+    @Test
+    fun computesHmacHashesForLegacyUrls() {
+        val builder = spyk(DownloadBuilder(storage, "bucket", "object-key").withFileExtension("txt"))
+        every { builder.physicalKey } answers { "physical-key" }
+
+        val buildURL = Storage::class.java.getDeclaredMethod("buildURL", DownloadBuilder::class.java)
+        buildURL.isAccessible = true
+
+        val url = buildURL.invoke(storage, builder) as String
+        val token = url.split("/")[4]
+
+        assertTrue(token.matches(Regex("[A-Za-z0-9_-]{43}")))
+        assertFalse(token.matches(Regex("[0-9a-f]{32}")))
+    }
+
+    companion object {
+        private const val SHARED_SECRET = "storage-test-secret"
+
+        @field:Part
+        private lateinit var storage: Storage
+
+        @field:Part
+        private lateinit var utils: StorageUtils
+    }
+}

--- a/src/test/kotlin/sirius/biz/storage/legacy/StorageSigningTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/legacy/StorageSigningTest.kt
@@ -11,7 +11,9 @@ package sirius.biz.storage.legacy
 import io.mockk.every
 import io.mockk.spyk
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import sirius.biz.storage.util.StorageUtils
+import sirius.kernel.SiriusExtension
 import sirius.kernel.commons.Hasher
 import sirius.kernel.di.std.Part
 import kotlin.test.assertFalse
@@ -24,6 +26,7 @@ import kotlin.test.assertTrue
  * existing MD5-signed URLs as fallback.
  */
 @Suppress("DEPRECATION")
+@ExtendWith(SiriusExtension::class)
 class StorageSigningTest {
 
     @Test

--- a/src/test/kotlin/sirius/biz/storage/util/StorageUtilsTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/util/StorageUtilsTest.kt
@@ -9,6 +9,8 @@
 package sirius.biz.storage.util
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
 import sirius.kernel.commons.Hasher
 import sirius.kernel.di.std.Part
 import java.time.Instant
@@ -24,6 +26,7 @@ import kotlin.test.assertTrue
  * Covers Base64URL HMAC token generation and verification, eternally valid HMAC tokens, malformed token rejection,
  * and legacy MD5 fallback verification for already issued URLs.
  */
+@ExtendWith(SiriusExtension::class)
 class StorageUtilsTest {
 
     @Test

--- a/src/test/kotlin/sirius/biz/storage/util/StorageUtilsTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/util/StorageUtilsTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.storage.util
+
+import org.junit.jupiter.api.Test
+import sirius.kernel.commons.Hasher
+import sirius.kernel.di.std.Part
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the storage URL signing helpers in [StorageUtils].
+ *
+ * Covers Base64URL HMAC token generation and verification, eternally valid HMAC tokens, malformed token rejection,
+ * and legacy MD5 fallback verification for already issued URLs.
+ */
+class StorageUtilsTest {
+
+    @Test
+    fun computeHashUsesBase64UrlHmacSha256() {
+        val token = utils.computeHash("physical-key", 0)
+
+        assertEquals(43, token.length)
+        assertTrue(token.matches(Regex("[A-Za-z0-9_-]+")))
+        assertFalse(token.matches(Regex("[0-9a-f]{32}")))
+    }
+
+    @Test
+    fun verifiesGeneratedHmacHashes() {
+        val token = utils.computeHash("physical-key", 0)
+
+        assertEquals(0, utils.verifyHash("physical-key", token, 2).orElseThrow())
+        assertTrue(utils.verifyHash("other-key", token, 2).isEmpty)
+    }
+
+    @Test
+    fun verifiesGeneratedEternalHmacHashes() {
+        val token = utils.computeEternallyValidHash("physical-key")
+
+        assertEquals(Int.MAX_VALUE, utils.verifyHash("physical-key", token, 2).orElseThrow())
+    }
+
+    @Test
+    fun acceptsLegacyEternalMd5Hashes() {
+        val legacyToken = legacyEternalMd5Token("physical-key")
+
+        assertEquals(Int.MAX_VALUE, utils.verifyHash("physical-key", legacyToken, 2).orElseThrow())
+    }
+
+    @Test
+    fun acceptsLegacyDayMd5Hashes() {
+        val legacyToken = legacyDayMd5Token("physical-key", 0)
+
+        assertEquals(0, utils.verifyHash("physical-key", legacyToken, 2).orElseThrow())
+    }
+
+    @Test
+    fun rejectsMalformedHmacTokens() {
+        assertTrue(utils.verifyHash("physical-key", "not-a-valid-hmac-token-but-long-enough", 2).isEmpty)
+    }
+
+    private fun legacyEternalMd5Token(key: String): String =
+        Hasher.md5().hash(key + SHARED_SECRET).toHexString()
+
+    private fun legacyDayMd5Token(key: String, offsetDays: Int): String {
+        val midnight: Instant =
+            LocalDate.now().plusDays(offsetDays.toLong()).atStartOfDay(ZoneId.systemDefault()).toInstant()
+        return Hasher.md5().hash(key + midnight.toEpochMilli() + SHARED_SECRET).toHexString()
+    }
+
+    companion object {
+        private const val SHARED_SECRET = "storage-test-secret"
+
+        @field:Part
+        private lateinit var utils: StorageUtils
+    }
+}

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -121,6 +121,7 @@ async {
     }
 }
 
+storage.sharedSecret = "storage-test-secret"
 
 storage.buckets.versioned-files.maxNumberOfVersions = 2
 


### PR DESCRIPTION
### Description
Storage URL access tokens now use Base64URL-encoded HMAC-SHA-256 signatures instead of MD5, while verification still accepts legacy MD5 tokens so previously issued URLs continue to work. Legacy storage framework delegates to `StorageUtils`. Added tests for new hashing and legacy fallback.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1204](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1204)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
