### PR TITLE
Accept broad SAML validity windows (SIRI-1201)

### DIFF
--- a/src/main/java/sirius/biz/saml/SamlHelper.java
+++ b/src/main/java/sirius/biz/saml/SamlHelper.java
@@ -478,13 +478,8 @@ public class SamlHelper {
             return subjectConfirmationNotOnOrAfter.get();
         }
 
-        if (subjectConfirmationNotOnOrAfter.isEmpty()) {
-            return conditionsNotOnOrAfter.get();
-        }
-
-        return conditionsNotOnOrAfter.get().isBefore(subjectConfirmationNotOnOrAfter.get()) ?
-               conditionsNotOnOrAfter.get() :
-               subjectConfirmationNotOnOrAfter.get();
+        return subjectConfirmationNotOnOrAfter.filter(instant -> !conditionsNotOnOrAfter.get().isBefore(instant))
+                                              .orElseGet(conditionsNotOnOrAfter::get);
     }
 
     /**

--- a/src/main/java/sirius/biz/saml/SamlHelper.java
+++ b/src/main/java/sirius/biz/saml/SamlHelper.java
@@ -430,7 +430,11 @@ public class SamlHelper {
                 throw invalidTimestamp(ATTRIBUTE_NOT_ON_OR_AFTER, DateTimeFormatter.ISO_INSTANT.format(notOnOrAfter));
             }
 
-            throw invalidTimestamp(ATTRIBUTE_ISSUE_INSTANT, DateTimeFormatter.ISO_INSTANT.format(issueInstant));
+            throw Exceptions.createHandled()
+                            .withSystemErrorMessage(
+                                    "Invalid SAML Response: Assertion is older than the maximum acceptance duration of %s.",
+                                    effectiveMaxResponseAcceptanceDuration)
+                            .handle();
         }
 
         return new TimestampValidationResult(deadline);

--- a/src/main/java/sirius/biz/saml/SamlHelper.java
+++ b/src/main/java/sirius/biz/saml/SamlHelper.java
@@ -100,6 +100,14 @@ public class SamlHelper {
 
     private static final String SAMLP_NAMESPACE = "urn:oasis:names:tc:SAML:2.0:protocol";
 
+    private static final String ATTRIBUTE_ID = "ID";
+
+    private static final String ATTRIBUTE_ISSUE_INSTANT = "IssueInstant";
+
+    private static final String ATTRIBUTE_NOT_BEFORE = "NotBefore";
+
+    private static final String ATTRIBUTE_NOT_ON_OR_AFTER = "NotOnOrAfter";
+
     private static final String FEATURE_DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
 
     private static final String FEATURE_LOAD_EXTERNAL_DTD =
@@ -209,9 +217,9 @@ public class SamlHelper {
         output.beginOutput("samlp:AuthnRequest",
                            Attribute.set("xmlns:samlp", SAMLP_NAMESPACE),
                            Attribute.set("xmlns:saml", SAML_NAMESPACE),
-                           Attribute.set("ID", "identifier_" + System.currentTimeMillis()),
+                           Attribute.set(ATTRIBUTE_ID, "identifier_" + System.currentTimeMillis()),
                            Attribute.set("Version", "2.0"),
-                           Attribute.set("IssueInstant",
+                           Attribute.set(ATTRIBUTE_ISSUE_INSTANT,
                                          DateTimeFormatter.ISO_INSTANT.format(Instant.now()
                                                                                      .truncatedTo(ChronoUnit.SECONDS))),
                            Attribute.set("AssertionConsumerServiceIndex", issuerIndex));
@@ -311,8 +319,8 @@ public class SamlHelper {
             TimestampValidationResult timestampValidationResult = checkTime ? verifyTimestamp(assertion) : null;
             String fingerprint = validateXMLSignature(document, assertion);
             if (timestampValidationResult != null) {
-                boolean reserved = replayProtector.reserve(document.getDocumentElement().getAttribute("ID"),
-                                                           assertion.getAttribute("ID"),
+                boolean reserved = replayProtector.reserve(document.getDocumentElement().getAttribute(ATTRIBUTE_ID),
+                                                           assertion.getAttribute(ATTRIBUTE_ID),
                                                            timestampValidationResult.replayCacheDeadline());
                 if (!reserved) {
                     throw Exceptions.createHandled()
@@ -337,7 +345,7 @@ public class SamlHelper {
     /**
      * Selects the element with the given node name.
      * <p>
-     * This method ensures, that there is only one element, as we want to ensure that there is only one <tt>Assertion</tt> and
+     * This method ensures that there is only one element, as we want to ensure that there is only one <tt>Assertion</tt> and
      * one <tt>Signature</tt> for it.
      *
      * @param document  the XML document
@@ -368,26 +376,26 @@ public class SamlHelper {
      */
     private TimestampValidationResult verifyTimestamp(Element assertion) {
         Instant now = Instant.now();
-        String issueInstantValue = assertion.getAttribute("IssueInstant");
+        String issueInstantValue = assertion.getAttribute(ATTRIBUTE_ISSUE_INSTANT);
         if (Strings.isEmpty(issueInstantValue)) {
-            throw invalidTimestamp("IssueInstant", "<missing>");
+            throw invalidTimestamp(ATTRIBUTE_ISSUE_INSTANT, "<missing>");
         }
 
-        Instant issueInstant = parseRequiredInstant("IssueInstant", issueInstantValue);
+        Instant issueInstant = parseRequiredInstant(ATTRIBUTE_ISSUE_INSTANT, issueInstantValue);
 
         if (issueInstant.isAfter(now.plus(SAML_CLOCK_SKEW))) {
-            throw invalidTimestamp("IssueInstant", DateTimeFormatter.ISO_INSTANT.format(issueInstant));
+            throw invalidTimestamp(ATTRIBUTE_ISSUE_INSTANT, DateTimeFormatter.ISO_INSTANT.format(issueInstant));
         }
 
-        Optional<Instant> notBefore = extractConditionsTimestamp(assertion, "NotBefore");
+        Optional<Instant> notBefore = extractConditionsTimestamp(assertion, ATTRIBUTE_NOT_BEFORE);
         if (notBefore.isPresent() && notBefore.get().isAfter(now.plus(SAML_CLOCK_SKEW))) {
-            throw invalidTimestamp("NotBefore", DateTimeFormatter.ISO_INSTANT.format(notBefore.get()));
+            throw invalidTimestamp(ATTRIBUTE_NOT_BEFORE, DateTimeFormatter.ISO_INSTANT.format(notBefore.get()));
         }
 
         Instant notOnOrAfter = extractEffectiveNotOnOrAfter(assertion);
         Instant deadline = notOnOrAfter.plus(SAML_CLOCK_SKEW);
         if (!now.isBefore(deadline)) {
-            throw invalidTimestamp("NotOnOrAfter", DateTimeFormatter.ISO_INSTANT.format(notOnOrAfter));
+            throw invalidTimestamp(ATTRIBUTE_NOT_ON_OR_AFTER, DateTimeFormatter.ISO_INSTANT.format(notOnOrAfter));
         }
 
         return new TimestampValidationResult(deadline);
@@ -457,12 +465,12 @@ public class SamlHelper {
      * @return the effective deadline after which the assertion is no longer valid
      */
     private Instant extractEffectiveNotOnOrAfter(Element assertion) {
-        Optional<Instant> conditionsNotOnOrAfter = extractConditionsTimestamp(assertion, "NotOnOrAfter");
+        Optional<Instant> conditionsNotOnOrAfter = extractConditionsTimestamp(assertion, ATTRIBUTE_NOT_ON_OR_AFTER);
         Optional<Instant> subjectConfirmationNotOnOrAfter = extractEarliestSubjectConfirmationNotOnOrAfter(assertion);
 
         if (conditionsNotOnOrAfter.isEmpty() && subjectConfirmationNotOnOrAfter.isEmpty()) {
             throw Exceptions.createHandled()
-                            .withSystemErrorMessage("Invalid SAML Response: Missing NotOnOrAfter.")
+                            .withSystemErrorMessage("Invalid SAML Response: Missing %s.", ATTRIBUTE_NOT_ON_OR_AFTER)
                             .handle();
         }
 
@@ -492,9 +500,9 @@ public class SamlHelper {
 
         for (int i = 0; i < subjectConfirmationDataElements.getLength(); i++) {
             Element subjectConfirmationData = (Element) subjectConfirmationDataElements.item(i);
-            String notOnOrAfter = subjectConfirmationData.getAttribute("NotOnOrAfter");
+            String notOnOrAfter = subjectConfirmationData.getAttribute(ATTRIBUTE_NOT_ON_OR_AFTER);
             if (Strings.isFilled(notOnOrAfter)) {
-                Instant timestamp = parseRequiredInstant("NotOnOrAfter", notOnOrAfter);
+                Instant timestamp = parseRequiredInstant(ATTRIBUTE_NOT_ON_OR_AFTER, notOnOrAfter);
                 if (earliestTimestamp.isEmpty() || timestamp.isBefore(earliestTimestamp.get())) {
                     earliestTimestamp = Optional.of(timestamp);
                 }
@@ -578,8 +586,8 @@ public class SamlHelper {
      * @throws Exception in case an XML or signing error occurs
      */
     private String validateXMLSignature(Document document, Element assertion) throws Exception {
-        assertion.setIdAttribute("ID", true);
-        String idToVerify = assertion.getAttribute("ID");
+        assertion.setIdAttribute(ATTRIBUTE_ID, true);
+        String idToVerify = assertion.getAttribute(ATTRIBUTE_ID);
 
         Element signatureElement = selectSingleElement(document, XMLSignature.XMLNS, "Signature");
 

--- a/src/main/java/sirius/biz/saml/SamlHelper.java
+++ b/src/main/java/sirius/biz/saml/SamlHelper.java
@@ -85,10 +85,21 @@ public class SamlHelper {
     public static final Duration SAML_CLOCK_SKEW = Duration.ofMinutes(2);
 
     /**
+     * The absolute upper bound for accepting a SAML assertion after its <tt>IssueInstant</tt>.
+     */
+    static final Duration ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION = Duration.ofMinutes(30);
+
+    /**
      * Limits the Base64 encoded SAMLResponse before decoding or XML parsing. The configured value can adapt this to
      * product-specific IdP payloads, but the effective limit is always capped at 1 MB.
      */
     static final int ABSOLUTE_MAX_ENCODED_SAML_RESPONSE_SIZE = 1_000_000;
+
+    /**
+     * Defines how long a SAML assertion is accepted after its <tt>IssueInstant</tt>.
+     */
+    @ConfigValue("security.saml.maxResponseAcceptanceDuration")
+    private Duration maxResponseAcceptanceDuration;
 
     @ConfigValue("security.saml.maxEncodedResponseSize")
     private int maxEncodedSamlResponseSize;
@@ -302,6 +313,23 @@ public class SamlHelper {
     }
 
     /**
+     * Determines the effective maximum response acceptance duration from the configured value.
+     *
+     * @param configuredMaxResponseAcceptanceDuration the configured maximum duration after the assertion issue instant
+     * @return the configured duration capped by {@link #ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION}
+     */
+    static Duration determineEffectiveMaxResponseAcceptanceDuration(Duration configuredMaxResponseAcceptanceDuration) {
+        if (configuredMaxResponseAcceptanceDuration == null || configuredMaxResponseAcceptanceDuration.isZero()
+            || configuredMaxResponseAcceptanceDuration.isNegative()) {
+            return ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION;
+        }
+
+        return configuredMaxResponseAcceptanceDuration.compareTo(ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION) > 0 ?
+               ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION :
+               configuredMaxResponseAcceptanceDuration;
+    }
+
+    /**
      * Parses a SAML 2 response from the given input string, optionally checking timestamps.
      * <p>
      * Note that the fingerprint <b>must</b> be verified against an externally configured trust source, as this method
@@ -393,12 +421,30 @@ public class SamlHelper {
         }
 
         Instant notOnOrAfter = extractEffectiveNotOnOrAfter(assertion);
-        Instant deadline = notOnOrAfter.plus(SAML_CLOCK_SKEW);
+        Duration effectiveMaxResponseAcceptanceDuration =
+                determineEffectiveMaxResponseAcceptanceDuration(maxResponseAcceptanceDuration);
+        Instant cappedNotOnOrAfter = min(notOnOrAfter, issueInstant.plus(effectiveMaxResponseAcceptanceDuration));
+        Instant deadline = cappedNotOnOrAfter.plus(SAML_CLOCK_SKEW);
         if (!now.isBefore(deadline)) {
-            throw invalidTimestamp(ATTRIBUTE_NOT_ON_OR_AFTER, DateTimeFormatter.ISO_INSTANT.format(notOnOrAfter));
+            if (cappedNotOnOrAfter.equals(notOnOrAfter)) {
+                throw invalidTimestamp(ATTRIBUTE_NOT_ON_OR_AFTER, DateTimeFormatter.ISO_INSTANT.format(notOnOrAfter));
+            }
+
+            throw invalidTimestamp(ATTRIBUTE_ISSUE_INSTANT, DateTimeFormatter.ISO_INSTANT.format(issueInstant));
         }
 
         return new TimestampValidationResult(deadline);
+    }
+
+    /**
+     * Returns the earlier of the given instants.
+     *
+     * @param first  the first instant to compare
+     * @param second the second instant to compare
+     * @return the earlier instant
+     */
+    private Instant min(Instant first, Instant second) {
+        return first.isBefore(second) ? first : second;
     }
 
     /**

--- a/src/main/java/sirius/biz/saml/SamlHelper.java
+++ b/src/main/java/sirius/biz/saml/SamlHelper.java
@@ -85,11 +85,6 @@ public class SamlHelper {
     public static final Duration SAML_CLOCK_SKEW = Duration.ofMinutes(2);
 
     /**
-     * The maximum accepted validity window for a SAML assertion.
-     */
-    public static final Duration MAX_ASSERTION_VALIDITY = Duration.ofMinutes(5);
-
-    /**
      * Limits the Base64 encoded SAMLResponse before decoding or XML parsing. The configured value can adapt this to
      * product-specific IdP payloads, but the effective limit is always capped at 1 MB.
      */
@@ -390,15 +385,6 @@ public class SamlHelper {
         }
 
         Instant notOnOrAfter = extractEffectiveNotOnOrAfter(assertion);
-        Instant validFrom = notBefore.orElse(issueInstant);
-        if (Duration.between(validFrom, notOnOrAfter).compareTo(MAX_ASSERTION_VALIDITY) > 0) {
-            throw Exceptions.createHandled()
-                            .withSystemErrorMessage(
-                                    "Invalid SAML Response: Assertion validity exceeds maximum duration of %s.",
-                                    MAX_ASSERTION_VALIDITY)
-                            .handle();
-        }
-
         Instant deadline = notOnOrAfter.plus(SAML_CLOCK_SKEW);
         if (!now.isBefore(deadline)) {
             throw invalidTimestamp("NotOnOrAfter", DateTimeFormatter.ISO_INSTANT.format(notOnOrAfter));
@@ -431,7 +417,7 @@ public class SamlHelper {
 
         try {
             return Instant.from(DateTimeFormatter.ISO_INSTANT.parse(value));
-        } catch (DateTimeParseException exception) {
+        } catch (DateTimeParseException _) {
             throw invalidTimestamp(attributeName, value);
         }
     }

--- a/src/main/java/sirius/biz/saml/SamlHelper.java
+++ b/src/main/java/sirius/biz/saml/SamlHelper.java
@@ -608,7 +608,7 @@ public class SamlHelper {
                             .handle();
         }
 
-        X509Certificate certificate = ((X509CertificateResult) signature.getKeySelectorResult()).getCertificate();
+        X509Certificate certificate = ((X509CertificateResult) signature.getKeySelectorResult()).certificate();
         return Hasher.sha1().hashBytes(certificate.getEncoded()).toHexString().toLowerCase();
     }
 
@@ -667,26 +667,11 @@ public class SamlHelper {
     /**
      * Represents the inlined X509 certificate from within the signature.
      */
-    private static class X509CertificateResult implements KeySelectorResult {
-
-        private final X509Certificate certificate;
-
-        /**
-         * Creates a new key selector result for the given X509 certificate.
-         *
-         * @param cert the certificate extracted from the signature
-         */
-        X509CertificateResult(X509Certificate cert) {
-            this.certificate = cert;
-        }
+    private record X509CertificateResult(X509Certificate certificate) implements KeySelectorResult {
 
         @Override
         public Key getKey() {
             return certificate.getPublicKey();
-        }
-
-        public X509Certificate getCertificate() {
-            return certificate;
         }
     }
 }

--- a/src/main/java/sirius/biz/saml/SamlHelper.java
+++ b/src/main/java/sirius/biz/saml/SamlHelper.java
@@ -633,9 +633,6 @@ public class SamlHelper {
      */
     private static class KeyValueKeySelector extends KeySelector {
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public KeySelectorResult select(KeyInfo keyInfo,
                                         KeySelector.Purpose purpose,

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -1460,6 +1460,10 @@ security {
         # Limits the encoded SAMLResponse POST body before decoding or XML parsing. The effective limit is hard-capped
         # at 1 MB by SamlHelper.
         maxEncodedResponseSize = 256000
+
+        # Defines how long a SAML response is accepted after the assertion IssueInstant. The effective duration is
+        # hard-capped at 30 minutes by SamlHelper.
+        maxResponseAcceptanceDuration = 30 minutes
     }
 
     passwords {

--- a/src/test/kotlin/sirius/biz/saml/SamlTest.kt
+++ b/src/test/kotlin/sirius/biz/saml/SamlTest.kt
@@ -305,7 +305,7 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
                 conditionsNotOnOrAfter = now.plus(Duration.ofHours(2)),
                 subjectNotOnOrAfter = now.plus(Duration.ofHours(2))
             ),
-            "Invalid SAML Response: Invalid IssueInstant:"
+            "Invalid SAML Response: Assertion is older than the maximum acceptance duration of PT5M."
         )
     }
 

--- a/src/test/kotlin/sirius/biz/saml/SamlTest.kt
+++ b/src/test/kotlin/sirius/biz/saml/SamlTest.kt
@@ -242,14 +242,13 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     fun `SAML response without NotBefore reaches signature validation`() {
         val now = Instant.now()
 
-        assertInvalidSamlResponse(
+        assertSamlTimestampValidationPasses(
             samlResponseWithConditions(
                 issueInstant = now,
                 notBefore = null,
                 conditionsNotOnOrAfter = now.plus(Duration.ofMinutes(5)),
                 subjectNotOnOrAfter = now.plus(Duration.ofMinutes(5))
-            ),
-            "Invalid SAML Response: Expected exactly one Signature!"
+            )
         )
     }
 
@@ -257,14 +256,13 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     fun `SubjectConfirmationData NotOnOrAfter without conditions reaches signature validation`() {
         val now = Instant.now()
 
-        assertInvalidSamlResponse(
+        assertSamlTimestampValidationPasses(
             samlResponseWithConditions(
                 issueInstant = now,
                 notBefore = null,
                 conditionsNotOnOrAfter = null,
                 subjectNotOnOrAfter = now.plus(Duration.ofMinutes(5))
-            ),
-            "Invalid SAML Response: Expected exactly one Signature!"
+            )
         )
     }
 
@@ -272,14 +270,13 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     fun `Conditions NotOnOrAfter without SubjectConfirmationData deadline reaches signature validation`() {
         val now = Instant.now()
 
-        assertInvalidSamlResponse(
+        assertSamlTimestampValidationPasses(
             samlResponseWithConditions(
                 issueInstant = now,
                 notBefore = now.minus(Duration.ofSeconds(30)),
                 conditionsNotOnOrAfter = now.plus(Duration.ofMinutes(5)),
                 subjectNotOnOrAfter = null
-            ),
-            "Invalid SAML Response: Expected exactly one Signature!"
+            )
         )
     }
 
@@ -287,14 +284,13 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     fun `broad assertion validity window reaches signature validation`() {
         val now = Instant.now()
 
-        assertInvalidSamlResponse(
+        assertSamlTimestampValidationPasses(
             samlResponseWithConditions(
                 issueInstant = now.minus(Duration.ofMinutes(2)),
                 notBefore = now.minus(Duration.ofHours(2)),
                 conditionsNotOnOrAfter = now.plus(Duration.ofHours(2)),
                 subjectNotOnOrAfter = now.plus(Duration.ofHours(2))
-            ),
-            "Invalid SAML Response: Expected exactly one Signature!"
+            )
         )
     }
 
@@ -431,14 +427,13 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     fun `valid SAML time conditions reach signature validation`() {
         val now = Instant.now()
 
-        assertInvalidSamlResponse(
+        assertSamlTimestampValidationPasses(
             samlResponseWithConditions(
                 issueInstant = now,
                 notBefore = now.minus(Duration.ofSeconds(30)),
                 conditionsNotOnOrAfter = now.plus(Duration.ofMinutes(5)),
                 subjectNotOnOrAfter = now.plus(Duration.ofMinutes(4)).plusSeconds(30)
-            ),
-            "Invalid SAML Response: Expected exactly one Signature!"
+            )
         )
     }
 
@@ -649,6 +644,12 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
             }
 
             assertTrue(exception.message!!.contains(expectedMessagePart))
+        }
+
+        fun assertSamlTimestampValidationPasses(response: String) {
+            // These fixtures intentionally omit the XML signature. Reaching the signature check proves that timestamp
+            // validation accepted the response before the parser rejected the incomplete test document.
+            assertInvalidSamlResponse(response, "Invalid SAML Response: Expected exactly one Signature!")
         }
 
         fun assertHint(expectedFormat: String, expectedValue: String, actual: SamlUserHint) {

--- a/src/test/kotlin/sirius/biz/saml/SamlTest.kt
+++ b/src/test/kotlin/sirius/biz/saml/SamlTest.kt
@@ -289,12 +289,27 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
 
         assertInvalidSamlResponse(
             samlResponseWithConditions(
-                issueInstant = now.minus(Duration.ofMinutes(10)),
+                issueInstant = now.minus(Duration.ofMinutes(2)),
                 notBefore = now.minus(Duration.ofHours(2)),
                 conditionsNotOnOrAfter = now.plus(Duration.ofHours(2)),
                 subjectNotOnOrAfter = now.plus(Duration.ofHours(2))
             ),
             "Invalid SAML Response: Expected exactly one Signature!"
+        )
+    }
+
+    @Test
+    fun `SAML response older than local acceptance duration is rejected`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            samlResponseWithConditions(
+                issueInstant = now.minus(Duration.ofMinutes(8)),
+                notBefore = now.minus(Duration.ofHours(2)),
+                conditionsNotOnOrAfter = now.plus(Duration.ofHours(2)),
+                subjectNotOnOrAfter = now.plus(Duration.ofHours(2))
+            ),
+            "Invalid SAML Response: Invalid IssueInstant:"
         )
     }
 
@@ -457,6 +472,28 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
         assertEquals(
             SamlHelper.ABSOLUTE_MAX_ENCODED_SAML_RESPONSE_SIZE,
             SamlHelper.determineEffectiveMaxEncodedSamlResponseSize(-1)
+        )
+    }
+
+    @Test
+    fun `configured SAML response acceptance duration is capped by absolute maximum`() {
+        assertEquals(
+            SamlHelper.ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION,
+            SamlHelper.determineEffectiveMaxResponseAcceptanceDuration(
+                SamlHelper.ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION.plus(Duration.ofMinutes(1))
+            )
+        )
+    }
+
+    @Test
+    fun `non-positive SAML response acceptance duration falls back to absolute maximum`() {
+        assertEquals(
+            SamlHelper.ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION,
+            SamlHelper.determineEffectiveMaxResponseAcceptanceDuration(Duration.ZERO)
+        )
+        assertEquals(
+            SamlHelper.ABSOLUTE_MAX_RESPONSE_ACCEPTANCE_DURATION,
+            SamlHelper.determineEffectiveMaxResponseAcceptanceDuration(Duration.ofSeconds(-1))
         )
     }
 

--- a/src/test/kotlin/sirius/biz/saml/SamlTest.kt
+++ b/src/test/kotlin/sirius/biz/saml/SamlTest.kt
@@ -239,6 +239,51 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     }
 
     @Test
+    fun `SAML response without NotBefore reaches signature validation`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            samlResponseWithConditions(
+                issueInstant = now,
+                notBefore = null,
+                conditionsNotOnOrAfter = now.plus(Duration.ofMinutes(5)),
+                subjectNotOnOrAfter = now.plus(Duration.ofMinutes(5))
+            ),
+            "Invalid SAML Response: Expected exactly one Signature!"
+        )
+    }
+
+    @Test
+    fun `SubjectConfirmationData NotOnOrAfter without conditions reaches signature validation`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            samlResponseWithConditions(
+                issueInstant = now,
+                notBefore = null,
+                conditionsNotOnOrAfter = null,
+                subjectNotOnOrAfter = now.plus(Duration.ofMinutes(5))
+            ),
+            "Invalid SAML Response: Expected exactly one Signature!"
+        )
+    }
+
+    @Test
+    fun `Conditions NotOnOrAfter without SubjectConfirmationData deadline reaches signature validation`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            samlResponseWithConditions(
+                issueInstant = now,
+                notBefore = now.minus(Duration.ofSeconds(30)),
+                conditionsNotOnOrAfter = now.plus(Duration.ofMinutes(5)),
+                subjectNotOnOrAfter = null
+            ),
+            "Invalid SAML Response: Expected exactly one Signature!"
+        )
+    }
+
+    @Test
     fun `broad assertion validity window reaches signature validation`() {
         val now = Instant.now()
 
@@ -265,6 +310,90 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
                 subjectNotOnOrAfter = null
             ),
             "Invalid SAML Response: Missing NotOnOrAfter."
