### PR TITLE
Enforce rate-limit for backend-login

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -12,6 +12,8 @@ import com.typesafe.config.Config;
 import sirius.biz.analytics.events.EventRecorder;
 import sirius.biz.analytics.events.UserActivityEvent;
 import sirius.biz.analytics.flags.PerformanceFlag;
+import sirius.biz.isenguard.Isenguard;
+import sirius.biz.isenguard.RateLimitingInfo;
 import sirius.biz.model.LoginData;
 import sirius.biz.protocol.AuditLog;
 import sirius.biz.web.SpyUser;
@@ -27,6 +29,7 @@ import sirius.kernel.di.PartCollection;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
@@ -151,6 +154,11 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
     private static final String SUFFIX_FINGERPRINT = "-fingerprint";
 
     /**
+     * Contains the Isenguard realm used to limit negative security events like failed password login attempts.
+     */
+    public static final String SECURITY_RATE_LIMIT_REALM = "security";
+
+    /**
      * Contains the prefix added to the account number which is added as artificial role.
      * <p>
      * Therefore, each user of a tenant has the following additional role (if filled):
@@ -177,6 +185,9 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
 
     @Part
     protected static AuditLog auditLog;
+
+    @Part
+    protected static Isenguard isenguard;
 
     @Part
     protected static EventRecorder eventRecorder;
@@ -627,9 +638,10 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
             return null;
         }
 
-        UserInfo result = findUserByName(webContext, user);
+        verifyLoginRateLimitNotReached(webContext);
+
+        UserInfo result = findUserByNameForPasswordLogin(webContext, user);
         if (result == null) {
-            auditLog.negative("AuditLog.lockedOrNonexistentUserTriedLogin").forUser(null, user).log();
             return null;
         }
 
@@ -641,6 +653,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
                                                                                         tenant.getTenantData()
                                                                                               .getExternalLoginIntervalDays())) {
             completeAuditLogForUser(auditLog.negative("AuditLog.externalLoginRequired"), account);
+            registerFailedLoginAttempt(webContext);
             throw Exceptions.createHandled().withNLSKey("UserAccount.externalLoginMustBePerformed").handle();
         }
 
@@ -665,7 +678,51 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
                 .forTenant(tenant.getIdAsString(), tenant.getTenantData().getName())
                 .log();
 
+        registerFailedLoginAttempt(webContext);
         return null;
+    }
+
+    private UserInfo findUserByNameForPasswordLogin(@Nullable WebContext webContext, String user) {
+        try {
+            UserInfo result = findUserByName(webContext, user);
+            if (result != null) {
+                return result;
+            }
+        } catch (HandledException _) {
+            // Locked accounts must not be distinguishable from nonexistent users during password login.
+        }
+
+        auditLog.negative("AuditLog.lockedOrNonexistentUserTriedLogin").forUser(null, user).log();
+        registerFailedLoginAttempt(webContext);
+        return null;
+    }
+
+    private void verifyLoginRateLimitNotReached(@Nullable WebContext webContext) {
+        if (webContext == null) {
+            return;
+        }
+
+        String ip = webContext.getRemoteIP().getHostAddress();
+        if (isenguard.checkRateLimitReached(ip, SECURITY_RATE_LIMIT_REALM)) {
+            throw isenguard.createException(SECURITY_RATE_LIMIT_REALM);
+        }
+    }
+
+    private void registerFailedLoginAttempt(@Nullable WebContext webContext) {
+        if (webContext == null) {
+            return;
+        }
+
+        String ip = webContext.getRemoteIP().getHostAddress();
+        boolean rateLimitReached =
+                isenguard.registerCallAndCheckRateLimitReached(ip,
+                                                               SECURITY_RATE_LIMIT_REALM,
+                                                               Isenguard.USE_LIMIT_FROM_CONFIG,
+                                                               () -> RateLimitingInfo.fromWebContext(webContext,
+                                                                                                     null));
+        if (rateLimitReached) {
+            throw isenguard.createException(SECURITY_RATE_LIMIT_REALM);
+        }
     }
 
     protected void completeAuditLogForUser(AuditLog.AuditLogBuilder builder, U account) {

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -33,6 +33,7 @@ import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.http.WebContext;
 import sirius.web.security.GenericUserManager;
 import sirius.web.security.Permissions;
@@ -41,6 +42,7 @@ import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
 import sirius.web.security.UserManager;
 import sirius.web.security.UserSettings;
+import sirius.web.util.CaptchaController;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -159,6 +161,11 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
     public static final String SECURITY_RATE_LIMIT_REALM = "security";
 
     /**
+     * Contains the number of failed password login attempts after which the next attempt requires a CAPTCHA.
+     */
+    private static final int FAILED_PASSWORD_LOGIN_ATTEMPTS_BEFORE_CAPTCHA = 4;
+
+    /**
      * Contains the prefix added to the account number which is added as artificial role.
      * <p>
      * Therefore, each user of a tenant has the following additional role (if filled):
@@ -188,6 +195,9 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
 
     @Part
     protected static Isenguard isenguard;
+
+    @Part
+    protected static CaptchaController captchaController;
 
     @Part
     protected static EventRecorder eventRecorder;
@@ -639,6 +649,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         }
 
         verifyLoginRateLimitNotReached(webContext);
+        verifyPasswordLoginCaptchaIfRequired(webContext);
 
         UserInfo result = findUserByNameForPasswordLogin(webContext, user);
         if (result == null) {
@@ -680,6 +691,30 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
 
         registerFailedLoginAttempt(webContext);
         return null;
+    }
+
+    /**
+     * Determines if the next password login attempt requires a CAPTCHA for the current caller.
+     *
+     * @param webContext the current web request to inspect
+     * @return <tt>true</tt> if a CAPTCHA has to be solved, <tt>false</tt> otherwise
+     */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
+    public static boolean isPasswordLoginCaptchaRequired(@Nullable WebContext webContext) {
+        if (webContext == null) {
+            return false;
+        }
+
+        String ip = webContext.getRemoteIP().getHostAddress();
+        return isenguard.checkRateLimitReached(ip,
+                                               SECURITY_RATE_LIMIT_REALM,
+                                               FAILED_PASSWORD_LOGIN_ATTEMPTS_BEFORE_CAPTCHA);
+    }
+
+    private void verifyPasswordLoginCaptchaIfRequired(@Nullable WebContext webContext) {
+        if (isPasswordLoginCaptchaRequired(webContext)) {
+            captchaController.verifyCaptcha(webContext);
+        }
     }
 
     private UserInfo findUserByNameForPasswordLogin(@Nullable WebContext webContext, String user) {

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -714,12 +714,12 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         }
 
         String ip = webContext.getRemoteIP().getHostAddress();
