### PR TITLE
Clean up some long standing deprecations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <url>https://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>50.2.1</sirius.kernel>
-        <sirius.web>101.0.0</sirius.web>
-        <sirius.db>67.0.2</sirius.db>
+        <sirius.kernel>51.0.0</sirius.kernel>
+        <sirius.web>102.0.0</sirius.web>
+        <sirius.db>68.0.0</sirius.db>
         <aws.sdk>2.44.9</aws.sdk>
     </properties>
 

--- a/src/main/java/sirius/biz/analytics/explorer/ChartFactory.java
+++ b/src/main/java/sirius/biz/analytics/explorer/ChartFactory.java
@@ -156,7 +156,7 @@ public abstract class ChartFactory<O> implements Named, Priorized {
             String identifier = resolver().fetchIdentifier((O) targetObject);
             try {
                 return resolver().resolve(identifier).map(ignored -> getName() + ":" + identifier).orElse(null);
-            } catch (Exception ignored) {
+            } catch (Exception _) {
                 // missing access to the target object may also be signaled by throwing an exception
                 return null;
             }

--- a/src/main/java/sirius/biz/analytics/flags/jdbc/SQLPerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/jdbc/SQLPerformanceData.java
@@ -30,7 +30,7 @@ public class SQLPerformanceData extends PerformanceData {
     protected long flags;
 
     /**
-     * Creeates a new instance for the given entity.
+     * Creates a new instance for the given entity.
      *
      * @param owner the entity in which this composite is embedded
      */

--- a/src/main/java/sirius/biz/analytics/flags/mongo/MongoPerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/mongo/MongoPerformanceData.java
@@ -32,7 +32,7 @@ public class MongoPerformanceData extends PerformanceData {
     protected final StringList flags = new StringList();
 
     /**
-     * Creeates a new instance for the given entity.
+     * Creates a new instance for the given entity.
      *
      * @param owner the entity in which this composite is embedded
      */

--- a/src/main/java/sirius/biz/analytics/metrics/MetricQuery.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricQuery.java
@@ -112,7 +112,7 @@ public class MetricQuery {
     }
 
     /**
-     * Speficies the object to query metrics for.
+     * Specifies the object to query metrics for.
      *
      * @param targetType the type of the entity to query metrics for
      * @param targetId   the id of the entity to query metrics for

--- a/src/main/java/sirius/biz/analytics/metrics/Metrics.java
+++ b/src/main/java/sirius/biz/analytics/metrics/Metrics.java
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * Provides a database independent API to store and retrieve metrics.
  * <p>
- * Metrics in this case are numerical values (integers) which are stored for an object in serveral time intervals.
+ * Metrics in this case are numerical values (integers) which are stored for an object in several time intervals.
  * <p>
  * Most metrics are most probably computed using a {@link DailyMetricComputer} or {@link MonthlyMetricComputer}.
  * However this API can also be used outside of such computers.

--- a/src/main/java/sirius/biz/cluster/Interconnect.java
+++ b/src/main/java/sirius/biz/cluster/Interconnect.java
@@ -21,7 +21,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 
 /**
- * Provides a pusblish / subscribe model to broadcast messages across all nodes of the cluster.
+ * Provides a publish / subscribe model to broadcast messages across all nodes of the cluster.
  */
 @Register(classes = {Interconnect.class, Subscriber.class})
 public class Interconnect implements Subscriber {
@@ -40,7 +40,7 @@ public class Interconnect implements Subscriber {
 
     /**
      * Contains the name of the key which is used to extract the handler class for handling an
-     * incoming mesage.
+     * incoming message.
      */
     public static final String HANDLER = "_handler";
 

--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -413,7 +413,7 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
         Value setting = Sirius.getSettings().get("orchestration." + key);
         try {
             targetMap.put(key, SynchronizeType.valueOf(setting.toUpperCase()));
-        } catch (IllegalArgumentException exception) {
+        } catch (IllegalArgumentException _) {
             Cluster.LOG.WARN("Invalid configuration found for orchestration." + key + ": " + setting);
             targetMap.put(key, SynchronizeType.LOCAL);
         }

--- a/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
  * scheduled. Additionally, prioritized queues are supported. For these queues a <tt>penalty token</tt>
  * per task is supplied (e.g. a user or tenant id). The system then counts the number of already queued
  * tasks for this token and computes a penalty time. Now if now other tasks are queued, a task with a
- * penalty time applied will still be immediatelly executed. However, as soon as other tasks are scheduled
+ * penalty time applied will still be immediately executed. However, as soon as other tasks are scheduled
  * a task might be delayed up until its penalty time is over. Currently, the penalty time is a static
  * value set in the system configuration and multiplied by the number of already queued tasks. Therefore, this
  * should be roughly equal to the estimated execution time.
@@ -115,7 +115,7 @@ public class DistributedTasks implements MetricProvider {
     /**
      * Contains the index of the queue in {@link #sortedTaskQueues} to pull work from.
      * <p>
-     * Work is pulled in a round-robin fasion and this index contains the next queue to try to poll.
+     * Work is pulled in a round-robin fashion, and this index contains the next queue to try to poll.
      */
     private final AtomicInteger nextQueueToFetchWorkFrom = new AtomicInteger(0);
 
@@ -303,7 +303,7 @@ public class DistributedTasks implements MetricProvider {
     }
 
     /**
-     * Feteches the config for the given queue.
+     * Fetches the config for the given queue.
      *
      * @param queueName the name of the queue to fetch the config for
      * @return the config of the given queue

--- a/src/main/java/sirius/biz/cluster/work/RedisNamedCounters.java
+++ b/src/main/java/sirius/biz/cluster/work/RedisNamedCounters.java
@@ -53,7 +53,7 @@ class RedisNamedCounters implements NamedCounters {
         } else {
             try {
                 return Optional.of(Long.parseLong(value));
-            } catch (NumberFormatException exception) {
+            } catch (NumberFormatException _) {
                 Exceptions.handle()
                           .to(Log.BACKGROUND)
                           .withSystemErrorMessage("Failed to parse counter value '%s' in counter '%s' of '%s'",
@@ -98,14 +98,14 @@ class RedisNamedCounters implements NamedCounters {
         }
 
         long nextCounterValue = Math.max(0, counterValue.get() - 1);
-        Transaction txn = db.multi();
+        Transaction transaction = db.multi();
         if (nextCounterValue == 0) {
-            txn.hdel(name, counter);
+            transaction.hdel(name, counter);
         } else {
-            txn.hset(name, counter, String.valueOf(nextCounterValue));
+            transaction.hset(name, counter, String.valueOf(nextCounterValue));
         }
 
-        List<?> response = txn.exec();
+        List<?> response = transaction.exec();
         if (response == null || response.isEmpty()) {
             return null;
         } else {

--- a/src/main/java/sirius/biz/cluster/work/WorkLoaderLoop.java
+++ b/src/main/java/sirius/biz/cluster/work/WorkLoaderLoop.java
@@ -90,7 +90,7 @@ public class WorkLoaderLoop extends BackgroundLoop {
                     schedulerLock.unlock();
                 }
             }
-        } catch (InterruptedException exception) {
+        } catch (InterruptedException _) {
             Thread.currentThread().interrupt();
         }
     }

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -249,7 +249,8 @@ class IDBLookupTable extends LookupTable {
         try {
             return table.query()
                         .lookupPaths(codeField)
-                        .searchValue(code).singleRow(SOURCE.columnName())
+                        .searchValue(code)
+                        .singleRow(SOURCE.columnName())
                         .map(row -> makeObject(type, Json.parseObject(row.at(0).asString())));
         } catch (Exception exception) {
             Exceptions.createHandled()
@@ -357,7 +358,7 @@ class IDBLookupTable extends LookupTable {
                                  DEPRECATED.columnName(),
                                  PERMISSION.columnName(),
                                  SOURCE.columnName())
-                        .filter(row -> filterRequiredPermission(row))
+                        .filter(this::filterRequiredPermission)
                         .map(this::processSearchOrScanRow)
                         .limit(limit.getMaxItems() == 0 ? Long.MAX_VALUE : limit.getMaxItems());
         } catch (Exception exception) {

--- a/src/main/java/sirius/biz/elastic/AutoBatchLoop.java
+++ b/src/main/java/sirius/biz/elastic/AutoBatchLoop.java
@@ -97,7 +97,7 @@ public class AutoBatchLoop extends BackgroundLoop {
         signalLock.lock();
         try {
             return loopExecuted.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException interruptedException) {
+        } catch (InterruptedException _) {
             Thread.currentThread().interrupt();
             return false;
         } finally {

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -16,8 +16,6 @@ import sirius.biz.importer.txn.ImportTransactionalEntity;
 import sirius.biz.process.ErrorContext;
 import sirius.biz.process.logs.ProcessLog;
 import sirius.biz.protocol.Journaled;
-import sirius.biz.protocol.TraceData;
-import sirius.biz.protocol.Traced;
 import sirius.biz.web.TenantAware;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.EntityDescriptor;

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandlerExtender.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandlerExtender.java
@@ -35,7 +35,7 @@ public abstract class SQLEntityImportHandlerExtender<E extends SQLEntity> implem
      * @param handler       the handler which can be extended
      * @param descriptor    the descriptor determining what kind of entities are processed by the given handler
      * @param context       the surrounding importer context
-     * @param queryConsumer the collector which consumes additiona find queries
+     * @param queryConsumer the collector which consumes additional find queries
      */
     public void collectFindQueries(SQLEntityImportHandler<E> handler,
                                    EntityDescriptor descriptor,

--- a/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
+++ b/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
@@ -61,7 +61,7 @@ public class DateTimeFormatCheck implements ValueCheck {
         String stringValue = value.asString();
         try {
             LocalDate.parse(stringValue, formatter);
-        } catch (DateTimeParseException exception) {
+        } catch (DateTimeParseException _) {
             throw new IllegalArgumentException(NLS.fmtr("DateTimeFormatCheck.errorMsg")
                                                   .set("value", stringValue)
                                                   .set("format", format)

--- a/src/main/java/sirius/biz/importer/txn/ImportTransactionHelper.java
+++ b/src/main/java/sirius/biz/importer/txn/ImportTransactionHelper.java
@@ -225,12 +225,12 @@ public class ImportTransactionHelper extends ImportHelper {
 
     /**
      * Sets a new value for the source.
+     * <p>
+     * IMPORTANT: Only use this method if you are sure that you want to change the source in one and the same transaction.
      * This is useful e.g. in migration scenarios where the source in one transaction could be different.
      *
      * @param source the new source
-     * @deprecated Only use this method if you are sure that you want to change the source in one and the same transaction.
      */
-    @Deprecated
     public void setSource(String source) {
         this.source = source;
     }

--- a/src/main/java/sirius/biz/isenguard/RateLimitReportJobFactory.java
+++ b/src/main/java/sirius/biz/isenguard/RateLimitReportJobFactory.java
@@ -13,7 +13,6 @@ import sirius.biz.analytics.reports.Report;
 import sirius.biz.jobs.StandardCategories;
 import sirius.biz.jobs.interactive.ReportJobFactory;
 import sirius.biz.jobs.params.Parameter;
-import sirius.kernel.async.CallContext;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.web.http.WebContext;

--- a/src/main/java/sirius/biz/jobs/JobsController.java
+++ b/src/main/java/sirius/biz/jobs/JobsController.java
@@ -80,7 +80,7 @@ public class JobsController extends BizController {
     public void job(WebContext webContext, String jobType) {
         try {
             jobs.findFactory(jobType, JobFactory.class).startInteractively(webContext);
-        } catch (IllegalArgumentException exception) {
+        } catch (IllegalArgumentException _) {
             UserContext.get()
                        .addMessage(Message.error()
                                           .withTextMessage(NLS.fmtr("JobsController.unknownJob")
@@ -155,7 +155,7 @@ public class JobsController extends BizController {
         try {
             JobFactory factory = jobs.findFactory(jobType, JobFactory.class);
             output.property("process", factory.startInBackground(webContext::get));
-        } catch (IllegalArgumentException exception) {
+        } catch (IllegalArgumentException _) {
             throw Exceptions.createHandled()
                             .withDirectMessage(Strings.apply("Unknown factory: %s", jobType))
                             .hint(Controller.HTTP_STATUS, HttpResponseStatus.NOT_FOUND.code())

--- a/src/main/java/sirius/biz/jobs/batch/SimpleBatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/SimpleBatchProcessJobFactory.java
@@ -20,7 +20,7 @@ import sirius.biz.process.ProcessContext;
  * factory itself.
  * <p>
  * For more complex jobs which need to keep their parameters in fields and which also might want to split their
- * logic into several methods, subclass {@link BatchProcessJobFactory} (or its pre-defined sublcasses) and provide
+ * logic into several methods, subclass {@link BatchProcessJobFactory} (or its pre-defined subclasses) and provide
  * a custom {@link BatchJob}.
  */
 public abstract class SimpleBatchProcessJobFactory extends BatchProcessJobFactory {

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveExportJob.java
@@ -46,7 +46,7 @@ public abstract class ArchiveExportJob extends FileExportJob {
      *
      * @param fileName the name of the archived file
      * @return a new output stream that points to the created entry
-     * @throws IOException in case the output stream couln't be created
+     * @throws IOException in case the output stream couldn't be created
      */
     @Nonnull
     protected OutputStream createEntry(String fileName) throws IOException {

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -16,7 +16,6 @@ import sirius.biz.util.ExtractedFile;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Callback;
 import sirius.kernel.commons.Context;
-import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.UnitOfWork;
 import sirius.web.data.LineBasedProcessor;

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
@@ -180,7 +180,7 @@ public class EntityImportJob<E extends BaseEntity<?>> extends DictionaryBasedImp
     /**
      * Creates or updates the given entity.
      * <p>
-     * This can be overwritten to use a custom way of persisting data. Also this can be used to perfrom
+     * This can be overwritten to use a custom way of persisting data. Also this can be used to perform
      * post-save activities.
      * <p>
      * By default we instantly create or update the entity. Note that if this is set to batch updates,

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJob.java
@@ -117,14 +117,13 @@ public abstract class LineBasedExportJob extends FileExportJob {
      */
     protected void createExport() {
         ExportFileType type = determineEffectiveFileType();
-        if (type == ExportFileType.CSV) {
-            export = new ExportCSV(new OutputStreamWriter(createOutputStream()));
-        } else if (type == ExportFileType.XLS) {
-            export = new ExportXLS(this::createOutputStream);
-        } else if (type == ExportFileType.XLSX) {
-            export = new ExportXLSX(this::createOutputStream);
-        } else {
-            throw Exceptions.createHandled().withSystemErrorMessage("Unknown export file format: %s", type).handle();
-        }
+        export = switch (type) {
+            case ExportFileType.CSV -> new ExportCSV(new OutputStreamWriter(createOutputStream()));
+            case ExportFileType.XLS -> new ExportXLS(this::createOutputStream);
+            case ExportFileType.XLSX -> new ExportXLSX(this::createOutputStream);
+            case null -> throw Exceptions.createHandled()
+                                         .withSystemErrorMessage("Unknown export file format: %s", type)
+                                         .handle();
+        };
     }
 }

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJob.java
@@ -118,9 +118,9 @@ public abstract class LineBasedExportJob extends FileExportJob {
     protected void createExport() {
         ExportFileType type = determineEffectiveFileType();
         export = switch (type) {
-            case ExportFileType.CSV -> new ExportCSV(new OutputStreamWriter(createOutputStream()));
-            case ExportFileType.XLS -> new ExportXLS(this::createOutputStream);
-            case ExportFileType.XLSX -> new ExportXLSX(this::createOutputStream);
+            case CSV -> new ExportCSV(new OutputStreamWriter(createOutputStream()));
+            case XLS -> new ExportXLS(this::createOutputStream);
+            case XLSX -> new ExportXLSX(this::createOutputStream);
             case null -> throw Exceptions.createHandled()
                                          .withSystemErrorMessage("Unknown export file format: %s", type)
                                          .handle();

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportExportJob.java
@@ -11,7 +11,6 @@ package sirius.biz.jobs.batch.file;
 import sirius.biz.process.ProcessContext;
 import sirius.kernel.commons.Values;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -79,7 +78,7 @@ public abstract class LineBasedImportExportJob extends LineBasedImportJob {
 
     @Override
     public void close() throws IOException {
-        try (Closeable c = exportJob) {
+        try (var _ = exportJob) {
             super.close();
         }
     }

--- a/src/main/java/sirius/biz/jobs/interactive/InteractiveJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/InteractiveJobFactory.java
@@ -39,7 +39,7 @@ public abstract class InteractiveJobFactory extends BasicJobFactory {
     private Tasks tasks;
 
     /**
-     * Provides the <tt>Cells</tt> helper for all sub classses which is used to populate a <tt>Report</tt>.
+     * Provides the <tt>Cells</tt> helper for all sub classes which is used to populate a <tt>Report</tt>.
      */
     @Part
     protected Cells cells;

--- a/src/main/java/sirius/biz/jobs/presets/jdbc/SQLJobPreset.java
+++ b/src/main/java/sirius/biz/jobs/presets/jdbc/SQLJobPreset.java
@@ -16,7 +16,7 @@ import sirius.db.mixing.annotations.TranslationSource;
 import sirius.kernel.di.std.Framework;
 
 /**
- * Provices the entity to store a {@link JobPreset} in a JDBC database.
+ * Provides the entity to store a {@link JobPreset} in a JDBC database.
  */
 @TranslationSource(JobPreset.class)
 @Framework(SQLJobPresets.FRAMEWORK_PRESETS_JDBC)

--- a/src/main/java/sirius/biz/jobs/presets/mongo/MongoJobPreset.java
+++ b/src/main/java/sirius/biz/jobs/presets/mongo/MongoJobPreset.java
@@ -16,7 +16,7 @@ import sirius.db.mixing.annotations.TranslationSource;
 import sirius.kernel.di.std.Framework;
 
 /**
- * Provices the entity to store a {@link JobPreset} in a MongoDB database.
+ * Provides the entity to store a {@link JobPreset} in a MongoDB database.
  */
 @TranslationSource(JobPreset.class)
 @Framework(MongoJobPresets.FRAMEWORK_PRESETS_MONGO)

--- a/src/main/java/sirius/biz/jupiter/JupiterConnector.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnector.java
@@ -70,7 +70,7 @@ public class JupiterConnector {
     /**
      * Returns the instance (config) name of this Jupiter instance.
      *
-     * @return the name of the config instace being used
+     * @return the name of the config instance being used
      */
     public String getName() {
         return instanceName;
@@ -133,10 +133,9 @@ public class JupiterConnector {
                                       RedisDB main,
                                       RedisDB fallback,
                                       Runnable executeOnFailover) {
-        try (Operation op = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME);
-             Jedis jedis = main.getConnection()) {
+        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME); Jedis jedis = main.getConnection()) {
             return perform(description, jedis, task);
-        } catch (JedisConnectionException ignored) {
+        } catch (JedisConnectionException _) {
             executeOnFailover.run();
             return performWithoutFailover(description, task, fallback);
         } catch (Exception exception) {
@@ -145,7 +144,7 @@ public class JupiterConnector {
     }
 
     private <T> T performWithoutFailover(Supplier<String> description, Function<Connection, T> task, RedisDB redis) {
-        try (Operation op = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME);
+        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME);
              Jedis jedis = redis.getConnection()) {
             return perform(description, jedis, task);
         } catch (Exception exception) {
@@ -172,7 +171,7 @@ public class JupiterConnector {
     /**
      * Executes one or more commands and returns a value of the given type without attempting a failover.
      * <p>
-     * If the main connection pool isn't available, this will not perform a failover but abort immediatelly.
+     * If the main connection pool isn't available, this will not perform a failover but abort immediately.
      * This can be used to execute administrative commands, which have to be executed on the target instance.
      *
      * @param description a description of the actions performed used for debugging and tracing
@@ -181,7 +180,7 @@ public class JupiterConnector {
      * @return a result computed by <tt>task</tt>
      */
     public <T> T queryDirect(Supplier<String> description, Function<Connection, T> task) {
-        try (Operation op = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME);
+        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME);
              Jedis jedis = redis.getConnection()) {
             return perform(description, jedis, task);
         } catch (Exception error) {

--- a/src/main/java/sirius/biz/jupiter/JupiterSync.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSync.java
@@ -72,7 +72,7 @@ public class JupiterSync implements Startable, EndOfDayTask {
      * <p>
      * After the repository contents have been synced (or more exactly, their sync has been requested) we ask jupiter
      * to increment the epochs (basically a simple counter) for the frontend and backend actors. As the frontend
-     * actor will immediatelly incement its value but the background actor will put this task into its internal queue,
+     * actor will immediately increment its value but the background actor will put this task into its internal queue,
      * we know that once the values are the same again, all background tasks which were previously scheduled, are
      * completed.
      * <p>

--- a/src/main/java/sirius/biz/jupiter/LRUCacheConfigUpdater.java
+++ b/src/main/java/sirius/biz/jupiter/LRUCacheConfigUpdater.java
@@ -19,7 +19,7 @@ import java.util.Map;
 /**
  * Updates the config for all known LRU caches.
  * <p>
- * This essentailly reads the settings from the <tt>caches</tt> block.
+ * This essentially reads the settings from the <tt>caches</tt> block.
  */
 @Register
 public class LRUCacheConfigUpdater implements JupiterConfigUpdater {

--- a/src/main/java/sirius/biz/locks/BasicLockManager.java
+++ b/src/main/java/sirius/biz/locks/BasicLockManager.java
@@ -47,7 +47,7 @@ public abstract class BasicLockManager implements LockManager {
     }
 
     /**
-     * If the lock is already aquired, this returns the initial amount of milliseconds to wait.
+     * If the lock is already acquired, this returns the initial amount of milliseconds to wait.
      *
      * @return the duration of the first interval until a new attempt is made to acquire a lock
      */
@@ -69,7 +69,7 @@ public abstract class BasicLockManager implements LockManager {
     protected abstract int getMaxWait();
 
     /**
-     * Actually obtains a lock and returns immediatelly.
+     * Actually obtains a lock and returns immediately.
      *
      * @param lockName the name of the lock to acquire.
      * @return <tt>true</tt> if the lock was obtained, <tt>false</tt> otherwise

--- a/src/main/java/sirius/biz/locks/LockManager.java
+++ b/src/main/java/sirius/biz/locks/LockManager.java
@@ -24,7 +24,7 @@ public interface LockManager extends Named {
      * Tries to acquire the lock with the given name within the given interval.
      *
      * @param lockName       the name of the lock to acquire.
-     * @param acquireTimeout the max time to wait for a lock. Used <tt>null</tt> to immediatelly return if a lock
+     * @param acquireTimeout the max time to wait for a lock. Used <tt>null</tt> to immediately return if a lock
      *                       cannot be obtained.
      * @return <tt>true</tt> if the lock was acquired, <tt>false</tt> otherwise
      */
@@ -34,7 +34,7 @@ public interface LockManager extends Named {
      * Tries to acquire the lock with the given name within the given interval.
      *
      * @param lockName       the name of the lock to acquire.
-     * @param acquireTimeout the max time to wait for a lock. Used <tt>null</tt> to immediatelly return if a lock
+     * @param acquireTimeout the max time to wait for a lock. Used <tt>null</tt> to immediately return if a lock
      *                       cannot be obtained.
      * @param lockTimeout    the max duration for which the lock will be kept before auto-releasing it.
      * @return <tt>true</tt> if the lock was acquired, <tt>false</tt> otherwise

--- a/src/main/java/sirius/biz/locks/jdbc/SQLLockManager.java
+++ b/src/main/java/sirius/biz/locks/jdbc/SQLLockManager.java
@@ -106,7 +106,7 @@ public class SQLLockManager extends BasicLockManager {
             }
 
             deleteStatement.executeUpdate();
-        } catch (SQLException exception) {
+        } catch (SQLException _) {
             throw Exceptions.handle()
                             .to(OMA.LOG)
                             .withSystemErrorMessage("An error occurred while unlocking %s: %s - %s", lock)

--- a/src/main/java/sirius/biz/model/ResaveEntitiesJobFactory.java
+++ b/src/main/java/sirius/biz/model/ResaveEntitiesJobFactory.java
@@ -116,13 +116,13 @@ public class ResaveEntitiesJobFactory extends DefaultBatchProcessFactory {
                     descriptor.getMapper().update(entity);
                 }
                 if (performValidation) {
-                    List<String> validationgErrors = descriptor.getMapper().validate(entity);
-                    if (!validationgErrors.isEmpty()) {
+                    List<String> validationErrors = descriptor.getMapper().validate(entity);
+                    if (!validationErrors.isEmpty()) {
                         process.log(ProcessLog.warn()
                                               .withFormattedMessage("Entity %s with id: %s has validation warnings:\n%s",
                                                                     entity.toString(),
                                                                     entity.getIdAsString(),
-                                                                    String.join("\n", validationgErrors)));
+                                                                    String.join("\n", validationErrors)));
 
                         process.addTiming("Validation-Error", watch.elapsedMillis());
                     }

--- a/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
@@ -84,7 +84,7 @@ public abstract class PrefixSearchableEntity extends MongoEntity {
     /**
      * Creates the tokenizer to use.
      *
-     * @return a new tokenier used to fill the search prefix list
+     * @return a new tokenizer used to fill the search prefix list
      */
     protected Tokenizer createPrefixTokenizer() {
         return new PrefixTokenizer();

--- a/src/main/java/sirius/biz/packages/PackageData.java
+++ b/src/main/java/sirius/biz/packages/PackageData.java
@@ -87,7 +87,7 @@ public class PackageData extends Composite {
      * Creates a new instance for the given owner.
      *
      * @param owner the owner entity which contains this composite.
-     * @param scope the scope used to determine which packages and updgrades to consider
+     * @param scope the scope used to determine which packages and upgrades to consider
      */
     public PackageData(BaseEntity<?> owner, String scope) {
         this.owner = owner;

--- a/src/main/java/sirius/biz/process/ProcessState.java
+++ b/src/main/java/sirius/biz/process/ProcessState.java
@@ -33,7 +33,7 @@ public enum ProcessState {
     RUNNING,
 
     /**
-     * Represents a prcoess which is running but the user already tried to cancel it.
+     * Represents a process which is running but the user already tried to cancel it.
      */
     CANCELED,
 

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -339,7 +339,7 @@ public class ProcessLog extends SearchableEntity {
     }
 
     /**
-     * Specifies the {@link ProcessOutput} to which this log entry belogs.
+     * Specifies the {@link ProcessOutput} to which this log entry belongs.
      *
      * @param output the name of the output this entry belongs to
      * @return the log entry itself for fluent method calls

--- a/src/main/java/sirius/biz/process/logs/ProcessLogHandler.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLogHandler.java
@@ -52,7 +52,7 @@ public interface ProcessLogHandler extends Named {
      * @param action    the name of the action to execute
      * @param returnUrl the url to eventually redirect to, once the action is fully completed
      * @return <tt>true</tt> if the action was executed (or its execution was started) and the request has been
-     * respondedm <tt>false</tt> if the system should generate a response
+     * responded, <tt>false</tt> if the system should generate a response
      */
     boolean executeAction(WebContext request, Process process, ProcessLog log, String action, String returnUrl);
 }

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -69,7 +69,7 @@ public class JournalData extends Composite {
         try {
             String changes = buildChangeJournal();
 
-            if (changes.length() > 0) {
+            if (Strings.isFilled(changes)) {
                 addJournalEntry(owner, changes, batchLog);
             }
         } catch (Exception exception) {

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -155,8 +155,13 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
             // The first element of the causal chain is always the throwable followed by its cause hierarchy.
             // Therefore, the first element is skipped.
             Throwables.getCausalChain(throwable).stream().skip(1).forEach(cause -> {
-                stringBuilder.append("\n").append("Caused by: ").append(cause.getClass().getName()).append(":").append("\n");
-                stringBuilder.append(truncateErrorMessage(determineErrorMessage(cause), numberOfCharactersPerMessage)).append("\n\n");
+                stringBuilder.append("\n")
+                             .append("Caused by: ")
+                             .append(cause.getClass().getName())
+                             .append(":")
+                             .append("\n");
+                stringBuilder.append(truncateErrorMessage(determineErrorMessage(cause), numberOfCharactersPerMessage))
+                             .append("\n\n");
             });
         } catch (IllegalArgumentException exception) {
             // This happens if the causal chain has a circular reference.
@@ -179,13 +184,15 @@ public class Protocols implements LogTap, ExceptionHandler, MailLog {
 
     private String truncateErrorMessage(String errorMessage, int length) {
         int charsToPreserveFromStart = Math.max(0, length - NUMBER_OF_CHARS_TO_PRESERVE_AT_THE_END_OF_AN_ERROR_MESSAGE);
-        return Strings.truncateMiddle(errorMessage, charsToPreserveFromStart, NUMBER_OF_CHARS_TO_PRESERVE_AT_THE_END_OF_AN_ERROR_MESSAGE);
+        return Strings.truncateMiddle(errorMessage,
+                                      charsToPreserveFromStart,
+                                      NUMBER_OF_CHARS_TO_PRESERVE_AT_THE_END_OF_AN_ERROR_MESSAGE);
     }
 
     private int calcCharactersPerMessage(Throwable throwable) {
         try {
             return maxMessageLength / Throwables.getCausalChain(throwable).size();
-        } catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException _) {
             return maxMessageLength;
         }
     }

--- a/src/main/java/sirius/biz/sequences/jdbc/SQLSequenceStrategy.java
+++ b/src/main/java/sirius/biz/sequences/jdbc/SQLSequenceStrategy.java
@@ -60,7 +60,7 @@ public class SQLSequenceStrategy implements SequenceStrategy {
                                 .where(SequenceCounter.NEXT_VALUE, result.getNextValue())
                                 .executeUpdate();
         if (numRowsChanged == 1) {
-            // Nobody else changed the counter, so we can savely return the determined value...
+            // Nobody else changed the counter, so we can safely return the determined value...
             return result.getNextValue();
         }
 

--- a/src/main/java/sirius/biz/sequences/mongo/MongoSequenceStrategy.java
+++ b/src/main/java/sirius/biz/sequences/mongo/MongoSequenceStrategy.java
@@ -70,7 +70,7 @@ public class MongoSequenceStrategy implements SequenceStrategy {
                                    .getModifiedCount();
 
         if (numRowsChanged == 1) {
-            // Nobody else changed the counter, so we can savely return the determined value...
+            // Nobody else changed the counter, so we can safely return the determined value...
             return result;
         }
 

--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpaceFactory.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpaceFactory.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
  * Creates an instance of {@link FSObjectStorageSpace} for each Layer 1 storage space which specified <b>fs</b> as engine.
  */
 @Register(framework = StorageUtils.FRAMEWORK_STORAGE)
-public class FSObjectStorageSpaceFactory implements ObjectStoraceSpaceFactory {
+public class FSObjectStorageSpaceFactory implements ObjectStorageSpaceFactory {
 
     @Override
     public ObjectStorageSpace create(String name, Extension extension) throws Exception{

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
@@ -44,7 +44,7 @@ public class ObjectStorage {
      */
     public static final String CONFIG_KEY_LAYER1_ENGINE = "engine";
     /**
-     * Contains the config attribute which determines which {@link ObjectStoraceSpaceFactory} to use for a space.
+     * Contains the config attribute which determines which {@link ObjectStorageSpaceFactory} to use for a space.
      */
     public static final String CONFIG_KEY_LAYER1_COMPRESSION = "compression";
     /**
@@ -91,9 +91,9 @@ public class ObjectStorage {
 
     private ObjectStorageSpace createSpace(Extension extension) {
         try {
-            ObjectStoraceSpaceFactory factory =
+            ObjectStorageSpaceFactory factory =
                     globalContext.findPart(extension.get(CONFIG_KEY_LAYER1_ENGINE).asString(),
-                                           ObjectStoraceSpaceFactory.class);
+                                           ObjectStorageSpaceFactory.class);
 
             return factory.create(extension.getId(), extension);
         } catch (Exception exception) {

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpaceFactory.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpaceFactory.java
@@ -16,7 +16,7 @@ import sirius.kernel.settings.Extension;
  * <p>
  * The effective factory is selected by the {@link ObjectStorage#CONFIG_KEY_LAYER1_ENGINE} setting.
  */
-public interface ObjectStoraceSpaceFactory extends Named {
+public interface ObjectStorageSpaceFactory extends Named {
 
     /**
      * Creates a {@link ObjectStorageSpace} for the given Layer 1 storage space.

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpaceFactory.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpaceFactory.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
  * Creates an instance of {@link S3ObjectStorageSpace} for each Layer 1 storage space which specified <b>s3</b> as engine.
  */
 @Register(framework = StorageUtils.FRAMEWORK_STORAGE)
-public class S3ObjectStorageSpaceFactory implements ObjectStoraceSpaceFactory {
+public class S3ObjectStorageSpaceFactory implements ObjectStorageSpaceFactory {
 
     @Override
     public ObjectStorageSpace create(String name, Extension extension) throws Exception {

--- a/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskExecutor.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskExecutor.java
@@ -17,7 +17,7 @@ import sirius.kernel.di.std.Part;
 import javax.annotation.Nullable;
 
 /**
- * Responsible to transfering batches of replication tasks back to
+ * Responsible to transferring batches of replication tasks back to
  * {@link ReplicationTaskStorage#executeBatch(ObjectNode)}.
  *
  * @see ReplicationTaskStorage

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTask.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTask.java
@@ -88,7 +88,7 @@ public class SQLReplicationTask extends SQLEntity {
     private boolean performDelete;
 
     /**
-     * Stores if this task has ultimatively failed.
+     * Stores if this task has ultimately failed.
      */
     public static final Mapping FAILED = Mapping.named("failed");
     private boolean failed;

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTask.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTask.java
@@ -93,7 +93,7 @@ public class MongoReplicationTask extends MongoEntity {
     private boolean performDelete;
 
     /**
-     * Stores if this task has ultimatively failed.
+     * Stores if this task has ultimately failed.
      */
     public static final Mapping FAILED = Mapping.named("failed");
     private boolean failed;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/CompressionLevel.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/CompressionLevel.java
@@ -21,7 +21,7 @@ public enum CompressionLevel {
     OFF(Deflater.NO_COMPRESSION),
 
     /**
-     * Fast compession ({@link Deflater#BEST_SPEED}).
+     * Fast compression ({@link Deflater#BEST_SPEED}).
      */
     FAST(Deflater.BEST_SPEED),
 

--- a/src/main/java/sirius/biz/storage/layer1/transformer/DeflateTransformer.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/DeflateTransformer.java
@@ -30,7 +30,7 @@ public class DeflateTransformer implements ByteBlockTransformer {
     private final byte[] deflateBuffer = new byte[TransformingInputStream.DEFAULT_BUFFER_SIZE];
 
     /**
-     * Creates a new trasformer using the given compression level.
+     * Creates a new transformer using the given compression level.
      *
      * @param level the compression level to use
      */

--- a/src/main/java/sirius/biz/storage/layer1/transformer/SecretKeyCipherProvider.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/SecretKeyCipherProvider.java
@@ -15,7 +15,7 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 
 /**
- * Represents a provider which uses a {@link SecretKey} to create an appropriate encryption and decrpytion {@link Cipher}.
+ * Represents a provider which uses a {@link SecretKey} to create an appropriate encryption and decryption {@link Cipher}.
  */
 public class SecretKeyCipherProvider implements CipherProvider {
 

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -174,7 +174,7 @@ public abstract class BasicBlobStorageSpace<B extends Blob & OptimisticCreate, D
     private static final String CONFIG_KEY_SORT_BY_LAST_MODIFIED = "sortByLastModified";
 
     /**
-     * Contains the name of the algorith used to compute the checksum of uploaded files.
+     * Contains the name of the algorithm used to compute the checksum of uploaded files.
      */
     private static final String CONFIG_KEY_CHECKSUM_ALGORITHM = "checksumAlgorithm";
 

--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcherHook.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcherHook.java
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
 /**
  * Gets invoked once the {@link BlobDispatcher} completely delivered a {@link Blob}.
  * <p>
- * This can be triggered by invoking {@link URLBuilder#withHook(String, String)}. The paylod
+ * This can be triggered by invoking {@link URLBuilder#withHook(String, String)}. The payload
  * should be short an concise (e.g. a database id). Also note that the payload is by default
  * not protected by any signature or other cryptographic framework as this is mostly used
  * by statistic / logging tasks. If such a protection is required, it has to be enforced

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorage.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorage.java
@@ -47,7 +47,7 @@ public abstract class BlobStorage {
     }
 
     /**
-     * Creates the storage spaceusing the given config.
+     * Creates the storage space using the given config.
      *
      * @param config the settings to use when creating the space
      * @return a wrapper which is used to access the objects stored in the storage space

--- a/src/main/java/sirius/biz/storage/layer2/Directory.java
+++ b/src/main/java/sirius/biz/storage/layer2/Directory.java
@@ -33,7 +33,7 @@ public interface Directory {
     /**
      * Returns the name of the {@link #getStorageSpace() storage space}.
      *
-     * @return the name of the stroage space in which this directory resides.
+     * @return the name of the storage space in which this directory resides.
      */
     String getSpaceName();
 

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLVariant.java
@@ -9,7 +9,6 @@
 package sirius.biz.storage.layer2.jdbc;
 
 import sirius.biz.storage.layer1.FileHandle;
-import sirius.biz.storage.layer2.BasicBlobStorageSpace;
 import sirius.biz.storage.layer2.variants.BlobVariant;
 import sirius.db.jdbc.SQLEntity;
 import sirius.db.jdbc.SQLEntityRef;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoVariant.java
@@ -9,7 +9,6 @@
 package sirius.biz.storage.layer2.mongo;
 
 import sirius.biz.storage.layer1.FileHandle;
-import sirius.biz.storage.layer2.BasicBlobStorageSpace;
 import sirius.biz.storage.layer2.variants.BlobVariant;
 import sirius.db.mixing.Mapping;
 import sirius.db.mixing.annotations.AfterDelete;

--- a/src/main/java/sirius/biz/storage/layer2/variants/BlobVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/BlobVariant.java
@@ -9,7 +9,6 @@
 package sirius.biz.storage.layer2.variants;
 
 import sirius.biz.storage.layer1.FileHandle;
-import sirius.biz.storage.layer2.BasicBlobStorageSpace;
 import sirius.biz.storage.layer2.Blob;
 
 import javax.annotation.Nullable;

--- a/src/main/java/sirius/biz/storage/layer3/FindOnlyProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/FindOnlyProvider.java
@@ -12,9 +12,9 @@ import javax.annotation.Nullable;
 import java.util.function.BiFunction;
 
 /**
- * Represents a {@link ChildProvider} which can only resolve files / direcoties but never enumerate them.
+ * Represents a {@link ChildProvider} which can only resolve files / directories but never enumerate them.
  * <p>
- * This is useful for virtual folders which accept (non-exisiting) child files, which are then processed elsewhere.
+ * This is useful for virtual folders which accept (non-existing) child files, which are then processed elsewhere.
  */
 public class FindOnlyProvider implements ChildProvider {
 

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeUserManager.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeUserManager.java
@@ -91,7 +91,7 @@ class BridgeUserManager implements UserManager {
                                            .getUserManager()
                                            .findUserByCredentials(null, effectiveUserName, auth.getPassword());
             if (authUser == null) {
-                StorageUtils.LOG.FINE("Layer 3/FTP: Invalid credentails...");
+                StorageUtils.LOG.FINE("Layer 3/FTP: Invalid credentials...");
                 throw new AuthenticationFailedException("Invalid credentials.");
             }
 

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeDirectoryStream.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeDirectoryStream.java
@@ -19,7 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Provides an interface between NIO and the <tt>FileSystem</tt> API torwards {@link VirtualFile#children(FileSearch)}.
+ * Provides an interface between NIO and the <tt>FileSystem</tt> API towards {@link VirtualFile#children(FileSearch)}.
  */
 public class BridgeDirectoryStream implements DirectoryStream<Path> {
 

--- a/src/main/java/sirius/biz/storage/legacy/BucketInfo.java
+++ b/src/main/java/sirius/biz/storage/legacy/BucketInfo.java
@@ -105,7 +105,7 @@ public class BucketInfo {
     /**
      * Determines if a user can create new objects in this bucket.
      *
-     * @return <tt>true</tt> if a user can create net objects, fale<tt>false</tt> otherwise
+     * @return <tt>true</tt> if a user can create net objects, <tt>false</tt> otherwise
      */
     public boolean isCanCreate() {
         return canCreate;

--- a/src/main/java/sirius/biz/storage/legacy/BucketInfo.java
+++ b/src/main/java/sirius/biz/storage/legacy/BucketInfo.java
@@ -105,7 +105,7 @@ public class BucketInfo {
     /**
      * Determines if a user can create new objects in this bucket.
      *
-     * @return <tt>true</tt> if a user can create net objects, <tt>false</tt> otherwise
+     * @return <tt>true</tt> if a user can create new objects, <tt>false</tt> otherwise
      */
     public boolean isCanCreate() {
         return canCreate;

--- a/src/main/java/sirius/biz/storage/legacy/DownloadBuilder.java
+++ b/src/main/java/sirius/biz/storage/legacy/DownloadBuilder.java
@@ -102,7 +102,7 @@ public class DownloadBuilder {
     }
 
     /**
-     * Make the URL a downlod url using the given filename.
+     * Make the URL a download url using the given filename.
      *
      * @param filename the filename to send to the browser
      * @return the builder itself for fluent method calls

--- a/src/main/java/sirius/biz/storage/legacy/Storage.java
+++ b/src/main/java/sirius/biz/storage/legacy/Storage.java
@@ -159,7 +159,7 @@ public class Storage {
      * Tries to find the object with the given id, for the given tenant and bucket.
      * <p>
      * Uses a cache for the {@link VirtualObject virtual objects}. When fetching an object from the cache, the buckets
-     * and tennants are compared to ensure integrity. Only non-temporary objects are cached.
+     * and tenants are compared to ensure integrity. Only non-temporary objects are cached.
      *
      * @param tenant the tenant to filter on
      * @param bucket the bucket to search in
@@ -458,7 +458,7 @@ public class Storage {
     /**
      * Creates a new output stream which updates the contents of the given file.
      * <p>
-     * Note that most probably, the file will be updated once the stream is closed and not immediatelly on a write.
+     * Note that most probably, the file will be updated once the stream is closed and not immediately on a write.
      * Also note that it is essential to close the stream to release underlying resources.
      *
      * @param file the file to update.
@@ -515,7 +515,7 @@ public class Storage {
     }
 
     /**
-     * Delivers a pyhsical file or object.
+     * Delivers a physical file or object.
      *
      * @param webContext    the request to respond to
      * @param bucket        the bucket to deliver from

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -437,7 +437,7 @@ public class ObjectStore {
         try {
             client.headBucket(HeadBucketRequest.builder().bucket(bucket.getName()).build());
             return true;
-        } catch (NoSuchBucketException exception) {
+        } catch (NoSuchBucketException _) {
             return false;
         } catch (S3Exception exception) {
             if (exception.statusCode() == HttpResponseStatus.NOT_FOUND.code()) {
@@ -508,23 +508,23 @@ public class ObjectStore {
      * @throws FileNotFoundException if the requested object does not exist
      */
     public File download(BucketName bucket, String objectId) throws FileNotFoundException {
-        File dest = null;
+        File destination = null;
         try (var _ = new Operation(() -> Strings.apply("S3: Downloading object %s from %s", objectId, bucket),
                                    Duration.ofHours(4))) {
-            dest = File.createTempFile("AMZS3", null);
+            destination = File.createTempFile("AMZS3", null);
             ensureBucketExists(bucket);
             transferManager.downloadFile(DownloadFileRequest.builder()
                                                             .getObjectRequest(GetObjectRequest.builder()
                                                                                               .bucket(bucket.getName())
                                                                                               .key(objectId)
                                                                                               .build())
-                                                            .destination(dest)
+                                                            .destination(destination)
                                                             .addTransferListener(new MonitoringProgressListener(false))
                                                             .build()).completionFuture().get();
-            return dest;
+            return destination;
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
-            Files.delete(dest);
+            Files.delete(destination);
 
             throw Exceptions.handle()
                             .to(ObjectStores.LOG)
@@ -534,22 +534,15 @@ public class ObjectStore {
                                     bucket,
                                     objectId)
                             .handle();
-        } catch (S3Exception exception) {
-            Files.delete(dest);
-            if (isNotFound(exception)) {
-                throw new FileNotFoundException(objectId);
-            } else {
-                throw handleDownloadError(bucket, objectId, exception);
-            }
-        } catch (ExecutionException exception) {
-            Files.delete(dest);
+        } catch (S3Exception | ExecutionException exception) {
+            Files.delete(destination);
             if (isNotFound(exception)) {
                 throw new FileNotFoundException(objectId);
             } else {
                 throw handleDownloadError(bucket, objectId, exception);
             }
         } catch (Exception exception) {
-            Files.delete(dest);
+            Files.delete(destination);
             throw handleDownloadError(bucket, objectId, exception);
         }
     }
@@ -669,7 +662,10 @@ public class ObjectStore {
      * @param metadata the metadata for the object
      * @return kind of a promise used to monitor the upload progress
      */
-    public FileUpload uploadAsync(BucketName bucket, String objectId, File data, @Nullable Map<String, String> metadata) {
+    public FileUpload uploadAsync(BucketName bucket,
+                                  String objectId,
+                                  File data,
+                                  @Nullable Map<String, String> metadata) {
         try {
             ensureBucketExists(bucket);
             return transferManager.uploadFile(UploadFileRequest.builder()
@@ -981,8 +977,8 @@ public class ObjectStore {
                                                      .partNumber(partNumber)
                                                      .build();
         String eTag = getClient().uploadPart(request,
-                                            RequestBody.fromInputStream(new ByteBufInputStream(buffer),
-                                                                        buffer.readableBytes())).eTag();
+                                             RequestBody.fromInputStream(new ByteBufInputStream(buffer),
+                                                                         buffer.readableBytes())).eTag();
         return CompletedPart.builder().partNumber(partNumber).eTag(eTag).build();
     }
 

--- a/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 /**
  * Wraps an {@link OutputStream} and provides a {@link Future completion future}.
  * <p>
- * The future is fullfilled once the stream is closed.
+ * The future is fulfilled once the stream is closed.
  */
 public class WatchableOutputStream extends OutputStream {
 

--- a/src/main/java/sirius/biz/tenants/ProfileController.java
+++ b/src/main/java/sirius/biz/tenants/ProfileController.java
@@ -175,7 +175,7 @@ public class ProfileController<I extends Serializable, T extends BaseEntity<I> &
         }
 
         if (!Strings.areEqual(newPassword, confirmation)) {
-            UserContext.setFieldError("confirmation", null);
+            UserContext.setFieldError(PARAM_CONFIRMATION, null);
             throw Exceptions.createHandled().withNLSKey("Model.password.confirmationMismatch").handle();
         }
 
@@ -205,4 +205,3 @@ public class ProfileController<I extends Serializable, T extends BaseEntity<I> &
         }
     }
 }
-

--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -604,11 +604,6 @@ public class TenantData extends Composite implements Journaled {
         return journal;
     }
 
-    @Deprecated
-    public LookupValue getLang() {
-        return language;
-    }
-
     public LookupValue getLanguage() {
         return language;
     }

--- a/src/main/java/sirius/biz/tenants/UserAccountData.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountData.java
@@ -31,7 +31,6 @@ import sirius.db.mixing.annotations.Transient;
 import sirius.db.mixing.annotations.Trim;
 import sirius.db.mixing.annotations.ValidatedBy;
 import sirius.db.mixing.types.StringList;
-import sirius.kernel.Sirius;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
@@ -369,7 +368,8 @@ public class UserAccountData extends Composite implements MessageProvider {
      * @return <tt>true</tt> if this user belongs to the current user's tenant, <tt>false</tt> otherwise
      */
     public boolean isOwnTenant() {
-        return Objects.equals(UserContext.getCurrentUser().as(UserAccount.class).getTenant().getIdAsString(), getTenant().getIdAsString());
+        return Objects.equals(UserContext.getCurrentUser().as(UserAccount.class).getTenant().getIdAsString(),
+                              getTenant().getIdAsString());
     }
 
     /**
@@ -449,11 +449,6 @@ public class UserAccountData extends Composite implements MessageProvider {
 
     public void setExternalLoginRequired(boolean externalLoginRequired) {
         this.externalLoginRequired = externalLoginRequired;
-    }
-
-    @Deprecated
-    public LookupValue getLang() {
-        return language;
     }
 
     public LookupValue getLanguage() {

--- a/src/main/java/sirius/biz/tenants/deletion/DeleteTenantTask.java
+++ b/src/main/java/sirius/biz/tenants/deletion/DeleteTenantTask.java
@@ -34,7 +34,7 @@ public interface DeleteTenantTask extends Priorized {
     void beforeExecution(ProcessContext process, Tenant<?> tenant, boolean simulate);
 
     /**
-     * Called to actually perfrom the delete.
+     * Called to actually perform the delete.
      * <p>
      * This will <b>not</b> be called in a simulation run.
      * <p>

--- a/src/main/java/sirius/biz/tenants/flags/CustomizationFlag.java
+++ b/src/main/java/sirius/biz/tenants/flags/CustomizationFlag.java
@@ -31,6 +31,7 @@ public class CustomizationFlag {
      *
      * @param name         the name of the flag to use
      * @param defaultValue the default value to use if no config is present
+     * @return the created flag
      */
     public static CustomizationFlag create(String name, boolean defaultValue) {
         CustomizationFlag flag = new CustomizationFlag(name, defaultValue);

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntry.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntry.java
@@ -144,16 +144,6 @@ public class KnowledgeBaseEntry extends SearchableEntity {
         this.chapter = chapter;
     }
 
-    @Deprecated
-    public String getLang() {
-        return language;
-    }
-
-    @Deprecated
-    public void setLang(String lang) {
-        this.language = lang;
-    }
-
     public String getLanguage() {
         return language;
     }

--- a/src/main/java/sirius/biz/tycho/kb/README.md
+++ b/src/main/java/sirius/biz/tycho/kb/README.md
@@ -16,6 +16,6 @@ applications.
 
 To create an article, use the **k:article** tag, for chapters use **k:chapter**.
 
-Note that articles are not imediatelly available after a system restart as the end of day task
+Note that articles are not immediately available after a system restart as the end of day task
 **synchronize-knowledgebase** has to run. This can be forced by running `eod synchronize-knowledgebase`
 in the console.

--- a/src/main/java/sirius/biz/util/ExtractedFile.java
+++ b/src/main/java/sirius/biz/util/ExtractedFile.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
 import java.time.LocalDateTime;
 
 /**
- * Represents a file which has been extraced from an archive by the {@link ArchiveExtractor}.
+ * Represents a file which has been extracted from an archive by the {@link ArchiveExtractor}.
  */
 public interface ExtractedFile {
 

--- a/src/main/java/sirius/biz/util/LocalArchiveExtractCallback.java
+++ b/src/main/java/sirius/biz/util/LocalArchiveExtractCallback.java
@@ -117,7 +117,7 @@ public class LocalArchiveExtractCallback implements IArchiveExtractCallback {
         }
         for (int i = 0; i < filePathBytes.length - 1; i++) {
             // Windows saves zip entry file paths in IBM437 Codepage,
-            // the 7z lib interpretates them as Unicode code points and we retrieve them in UTF-8.
+            // the 7z lib interprets them as Unicode code points and we retrieve them in UTF-8.
             //
             // This way
             // ... special characters in IBM437 (80..bf) become Control Characters (c2 80..9f)
@@ -151,7 +151,7 @@ public class LocalArchiveExtractCallback implements IArchiveExtractCallback {
     private String attemptToFixEncodingErrors(@Nonnull String filePath) {
         byte[] filePathBytes = filePath.getBytes(StandardCharsets.UTF_8);
         for (int i = 0; i < filePathBytes.length - 3; i++) {
-            // The bug interpretates UTF-8 as ISO-8859-1 (which doubles the number of characters)
+            // The bug interprets UTF-8 as ISO-8859-1 (which doubles the number of characters)
             // and converts them back to UTF-8.
             // This way all possible 2-byte UTF-8 bytes (c0..df 80..bf) become 4 bytes: (c3 80..9f c2 80..bf)
             if (filePathBytes[i] == (byte) 0xc3

--- a/src/main/java/sirius/biz/util/SOAPCallEvent.java
+++ b/src/main/java/sirius/biz/util/SOAPCallEvent.java
@@ -64,7 +64,7 @@ public class SOAPCallEvent extends Event<SOAPCallEvent> implements UserEvent {
 
     /**
      * Contains the fault message (if the corresponding soap response contained a fault element)
-     * or the root cause message (if there was an exception whilse sending/receiving the request/response).
+     * or the root cause message (if there was an exception while sending/receiving the request/response).
      */
     public static final Mapping ERROR_MESSAGE = Mapping.named("errorMessage");
     @Trim

--- a/src/main/java/sirius/biz/util/ZipBuilder.java
+++ b/src/main/java/sirius/biz/util/ZipBuilder.java
@@ -67,7 +67,7 @@ public class ZipBuilder implements Closeable {
      *
      * @param path      the path to use when creating the ZIP entry
      * @param fileToAdd the file to add to the archive
-     * @throws IOException in case of an IO error while reading or writing data. Note that once an IO error ocurrend,
+     * @throws IOException in case of an IO error while reading or writing data. Note that once an IO error occurred,
      *                     all subsequently emitted ZIP archives might be broken and should not be used. Still,
      *                     {@link FileHandle#close()} and {@link #close()} must be invoked to release all temporary
      *                     data.
@@ -108,9 +108,9 @@ public class ZipBuilder implements Closeable {
         }
     }
 
-
     /**
      * Provides a boilerplate method to directly add a <tt>FileHandle</tt> to the ZIP archive.
+     *
      * @param path      the path to use when creating the ZIP entry
      * @param fileToAdd the file to add. Note that {@link FileHandle#close()} will not be invoked for the given
      *                  handle.

--- a/src/main/java/sirius/biz/web/BizLegacyGlobalsHandler.java
+++ b/src/main/java/sirius/biz/web/BizLegacyGlobalsHandler.java
@@ -12,7 +12,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.compiler.LegacyGlobalsHandler;
 
 /**
- * Replaces magic constants which were proviously automatically available in Tagliatelle.
+ * Replaces magic constants which were previously automatically available in Tagliatelle.
  */
 @Register
 public class BizLegacyGlobalsHandler extends LegacyGlobalsHandler {

--- a/src/main/java/sirius/biz/web/MongoPageHelper.java
+++ b/src/main/java/sirius/biz/web/MongoPageHelper.java
@@ -75,20 +75,6 @@ public class MongoPageHelper<E extends MongoEntity>
      * @param field    the field to aggregate on
      * @param enumType the type of enums in this field used for proper translation
      * @return the helper itself for fluent method calls
-     *
-     * @deprecated Use {@link #addEnumTermAggregation(Mapping, Class)} instead
-     */
-    @Deprecated(since = "2024/11/04", forRemoval = true)
-    public MongoPageHelper<E> addTermAggregation(Mapping field, Class<? extends Enum<?>> enumType) {
-        return addEnumTermAggregation(field, enumType);
-    }
-
-    /**
-     * Adds an automatic facet for values in the given field.
-     *
-     * @param field    the field to aggregate on
-     * @param enumType the type of enums in this field used for proper translation
-     * @return the helper itself for fluent method calls
      */
     public MongoPageHelper<E> addEnumTermAggregation(Mapping field, Class<? extends Enum<?>> enumType) {
         return addEnumTermAggregation(baseQuery.getDescriptor().findProperty(field.toString()).getLabel(),

--- a/src/main/java/sirius/biz/web/MongoPageHelperExtender.java
+++ b/src/main/java/sirius/biz/web/MongoPageHelperExtender.java
@@ -28,7 +28,7 @@ public interface MongoPageHelperExtender<E extends MongoEntity> extends Priorize
     void extend(MongoPageHelper<E> pageHelper);
 
     /**
-     * Returns the target entity type addresed by this extender.
+     * Returns the target entity type addressed by this extender.
      *
      * @return the target entity for which the page helper is to be extended
      */

--- a/src/main/java/sirius/biz/web/SQLPageHelperExtender.java
+++ b/src/main/java/sirius/biz/web/SQLPageHelperExtender.java
@@ -28,7 +28,7 @@ public interface SQLPageHelperExtender<E extends SQLEntity> extends Priorized {
     void extend(SQLPageHelper<E> pageHelper);
 
     /**
-     * Returns the target entity type addresed by this extender.
+     * Returns the target entity type addressed by this extender.
      *
      * @return the target entity for which the page helper is to be extended
      */

--- a/src/main/resources/default/assets/stylesheets/multiLanguageField.scss
+++ b/src/main/resources/default/assets/stylesheets/multiLanguageField.scss
@@ -52,7 +52,7 @@ input.form-control.mls-input {
   align-items: flex-end;
   flex-direction: row-reverse;
 
-  // We supress a border/separation between tab and textarea input
+  // We suppress a border/separation between tab and textarea input
   margin-bottom: -1px;
 }
 
@@ -68,7 +68,7 @@ input.form-control.mls-input {
   }
 
   .nav-tabs > li {
-    // We supress a border/separation between tab and textarea input
+    // We suppress a border/separation between tab and textarea input
     border-bottom: 1px solid #ffffff;
   }
 

--- a/src/test/java/sirius/biz/importer/SQLTenantImportHandler.java
+++ b/src/test/java/sirius/biz/importer/SQLTenantImportHandler.java
@@ -19,7 +19,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
- * Provides a test importer used for SQL tenants and alsi in {@link ImporterSpec}.
+ * Provides a test importer used for SQL tenants and also in {@link ImporterTest}.
  */
 public class SQLTenantImportHandler extends SQLEntityImportHandler<SQLTenant> {
 


### PR DESCRIPTION
### BREAKING CHANGES

**Removed deprecations:**

- `TenantData.getLang()` → use `getLanguage()`
- `UserAccountData.getLang()` → use `getLanguage()`
- `KnowledgeBaseEntry.getLang()` → use `getLanguage()`
- `KnowledgeBaseEntry.setLang(String)` → use `setLanguage(String)`
- `MongoPageHelper.addTermAggregation(Mapping, Class)` → use `addEnumTermAggregation(Mapping, Class)`
- `ImportTransactionHelper.setSource(String)` is no longer marked deprecated (behavior unchanged; Javadoc still warns about transactional use)
- Renames `ObjectStoraceSpaceFactory` → `ObjectStorageSpaceFactory` (typo) - No Usage outside of sirius-biz

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1220](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1220)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