+        )
+    }
+
+    @Test
+    fun `multiple Conditions elements are rejected`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            """<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_assertion" IssueInstant="$now">
+        <Issuer>https://sso.example.test</Issuer>
+        <Subject>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <SubjectConfirmationData NotOnOrAfter="${now.plus(Duration.ofMinutes(5))}" />
+            </SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="${now.minus(Duration.ofSeconds(30))}" NotOnOrAfter="${now.plus(Duration.ofMinutes(5))}" />
+        <Conditions NotBefore="${now.minus(Duration.ofSeconds(30))}" NotOnOrAfter="${now.plus(Duration.ofMinutes(5))}" />
+    </Assertion>
+</samlp:Response>""",
+            "Invalid SAML Response: Expected at most one Conditions element."
+        )
+    }
+
+    @Test
+    fun `malformed NotBefore is rejected`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            """<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_assertion" IssueInstant="$now">
+        <Issuer>https://sso.example.test</Issuer>
+        <Subject>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <SubjectConfirmationData NotOnOrAfter="${now.plus(Duration.ofMinutes(5))}" />
+            </SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="tomorrow" NotOnOrAfter="${now.plus(Duration.ofMinutes(5))}" />
+    </Assertion>
+</samlp:Response>""",
+            "Invalid SAML Response: Invalid NotBefore: tomorrow"
+        )
+    }
+
+    @Test
+    fun `malformed NotOnOrAfter is rejected`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            """<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_assertion" IssueInstant="$now">
+        <Issuer>https://sso.example.test</Issuer>
+        <Subject>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <SubjectConfirmationData NotOnOrAfter="${now.plus(Duration.ofMinutes(5))}" />
+            </SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="${now.minus(Duration.ofSeconds(30))}" NotOnOrAfter="later" />
+    </Assertion>
+</samlp:Response>""",
+            "Invalid SAML Response: Invalid NotOnOrAfter: later"
+        )
+    }
+
+    @Test
+    fun `earliest SubjectConfirmationData NotOnOrAfter is used as effective deadline`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            """<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+    <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_assertion" IssueInstant="${now.minus(Duration.ofMinutes(4))}">
+        <Issuer>https://sso.example.test</Issuer>
+        <Subject>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <SubjectConfirmationData NotOnOrAfter="${now.plus(Duration.ofMinutes(5))}" />
+            </SubjectConfirmation>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <SubjectConfirmationData NotOnOrAfter="${now.minus(Duration.ofMinutes(3))}" />
+            </SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="${now.minus(Duration.ofMinutes(4))}" NotOnOrAfter="${now.plus(Duration.ofMinutes(10))}" />
+    </Assertion>
+</samlp:Response>""",
+            "Invalid SAML Response: Invalid NotOnOrAfter:"
         )
     }
 
