### PR TITLE
Fix user lock actions in account list to use POST

### DIFF
--- a/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
@@ -75,12 +75,14 @@
                                     <t:dropdownItem
                                             labelKey="LoginData.unlock"
                                             icon="fa-solid fa-unlock"
-                                            url="@apply('/user-account/%s/unlock', account.getIdAsString())"/>
+                                            url="@apply('/user-account/%s/unlock', account.getIdAsString())"
+                                            sendPostRequest="true"/>
                                     <i:else>
                                         <t:dropdownItem
                                                 labelKey="LoginData.lock"
                                                 icon="fa-solid fa-lock"
-                                                url="@apply('/user-account/%s/lock', account.getIdAsString())"/>
+                                                url="@apply('/user-account/%s/lock', account.getIdAsString())"
+                                                sendPostRequest="true"/>
                                     </i:else>
                                 </i:if>
                             </t:dropdownSection>


### PR DESCRIPTION
### Description

- Fixes user lock/unlock actions in the account list to use POST instead of GET.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1245](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1245)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
