### PR TITLE
Permits ad-hoc save and evaluation of buffered events 

### DIFF
--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -89,7 +89,7 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
     private static final String AGGREGATION_SUM = "summation";
     private static final String AGGREGATION_DISTINCT_COUNT = "distinctCount";
 
-    private LocalDateTime lastProcessed;
+    private volatile LocalDateTime lastProcessed;
     private final AtomicInteger bufferedEvents = new AtomicInteger();
     private final Queue<Event<?>> buffer = new ConcurrentLinkedQueue<>();
 
@@ -480,7 +480,7 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
      *
      * @return the number of inserted events
      */
-    protected int process() {
+    public synchronized int process() {
         lastProcessed = LocalDateTime.now();
         int processedEvents = 0;
         try (BatchContext ctx = new BatchContext(() -> "Process recorded events.", Duration.ofMinutes(1))) {

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -453,6 +453,18 @@ public class EventRecorder implements Startable, Stoppable, MetricProvider {
     }
 
     /**
+     * Provides a stream of all events currently in the buffer. Note that this is not a synchronized view on the buffer
+     * and might contain events which are already processed or might not contain events which are added after stream initialization.
+     * <p>
+     * The events in the stream should be used solely for evaluation and shall not be modified!
+     *
+     * @return a stream of all events currently in the buffer
+     */
+    public Stream<Event<?>> fetchBufferedEvents() {
+        return buffer.stream();
+    }
+
+    /**
      * Invoked periodically by the {@link EventProcessorLoop} to process events if necessary.
      * <p>
      * An insertion run will be started if there are enough events in the buffer (more than {@link #MIN_BUFFER_SIZE})

--- a/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
+++ b/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
@@ -57,7 +57,11 @@ class EventRecorderTest {
         recorder.record(TestEvent2())
         recorder.record(TestEvent2())
 
+        assertEquals(8, recorder.fetchBufferedEvents().toList().size)
+
         recorder.process()
+
+        assertEquals(0, recorder.fetchBufferedEvents().toList().size)
 
         assertEquals(4, dbs.get("clickhouse").createQuery("SELECT * FROM testevent1").queryList().size)
         assertEquals(4, dbs.get("clickhouse").createQuery("SELECT * FROM testevent2").queryList().size)


### PR DESCRIPTION
### Description

Events are written in batch by a loop, but can also be persisted ad-hoc.
In addition, a new method permits them to be evaluated.

#### Use-Case
A job writes events and upon finish, a summary must be computed from the stored events. 
The job can force the events to be written until all events submitted with a certain context have been persisted.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12518](https://scireum.myjetbrains.com/youtrack/issue/OX-12518)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
