### PR TITLE
Set a custom captcha secret for development

### DIFF
--- a/develop.conf
+++ b/develop.conf
@@ -5,6 +5,7 @@ docker.keepRunning=true
 sirius.autoSetup = true
 
 product.baseUrl = "localhost:9000"
+http.captcha.secret = "qA7#nZ2@Lm9-pR4XvT8/Bc6YdE1#kF3@"
 
 jdbc {
     database {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.2.2-alpine
+    image: redis:8.2.6-alpine
     ports:
       - "6379"
     hostname: redis

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <sirius.kernel>52.1.1</sirius.kernel>
-        <sirius.web>105.0.0</sirius.web>
+        <sirius.web>106.0.0</sirius.web>
         <sirius.db>68.1.1</sirius.db>
         <aws.sdk>2.46.17</aws.sdk>
         <commonmark>0.29.0</commonmark>

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.2.2-alpine
+    image: redis:8.2.6-alpine
     ports:
       - "6379"
     hostname: redis


### PR DESCRIPTION
### Description

Adds a configuration for a custom captcha secret to be used exclusively in development environments. This ensures that real systems continue using secrets allocated via puppet while enabling easier testing in local development.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1225](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1225)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1667

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.