-        boolean rateLimitReached =
-                isenguard.registerCallAndCheckRateLimitReached(ip,
-                                                               SECURITY_RATE_LIMIT_REALM,
-                                                               Isenguard.USE_LIMIT_FROM_CONFIG,
-                                                               () -> RateLimitingInfo.fromWebContext(webContext,
-                                                                                                     null));
+        boolean rateLimitReached = isenguard.registerCallAndCheckRateLimitReached(ip,
+                                                                                  SECURITY_RATE_LIMIT_REALM,
+                                                                                  Isenguard.USE_LIMIT_FROM_CONFIG,
+                                                                                  () -> RateLimitingInfo.fromWebContext(
+                                                                                          webContext,
+                                                                                          null));
         if (rateLimitReached) {
             throw isenguard.createException(SECURITY_RATE_LIMIT_REALM);
         }

--- a/src/main/resources/component-070-biz.conf
+++ b/src/main/resources/component-070-biz.conf
@@ -223,10 +223,10 @@ isenguard {
         }
 
         # Specifies the constraints for negative AuditLog events (wrong password etc).
-        # Once this limit is hit, the calling IP will be blocked for ten minutes.
+        # Once this limit is hit, further matching calls will be rejected until the current interval has elapsed.
         security {
             interval = 2m
-            limit = 50
+            limit = 10
             type = "ip"
         }
     }

--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -52,6 +52,11 @@
                                     <i class="fa fa-eye" id="passwordToggleIcon" style="cursor: pointer;"></i>
                                 </span>
                             </div>
+                            <i:if test="@sirius.biz.tenants.TenantUserManager.isPasswordLoginCaptchaRequired(WebContext.getCurrent())">
+                                <div class="form-group mb-3">
+                                    <t:captcha hideLogo="true" hideFooter="true"/>
+                                </div>
+                            </i:if>
                             <div>
                                 <input type="checkbox" tabindex="4" value="true" name="keepLogin" checked/>
                                 <span>@i18n('Model.login.keepLogin')</span>

--- a/src/test/kotlin/sirius/biz/tenants/TenantUserManagerTest.kt
+++ b/src/test/kotlin/sirius/biz/tenants/TenantUserManagerTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.tenants
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.biz.tenants.jdbc.SQLTenantUserManager
+import sirius.db.jdbc.OMA
+import sirius.kernel.SiriusExtension
+import sirius.kernel.di.std.Part
+import sirius.kernel.health.HandledException
+import sirius.web.http.WebContext
+import sirius.web.security.UserContext
+import java.time.Duration
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests the [TenantUserManager].
+ */
+@ExtendWith(SiriusExtension::class)
+class TenantUserManagerTest {
+
+    @Test
+    fun `Only failed password logins count towards rate limit`() {
+        TenantsHelper.getTestUser()
+
+        val userManager = UserContext.get().userManager as SQLTenantUserManager
+        val webContext = WebContext.getCurrent()
+
+        assertNotNull(userManager.findUserByCredentials(webContext, "test", "test"))
+        assertNull(userManager.findUserByCredentials(webContext, "test", "wrong-password-1"))
+        assertNull(userManager.findUserByCredentials(webContext, "test", "wrong-password-2"))
+
+        assertThrows<HandledException> {
+            userManager.findUserByCredentials(webContext, "test", "wrong-password-3")
+        }
+    }
+
+    companion object {
+        @Part
+        @JvmStatic
+        private lateinit var oma: OMA
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            oma.readyFuture.await(Duration.ofSeconds(60))
+        }
+    }
+}

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -102,6 +102,12 @@ isenguard.limit.test {
     limit = 5
 }
 
+isenguard.limit.security {
+    interval = 1m
+    limit = 3
+    type = "ip"
+}
+
 async {
     distributed {
         queues {


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
it seems, that there was rate-limiting years ago, but got removed in https://github.com/scireum/sirius-biz/commit/613257814#diff-11ffed5b48f839e6d599427f3f00a4510ef156fd08267b2fb8b92c1ac138cebeL48-L49 the security-block is now adjusted to only allow 10 wrong logins in 2 minutes, then the rate-limit will stop the user earlier for trying more users/passwords

<img width="1032" height="671" alt="Bildschirmfoto 2026-05-27 um 16 04 51" src="https://github.com/user-attachments/assets/38f975e9-a8b6-488e-8b5c-469f4f4b83d2" />

- after the 4th bad login a Captcha is included now in the login-form which should be ok for real users with typos


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1217](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1217)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
