### PR TITLE
Add CSRF token to the login form …

### DIFF
--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -72,6 +72,7 @@
                                 </a>
                             </div>
                         </div>
+                        <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
### Description

… because the login form may be shown on any page that requires login

This seems counter-intuitive because when we're on the login page, we have no session that can be abused. However, the form is sent to the current requested (which can literally be any known route) as a POST request. The UserManager responsible for the specific scope later (and lazily which is an important detail!) picks up the parameters and automatically logs in the user.

Because the login happens AFTER the ControllerDispatcher is active, we can't just check the WebContext#hidePost flag as it has not yet flipped when the CSRF token validation happens. We also can neither access the current user nor the current scope easily as binding the request in the ControllerDispatcher creates its own issues...

We would need to either (A) make user managers declare whether they are gonna try to log in the user and thus hide POST requests as such or (B) change our approach of handling fallback when a login-required route is accessed without providing credentials (or already being logged-in).

As SSO logins or other special forms of logins on arbitrary pages sound really obscure, it's probably best to go with the easy solution (for now).

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1216](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1216)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
