### PR TITLE
Close a reflected XSS security flaw

### DIFF
--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -130,7 +130,7 @@
             });
 
             try {
-                window.localStorage.setItem('samlPostLoginUri', '<i:raw>@originalUrl</i:raw>');
+                window.localStorage.setItem('samlPostLoginUri', '@raw {@escapeJS(originalUrl)}');
             } catch (e) {
                 console.log(e);
             }


### PR DESCRIPTION
### Description

The "originalUrl" is the URL the user invoked before being redirected to the login page. Therefore, attackers could potentially provide a modified URL for the user to e.g. `/admin?');window.alert('PING');//`. This would result in this being inserted into the HTML pages code:
```
window.localStorage.setItem('samlPostLoginUri', /admin?');window.alert('PING');//');
```

The `escapeJS` macro will among other things escape single quotes which ensures the `originalUrl` can't "break out" of the string quotations.

However, currently this issue can't actually be abused as (hopefully all) browsers will escape special characters in URLs.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1218](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1218)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
