### PR TITLE
add magic-login via samlTenantId parameter to jump over login 

### DIFF
--- a/src/main/java/sirius/biz/tenants/BizInterceptor.java
+++ b/src/main/java/sirius/biz/tenants/BizInterceptor.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.tenants;
 
+import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.nls.NLS;
 import sirius.web.controller.Interceptor;
@@ -23,6 +24,9 @@ import sirius.web.security.UserContext;
 @Register(framework = Tenants.FRAMEWORK_TENANTS)
 public class BizInterceptor implements Interceptor {
 
+    @Part
+    private SamlController<?, ?, ?> samlController;
+
     @Override
     public boolean before(WebContext webContext, Route route) throws Exception {
         return false;
@@ -37,6 +41,9 @@ public class BizInterceptor implements Interceptor {
             return false;
         }
         if (!UserContext.getCurrentUser().isLoggedIn()) {
+            if (samlController.tryStartTenantSamlLogin(webContext, webContext.getRequest().uri())) {
+                return true;
+            }
             webContext.respondWith().template("/templates/biz/login.html.pasta", webContext.getRequest().uri());
         } else {
             webContext.respondWith()

--- a/src/main/java/sirius/biz/tenants/SamlController.java
+++ b/src/main/java/sirius/biz/tenants/SamlController.java
@@ -97,10 +97,10 @@ public class SamlController<I extends Serializable, T extends BaseEntity<I> & Te
 
     private boolean isSamlLoginConfigured(T tenant) {
         TenantData tenantData = tenant.getTenantData();
-        return Strings.isFilled(tenantData.getSamlIssuerUrl())
-               && Strings.isFilled(tenantData.getSamlRequestIssuerName())
-               && Strings.isFilled(tenantData.getSamlIssuerName())
-               && Strings.isFilled(tenantData.getSamlFingerprint());
+        return Strings.areAllFilled(tenantData.getSamlIssuerUrl(),
+                                    tenantData.getSamlRequestIssuerName(),
+                                    tenantData.getSamlIssuerName(),
+                                    tenantData.getSamlFingerprint());
     }
 
     /**

--- a/src/main/java/sirius/biz/tenants/SamlController.java
+++ b/src/main/java/sirius/biz/tenants/SamlController.java
@@ -18,6 +18,7 @@ import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
+import sirius.web.controller.Controller;
 import sirius.web.controller.Routed;
 import sirius.web.http.WebContext;
 import sirius.web.security.UserContext;
@@ -25,6 +26,7 @@ import sirius.web.security.UserInfo;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -35,7 +37,7 @@ import java.util.UUID;
  * @param <T> specifies the effective entity type used to represent Tenants
  * @param <U> specifies the effective entity type used to represent UserAccounts
  */
-@Register(framework = Tenants.FRAMEWORK_TENANTS)
+@Register(classes = {Controller.class, SamlController.class}, framework = Tenants.FRAMEWORK_TENANTS)
 public class SamlController<I extends Serializable, T extends BaseEntity<I> & Tenant<I>, U extends BaseEntity<I> & UserAccount<I, T>>
         extends BizController {
 
@@ -43,6 +45,11 @@ public class SamlController<I extends Serializable, T extends BaseEntity<I> & Te
      * Contains the URI prefix shared by all routes related to the SAML login process.
      */
     public static final String SAML_URI_PREFIX = "/saml";
+
+    /**
+     * Contains the request parameter which can be used to directly start the SAML login for a tenant.
+     */
+    public static final String SAML_TENANT_ID_PARAMETER = "samlTenantId";
 
     @Part
     private SamlHelper saml;
@@ -59,6 +66,41 @@ public class SamlController<I extends Serializable, T extends BaseEntity<I> & Te
     public void saml(WebContext webContext) {
         List<T> tenants = querySAMLTenants();
         webContext.respondWith().template("/templates/biz/tenants/saml.html.pasta", tenants);
+    }
+
+    /**
+     * Directly starts the SAML login for the tenant given in {@link #SAML_TENANT_ID_PARAMETER}, if possible.
+     *
+     * @param webContext  the current request
+     * @param originalUrl the URL to return to after the SAML login
+     * @return <tt>true</tt> if the request has been handled, <tt>false</tt> otherwise
+     */
+    public boolean tryStartTenantSamlLogin(WebContext webContext, String originalUrl) {
+        String tenantId = webContext.get(SAML_TENANT_ID_PARAMETER).asString();
+        if (Strings.isEmpty(tenantId)) {
+            return false;
+        }
+
+        T tenant = querySAMLTenants().stream()
+                                     .filter(candidate -> Strings.areEqual(candidate.getIdAsString(), tenantId))
+                                     .filter(this::isSamlLoginConfigured)
+                                     .findFirst()
+                                     .orElse(null);
+        if (tenant == null) {
+            return false;
+        }
+
+        webContext.respondWith()
+                  .template("/templates/biz/tenants/saml.html.pasta", Collections.singletonList(tenant), originalUrl);
+        return true;
+    }
+
+    private boolean isSamlLoginConfigured(T tenant) {
+        TenantData tenantData = tenant.getTenantData();
+        return Strings.isFilled(tenantData.getSamlIssuerUrl())
+               && Strings.isFilled(tenantData.getSamlRequestIssuerName())
+               && Strings.isFilled(tenantData.getSamlIssuerName())
+               && Strings.isFilled(tenantData.getSamlFingerprint());
     }
 
     /**

--- a/src/main/resources/default/templates/biz/login.html.pasta
+++ b/src/main/resources/default/templates/biz/login.html.pasta
@@ -137,8 +137,8 @@
 
             try {
                 window.localStorage.setItem('samlPostLoginUri', '@raw {@escapeJS(originalUrl)}');
-            } catch (e) {
-                console.log(e);
+            } catch (exception) {
+                console.log(exception);
             }
         });
 

--- a/src/main/resources/default/templates/biz/tenants/saml.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/saml.html.pasta
@@ -1,4 +1,5 @@
 <i:arg type="List" name="tenants"/>
+<i:arg type="String" name="originalUrl" default=""/>
 
 <t:page titleKey="SAMLController.loginViaSAML" ignoreDisasterMode="true">
     <i:block name="breadcrumbs">
@@ -27,6 +28,13 @@
         <i:if test="tenants.size() == 1 && !user().isLoggedIn()">
             <script type="text/javascript">
                 sirius.ready(function () {
+                    if (___isFilled(originalUrl)) {
+                        try {
+                            window.localStorage.setItem('samlPostLoginUri', '@raw { @escapeJS(originalUrl) }');
+                        } catch (e) {
+                            console.log(e);
+                        }
+                    }
                     document.getElementsByClassName("samlForm").item(0).submit();
                 });
             </script>

--- a/src/main/resources/default/templates/biz/tenants/saml.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/saml.html.pasta
@@ -31,8 +31,8 @@
                     if (___isFilled(originalUrl)) {
                         try {
                             window.localStorage.setItem('samlPostLoginUri', '@raw { @escapeJS(originalUrl) }');
-                        } catch (e) {
-                            console.log(e);
+                        } catch (exception) {
+                            console.log(exception);
                         }
                     }
                     document.getElementsByClassName("samlForm").item(0).submit();

--- a/src/test/kotlin/sirius/biz/tenants/SamlControllerTest.kt
+++ b/src/test/kotlin/sirius/biz/tenants/SamlControllerTest.kt
@@ -10,11 +10,14 @@ package sirius.biz.tenants
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import sirius.biz.saml.SamlResponse
 import sirius.biz.tenants.jdbc.SQLTenant
 import sirius.biz.tenants.jdbc.SQLUserAccount
+import sirius.kernel.SiriusExtension
 import sirius.kernel.commons.MultiMap
 import sirius.kernel.health.HandledException
+import sirius.web.http.TestRequest
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -22,6 +25,7 @@ import kotlin.test.assertTrue
 /**
  * Tests the [SamlController].
  */
+@ExtendWith(SiriusExtension::class)
 class SamlControllerTest {
 
     @Test
@@ -55,9 +59,31 @@ class SamlControllerTest {
         }
     }
 
+    @Test
+    fun `SAML controller starts login for samlTenantId parameter`() {
+        val tenant = samlTenant("C5:FB:EB:48:78:60:C8:E3:CB:E5:64:09:61:70:21:D0:1B:E3:71:FF")
+        tenant.setId(4711)
+        val controller = TestSamlController(listOf(tenant))
+
+        assertTrue(
+            controller.tryStartTenantSamlLogin(
+                TestRequest.GET("/admin?samlTenantId=4711"),
+                "/admin"
+            )
+        )
+        assertFalse(
+            controller.tryStartTenantSamlLogin(
+                TestRequest.GET("/admin?samlTenantId=4712"),
+                "/admin"
+            )
+        )
+    }
+
     private fun samlTenant(fingerprint: String): SQLTenant {
         val tenant = SQLTenant()
         tenant.tenantData.samlIssuerName = "issuer"
+        tenant.tenantData.samlIssuerUrl = "https://sso.example.test/login"
+        tenant.tenantData.samlRequestIssuerName = "request-issuer"
         tenant.tenantData.samlFingerprint = fingerprint
         return tenant
     }


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
if a valid saml config is present for the given samlTenantId we diectly fil the saml-form and jump over to the SAML-provider to login.
After logging in, the wanted location from the given parameter will be loaded.
Also added a test-case 
### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15284](https://scireum.myjetbrains.com/youtrack/issue/SE-15284)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
