### PR TITLE
Upgrade Elasticsearch client and Docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       CLICKHOUSE_PASSWORD: secret
 
   elasticsearch:
-    image: elasticsearch:8.19.3
+    image: elasticsearch:8.19.18
     ports:
       - "9200"
     environment:

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>52.1.1</sirius.kernel>
         <sirius.web>106.0.1</sirius.web>
-        <sirius.db>68.1.1</sirius.db>
+        <sirius.db>68.2.0</sirius.db>
         <aws.sdk>2.46.21</aws.sdk>
         <commonmark>0.29.0</commonmark>
     </properties>

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       CLICKHOUSE_PASSWORD: secret
 
   elasticsearch:
-    image: elasticsearch:8.19.3
+    image: elasticsearch:8.19.18
     ports:
       - "9200"
     environment:


### PR DESCRIPTION
### Description

This PR introduces the following changes:
- Updates the Sirius database by incorporating a new Elasticsearch client.
- Upgrades Elasticsearch from version 8.19.3 to 8.19.18 in Docker configurations.

These changes address compatibility issues and bring enhancements related to [SIRI-1153](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1153).

### Additional Notes

- This PR fixes or works on the following ticket(s): [SIRI-1153](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1153).
- This PR is related to: https://github.com/scireum/sirius-db/pull/754

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.