### PR TITLE
Upgrades apache mina

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
             <version>2.2.8</version>
-            <scope>compile</scope>
         </dependency>
 
         <!-- Changelog: https://github.com/apache/mina-sshd/releases -->

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,14 @@
             <artifactId>ftpserver-core</artifactId>
             <version>1.2.1</version>
         </dependency>
+        <!-- Required as the version provided by org.apache.ftpserver has security issues
+             Changelog: https://mina.apache.org/mina-project/ -->
+        <dependency>
+            <groupId>org.apache.mina</groupId>
+            <artifactId>mina-core</artifactId>
+            <version>2.2.8</version>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- Changelog: https://github.com/apache/mina-sshd/releases -->
         <dependency>


### PR DESCRIPTION
### Description
- org.apache.ftpserver:ftpserver-core:1.2.1 brings a dependency to mina 2.2.4
- as 2.2.4 contains some already fixed CVEs, we upgrade to 2.2.8
- See: https://mina.apache.org/mina-project/ for details

### Additional Notes
- no ticket, just small version update

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
