### PR TITLE
Permits forcing buffered events to be persisted

### DIFF
--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -89,7 +89,7 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
     private static final String AGGREGATION_SUM = "summation";
     private static final String AGGREGATION_DISTINCT_COUNT = "distinctCount";
 
-    private LocalDateTime lastProcessed;
+    private volatile LocalDateTime lastProcessed;
     private final AtomicInteger bufferedEvents = new AtomicInteger();
     private final Queue<Event<?>> buffer = new ConcurrentLinkedQueue<>();
 

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -480,7 +480,7 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
      *
      * @return the number of inserted events
      */
-    protected int process() {
+    public synchronized int process() {
         lastProcessed = LocalDateTime.now();
         int processedEvents = 0;
         try (BatchContext ctx = new BatchContext(() -> "Process recorded events.", Duration.ofMinutes(1))) {


### PR DESCRIPTION
### Description

Events are collected in a buffer and written in batches when we reach a minimum number of events, or they are buffered for a certain time.

We make the method public so a caller can force that to happen independent on buffer size or age. Useful for cases where events just submitted must be evaluated.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12518](https://scireum.myjetbrains.com/youtrack/issue/OX-12518)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