@@ -354,6 +483,12 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     }
 
     @Test
+    fun `replay protection ignores absent response and assertion IDs`() {
+        assertTrue(replayProtector.reserve(null, null, Instant.now().plus(Duration.ofMinutes(5))))
+        assertTrue(replayProtector.reserve("", " ", Instant.now().plus(Duration.ofMinutes(5))))
+    }
+
+    @Test
     fun `SAML response fingerprint comparison normalizes configured trust source`() {
         val response = SamlResponse(
             "issuer",
@@ -395,7 +530,7 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
 
     private fun samlResponseWithConditions(
         issueInstant: Instant,
-        notBefore: Instant,
+        notBefore: Instant?,
         conditionsNotOnOrAfter: Instant?,
         subjectNotOnOrAfter: Instant?
     ): String {
@@ -407,6 +542,15 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
         val conditionsNotOnOrAfterAttribute = conditionsNotOnOrAfter?.let {
             " NotOnOrAfter=\"$it\""
         } ?: ""
+        val conditions = if (notBefore == null && conditionsNotOnOrAfter == null) {
+            ""
+        } else {
+            val notBeforeAttribute = notBefore?.let {
+                " NotBefore=\"$it\""
+            } ?: ""
+
+            "<Conditions$notBeforeAttribute$conditionsNotOnOrAfterAttribute />"
+        }
 
         return """<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
     <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_assertion" IssueInstant="$issueInstant">
@@ -416,7 +560,7 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
                 $subjectConfirmationData
             </SubjectConfirmation>
         </Subject>
-        <Conditions NotBefore="$notBefore"$conditionsNotOnOrAfterAttribute />
+        $conditions
     </Assertion>
 </samlp:Response>"""
     }

--- a/src/test/kotlin/sirius/biz/saml/SamlTest.kt
+++ b/src/test/kotlin/sirius/biz/saml/SamlTest.kt
@@ -239,17 +239,32 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     }
 
     @Test
-    fun `assertion validity longer than five minutes is rejected`() {
+    fun `broad assertion validity window reaches signature validation`() {
+        val now = Instant.now()
+
+        assertInvalidSamlResponse(
+            samlResponseWithConditions(
+                issueInstant = now.minus(Duration.ofMinutes(10)),
+                notBefore = now.minus(Duration.ofHours(2)),
+                conditionsNotOnOrAfter = now.plus(Duration.ofHours(2)),
+                subjectNotOnOrAfter = now.plus(Duration.ofHours(2))
+            ),
+            "Invalid SAML Response: Expected exactly one Signature!"
+        )
+    }
+
+    @Test
+    fun `missing effective NotOnOrAfter is rejected`() {
         val now = Instant.now()
 
         assertInvalidSamlResponse(
             samlResponseWithConditions(
                 issueInstant = now,
-                notBefore = now,
-                conditionsNotOnOrAfter = now.plus(Duration.ofMinutes(6)),
-                subjectNotOnOrAfter = now.plus(Duration.ofMinutes(6))
+                notBefore = now.minus(Duration.ofSeconds(30)),
+                conditionsNotOnOrAfter = null,
+                subjectNotOnOrAfter = null
             ),
-            "Invalid SAML Response: Assertion validity exceeds maximum duration"
+            "Invalid SAML Response: Missing NotOnOrAfter."
         )
     }
 
@@ -381,18 +396,27 @@ UtS2kvA28X4ToQg3REfK8K+MroixIpwVfdyHRCP4CsLrz4w+EJw4VlWAzJ45HFHg
     private fun samlResponseWithConditions(
         issueInstant: Instant,
         notBefore: Instant,
-        conditionsNotOnOrAfter: Instant,
-        subjectNotOnOrAfter: Instant
+        conditionsNotOnOrAfter: Instant?,
+        subjectNotOnOrAfter: Instant?
     ): String {
+        val subjectConfirmationData = if (subjectNotOnOrAfter == null) {
+            "<SubjectConfirmationData />"
+        } else {
+            """<SubjectConfirmationData NotOnOrAfter="$subjectNotOnOrAfter" />"""
+        }
+        val conditionsNotOnOrAfterAttribute = conditionsNotOnOrAfter?.let {
+            " NotOnOrAfter=\"$it\""
+        } ?: ""
+
         return """<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
     <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_assertion" IssueInstant="$issueInstant">
         <Issuer>https://sso.example.test</Issuer>
         <Subject>
             <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-                <SubjectConfirmationData NotOnOrAfter="$subjectNotOnOrAfter" />
+                $subjectConfirmationData
             </SubjectConfirmation>
         </Subject>
-        <Conditions NotBefore="$notBefore" NotOnOrAfter="$conditionsNotOnOrAfter" />
+        <Conditions NotBefore="$notBefore"$conditionsNotOnOrAfterAttribute />
     </Assertion>
 </samlp:Response>"""
     }

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -124,6 +124,7 @@ async {
 storage.sharedSecret = "storage-test-secret"
 
 security.saml.maxEncodedResponseSize = 64
+security.saml.maxResponseAcceptanceDuration = 5 minutes
 
 storage.buckets.versioned-files.maxNumberOfVersions = 2
 


### PR DESCRIPTION
### Description

This PR fixes SAML responses from IdPs that issue broad assertion condition windows, such as ADFS responses with several hours between `NotBefore` and `NotOnOrAfter`.

Instead of rejecting responses because the IdP condition window is broad, SAML responses are accepted when they are currently valid according to `IssueInstant`, optional `NotBefore`, and the effective earliest `NotOnOrAfter`. To keep stale responses and Redis replay retention bounded, the effective acceptance deadline is capped by a configurable duration after `Assertion@IssueInstant`, with an absolute maximum of 30 minutes.

Redis-backed replay protection reserves response/assertion IDs until the earlier of the SAML `NotOnOrAfter` deadline and the local acceptance deadline, plus clock skew. This keeps duplicate submissions blocked without allowing very distant IdP expiry timestamps to create long-lived replay keys.

The SAML tests now document the relevant edge cases: optional `NotBefore`, independent `NotOnOrAfter` sources, malformed timestamps, duplicate `Conditions`, earliest deadline selection, stale response rejection, config parsing for the acceptance duration, and replay behavior for absent IDs.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1201](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1201)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

### Test Plan

- `mvn -Dtest=sirius.biz.saml.SamlTest test`