### PR TITLE
Fix not being able to upload files due to missing the CSRF token

### DIFF
--- a/src/main/resources/default/assets/scripts/vfs-dropzone-and-modals.js.pasta
+++ b/src/main/resources/default/assets/scripts/vfs-dropzone-and-modals.js.pasta
@@ -193,7 +193,10 @@ function createDropzone(dropzoneId, config, modal, resolve) {
             '   </div>\n' +
             '</div>',
         url: function (files) {
-            return '/fs/upload?filename=' + encodeURIComponent(files[0].name) + '&path=' + path;
+            const csrfToken = '@escapeJS(part(CSRFHelper.class).getCSRFToken())';
+            return '/fs/upload?filename=' + encodeURIComponent(files[0].name)
+                + '&path=' + path
+                + '&CSRFToken=' + encodeURIComponent(csrfToken);
         },
         error: function (file, message) {
             errorHandler(file, message, config.allowedExtensions, config._input, modal);


### PR DESCRIPTION
### Description

We must send the token aus part of the URL, not as part of the body, as that generally only consists of the single file. We use the same logic in t:imageUpload and t:fileUpload.

I had the AI check for additional places with missing CSRF tokens but none came up.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1216](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1216)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1641

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
