### PR TITLE
Inherit sirius webs dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,4 +173,18 @@
             <version>10.9</version>
         </dependency>
     </dependencies>
+
+    <!-- Inherit the dependency management from sirius-web to ensure consistent versions across all modules -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.scireum</groupId>
+                <artifactId>sirius-web</artifactId>
+                <version>${sirius.web}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>


### PR DESCRIPTION
### Description
Inherit sirius webs dependency management so the netty bom from web gets used to ensure consistent versions in web to. Previously the awssdk provided netty dependencies did lead to a resolution of netty libraries in different versions

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
