### PR TITLE
Runs tests sequentially

### DIFF
--- a/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
+++ b/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import sirius.db.jdbc.Databases
 import sirius.kernel.SiriusExtension
 import sirius.kernel.async.BackgroundLoop
@@ -23,6 +25,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 @ExtendWith(SiriusExtension::class)
+@Execution(ExecutionMode.SAME_THREAD)
 class EventRecorderTest {
 
     companion object {

--- a/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
+++ b/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
@@ -60,11 +60,11 @@ class EventRecorderTest {
         recorder.record(TestEvent2())
         recorder.record(TestEvent2())
 
-        assertEquals(4, recorder.fetchBufferedEvents().filter { event -> event is TestEvent1 }.count())
+        assertEquals(4L, recorder.fetchBufferedEvents().filter { event -> event is TestEvent1 }.count())
 
         recorder.process()
 
-        assertEquals(0, recorder.fetchBufferedEvents().filter { event -> event is TestEvent1 }.count())
+        assertEquals(0L, recorder.fetchBufferedEvents().filter { event -> event is TestEvent1 }.count())
 
         assertEquals(4, dbs.get("clickhouse").createQuery("SELECT * FROM testevent1").queryList().size)
         assertEquals(4, dbs.get("clickhouse").createQuery("SELECT * FROM testevent2").queryList().size)

--- a/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
+++ b/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
-import org.junit.jupiter.api.parallel.Isolated
 import sirius.db.jdbc.Databases
 import sirius.kernel.SiriusExtension
 import sirius.kernel.async.BackgroundLoop
@@ -27,7 +26,6 @@ import kotlin.test.assertNull
 
 @ExtendWith(SiriusExtension::class)
 @Execution(ExecutionMode.SAME_THREAD)
-@Isolated
 class EventRecorderTest {
 
     companion object {
@@ -62,11 +60,11 @@ class EventRecorderTest {
         recorder.record(TestEvent2())
         recorder.record(TestEvent2())
 
-        assertEquals(8, recorder.fetchBufferedEvents().count())
+        assertEquals(4, recorder.fetchBufferedEvents().filter { event -> event is TestEvent1 }.count())
 
         recorder.process()
 
-        assertEquals(0, recorder.fetchBufferedEvents().count())
+        assertEquals(0, recorder.fetchBufferedEvents().filter { event -> event is TestEvent1 }.count())
 
         assertEquals(4, dbs.get("clickhouse").createQuery("SELECT * FROM testevent1").queryList().size)
         assertEquals(4, dbs.get("clickhouse").createQuery("SELECT * FROM testevent2").queryList().size)

--- a/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
+++ b/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import sirius.db.jdbc.Databases
 import sirius.kernel.SiriusExtension
 import sirius.kernel.async.BackgroundLoop
@@ -26,6 +27,7 @@ import kotlin.test.assertNull
 
 @ExtendWith(SiriusExtension::class)
 @Execution(ExecutionMode.SAME_THREAD)
+@Isolated
 class EventRecorderTest {
 
     companion object {
@@ -60,11 +62,11 @@ class EventRecorderTest {
         recorder.record(TestEvent2())
         recorder.record(TestEvent2())
 
-        assertEquals(8, recorder.fetchBufferedEvents().toList().size)
+        assertEquals(8, recorder.fetchBufferedEvents().count())
 
         recorder.process()
 
-        assertEquals(0, recorder.fetchBufferedEvents().toList().size)
+        assertEquals(0, recorder.fetchBufferedEvents().count())
 
         assertEquals(4, dbs.get("clickhouse").createQuery("SELECT * FROM testevent1").queryList().size)
         assertEquals(4, dbs.get("clickhouse").createQuery("SELECT * FROM testevent2").queryList().size)


### PR DESCRIPTION
### Description

Parallel execution can influence the results in each test as common counters/buffers are read from the same singleton object (EventRecorder).

Updates test to count an specific event as other foreign events might be in buffer when the test runs.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12518](https://scireum.myjetbrains.com/youtrack/issue/OX-12518)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/2300

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
