### PR TITLE
Upgrade jackson from 2.22.0 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>15.3.0</version>
+        <version>16.0.0</version>
     </parent>
     <artifactId>sirius-biz</artifactId>
     <version>DEVELOPMENT-SNAPSHOT</version>
@@ -17,9 +17,9 @@
     <url>https://www.sirius-lib.net</url>
 
     <properties>
-        <sirius.kernel>52.1.1</sirius.kernel>
-        <sirius.web>106.1.0</sirius.web>
-        <sirius.db>69.0.1</sirius.db>
+        <sirius.kernel>53.0.0</sirius.kernel>
+        <sirius.web>107.0.0</sirius.web>
+        <sirius.db>70.0.0</sirius.db>
         <aws.sdk>2.48.0</aws.sdk>
         <commonmark>0.29.0</commonmark>
     </properties>

--- a/src/main/java/sirius/biz/analytics/reports/CSSCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/CSSCellFormat.java
@@ -28,9 +28,9 @@ public class CSSCellFormat implements CellFormat {
     @Override
     public String format(ObjectNode data) {
         return "<div class=\""
-               + Strings.cleanup(data.path(KEY_CLASSES).asString(), StringCleanup::escapeXml)
+               + Strings.cleanup(data.path(KEY_CLASSES).asString(""), StringCleanup::escapeXml)
                + "\">"
-               + Strings.cleanup(data.path(KEY_VALUE).asString(), StringCleanup::escapeXml)
+               + Strings.cleanup(data.path(KEY_VALUE).asString(""), StringCleanup::escapeXml)
                + "</div>";
     }
 

--- a/src/main/java/sirius/biz/analytics/reports/CSSCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/CSSCellFormat.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.StringCleanup;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
@@ -28,15 +28,15 @@ public class CSSCellFormat implements CellFormat {
     @Override
     public String format(ObjectNode data) {
         return "<div class=\""
-               + Strings.cleanup(data.path(KEY_CLASSES).asText(), StringCleanup::escapeXml)
+               + Strings.cleanup(data.path(KEY_CLASSES).asString(), StringCleanup::escapeXml)
                + "\">"
-               + Strings.cleanup(data.path(KEY_VALUE).asText(), StringCleanup::escapeXml)
+               + Strings.cleanup(data.path(KEY_VALUE).asString(), StringCleanup::escapeXml)
                + "</div>";
     }
 
     @Override
     public String rawValue(ObjectNode data) {
-        return data.path(KEY_VALUE).asText(null);
+        return data.path(KEY_VALUE).asString(null);
     }
 
     @Nonnull

--- a/src/main/java/sirius/biz/analytics/reports/Cell.java
+++ b/src/main/java/sirius/biz/analytics/reports/Cell.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;

--- a/src/main/java/sirius/biz/analytics/reports/CellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/CellFormat.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.di.std.Named;
 
 /**

--- a/src/main/java/sirius/biz/analytics/reports/Cells.java
+++ b/src/main/java/sirius/biz/analytics/reports/Cells.java
@@ -8,8 +8,8 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.NumberFormat;
@@ -347,7 +347,7 @@ public class Cells {
         try {
             ObjectNode data = Json.tryParseObject(cellValue);
             return renderJSON(data);
-        } catch (JsonProcessingException exception) {
+        } catch (JacksonException exception) {
             Exceptions.ignore(exception);
         }
 
@@ -368,7 +368,7 @@ public class Cells {
         try {
             ObjectNode data = Json.tryParseObject(cellValue);
             return renderRaw(data);
-        } catch (JsonProcessingException exception) {
+        } catch (JacksonException exception) {
             Exceptions.ignore(exception);
         }
 

--- a/src/main/java/sirius/biz/analytics/reports/LinesCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/LinesCellFormat.java
@@ -8,9 +8,9 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 import sirius.kernel.di.std.Register;
 
@@ -41,7 +41,7 @@ public class LinesCellFormat implements CellFormat {
         return Json.tryGetArray(data, KEY_VALUES)
                    .map(ArrayNode::valueStream)
                    .orElseGet(Stream::empty)
-                   .map(JsonNode::asText)
+                   .map(JsonNode::asString)
                    .collect(Collectors.joining(delimiter));
     }
 

--- a/src/main/java/sirius/biz/analytics/reports/LinesCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/LinesCellFormat.java
@@ -41,7 +41,7 @@ public class LinesCellFormat implements CellFormat {
         return Json.tryGetArray(data, KEY_VALUES)
                    .map(ArrayNode::valueStream)
                    .orElseGet(Stream::empty)
-                   .map(JsonNode::asString)
+                   .map(jsonNode -> jsonNode.asString(""))
                    .collect(Collectors.joining(delimiter));
     }
 

--- a/src/main/java/sirius/biz/analytics/reports/LinkCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/LinkCellFormat.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.web.BizController;
 import sirius.kernel.commons.StringCleanup;
 import sirius.kernel.commons.Strings;
@@ -30,8 +30,8 @@ public class LinkCellFormat implements CellFormat {
     @Override
     public String format(ObjectNode data) {
         boolean newTab = data.get(KEY_TARGET_BLANK).asBoolean();
-        String keyUrl = Strings.cleanup(data.path(KEY_URL).asText(), StringCleanup::escapeXml);
-        String keyValue = Strings.cleanup(data.path(KEY_VALUE).asText(), StringCleanup::escapeXml);
+        String keyUrl = Strings.cleanup(data.path(KEY_URL).asString(), StringCleanup::escapeXml);
+        String keyValue = Strings.cleanup(data.path(KEY_VALUE).asString(), StringCleanup::escapeXml);
         String newTabLink = " <i class=\"fa-regular fa-arrow-up-right-from-square\"></i>";
         String html = """
                 <a href="%s" class="link" target="%s">%s%s</a>
@@ -42,7 +42,7 @@ public class LinkCellFormat implements CellFormat {
 
     @Override
     public String rawValue(ObjectNode data) {
-        StringBuilder linkUrl = new StringBuilder(data.path(KEY_URL).asText());
+        StringBuilder linkUrl = new StringBuilder(data.path(KEY_URL).asString());
         if (!linkUrl.toString().startsWith("http") && linkUrl.toString().startsWith("/")) {
             linkUrl.insert(0, BizController.getBaseUrl());
         }

--- a/src/main/java/sirius/biz/analytics/reports/LinkCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/LinkCellFormat.java
@@ -30,8 +30,8 @@ public class LinkCellFormat implements CellFormat {
     @Override
     public String format(ObjectNode data) {
         boolean newTab = data.get(KEY_TARGET_BLANK).asBoolean();
-        String keyUrl = Strings.cleanup(data.path(KEY_URL).asString(), StringCleanup::escapeXml);
-        String keyValue = Strings.cleanup(data.path(KEY_VALUE).asString(), StringCleanup::escapeXml);
+        String keyUrl = Strings.cleanup(data.path(KEY_URL).asString(""), StringCleanup::escapeXml);
+        String keyValue = Strings.cleanup(data.path(KEY_VALUE).asString(""), StringCleanup::escapeXml);
         String newTabLink = " <i class=\"fa-regular fa-arrow-up-right-from-square\"></i>";
         String html = """
                 <a href="%s" class="link" target="%s">%s%s</a>
@@ -42,7 +42,7 @@ public class LinkCellFormat implements CellFormat {
 
     @Override
     public String rawValue(ObjectNode data) {
-        StringBuilder linkUrl = new StringBuilder(data.path(KEY_URL).asString());
+        StringBuilder linkUrl = new StringBuilder(data.path(KEY_URL).asString(""));
         if (!linkUrl.toString().startsWith("http") && linkUrl.toString().startsWith("/")) {
             linkUrl.insert(0, BizController.getBaseUrl());
         }

--- a/src/main/java/sirius/biz/analytics/reports/ListCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/ListCellFormat.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.StringCleanup;
 import sirius.kernel.commons.Strings;

--- a/src/main/java/sirius/biz/analytics/reports/SparklineCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/SparklineCellFormat.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.di.std.Register;
 
 import javax.annotation.Nonnull;
@@ -25,8 +25,8 @@ public class SparklineCellFormat implements CellFormat {
 
     @Override
     public String format(ObjectNode data) {
-        String value = data.path(KEY_VALUE).asText();
-        String values = data.path(KEY_VALUES).asText();
+        String value = data.path(KEY_VALUE).asString();
+        String values = data.path(KEY_VALUES).asString();
 
         StringBuilder sb = new StringBuilder("<div class=\"text-end\">");
         sb.append(value);
@@ -40,7 +40,7 @@ public class SparklineCellFormat implements CellFormat {
 
     @Override
     public String rawValue(ObjectNode data) {
-        return data.path(KEY_VALUE).asText(null);
+        return data.path(KEY_VALUE).asString(null);
     }
 
     @Nonnull

--- a/src/main/java/sirius/biz/analytics/reports/SparklineCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/SparklineCellFormat.java
@@ -8,8 +8,8 @@
 
 package sirius.biz.analytics.reports;
 
-import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.di.std.Register;
+import tools.jackson.databind.node.ObjectNode;
 
 import javax.annotation.Nonnull;
 
@@ -25,17 +25,17 @@ public class SparklineCellFormat implements CellFormat {
 
     @Override
     public String format(ObjectNode data) {
-        String value = data.path(KEY_VALUE).asString();
-        String values = data.path(KEY_VALUES).asString();
+        String value = data.path(KEY_VALUE).asString("");
+        String values = data.path(KEY_VALUES).asString("");
 
-        StringBuilder sb = new StringBuilder("<div class=\"text-end\">");
-        sb.append(value);
-        sb.append(" ");
-        sb.append("<canvas width=\"40\" height=\"20\" class=\"sparkline-js\" data-sparkline=\"");
-        sb.append(values);
-        sb.append("\"></canvas>");
-        sb.append("</div>");
-        return sb.toString();
+        StringBuilder builder = new StringBuilder("<div class=\"text-end\">");
+        builder.append(value);
+        builder.append(" ");
+        builder.append("<canvas width=\"40\" height=\"20\" class=\"sparkline-js\" data-sparkline=\"");
+        builder.append(values);
+        builder.append("\"></canvas>");
+        builder.append("</div>");
+        return builder.toString();
     }
 
     @Override

--- a/src/main/java/sirius/biz/analytics/reports/TrendCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/TrendCellFormat.java
@@ -8,10 +8,10 @@
 
 package sirius.biz.analytics.reports;
 
-import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.StringCleanup;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
+import tools.jackson.databind.node.ObjectNode;
 
 import javax.annotation.Nonnull;
 
@@ -30,52 +30,52 @@ public class TrendCellFormat implements CellFormat {
 
     @Override
     public String format(ObjectNode data) {
-        String classes = data.path(KEY_CLASSES).asString();
-        String value = data.path(KEY_VALUE).asString();
-        String trend = data.path(KEY_TREND).asString();
-        String hint = data.path(KEY_HINT).asString();
-        String icon = data.path(KEY_ICON).asString();
+        String classes = data.path(KEY_CLASSES).asString("");
+        String value = data.path(KEY_VALUE).asString("");
+        String trend = data.path(KEY_TREND).asString("");
+        String hint = data.path(KEY_HINT).asString("");
+        String icon = data.path(KEY_ICON).asString("");
 
-        StringBuilder sb = new StringBuilder("<div class=\"text-end\"");
+        StringBuilder builder = new StringBuilder("<div class=\"text-end\"");
         if (Strings.isFilled(hint)) {
-            sb.append(" title=\"");
-            sb.append(Strings.cleanup(hint, StringCleanup::escapeXml));
-            sb.append("\"");
+            builder.append(" title=\"");
+            builder.append(Strings.cleanup(hint, StringCleanup::escapeXml));
+            builder.append("\"");
         }
-        sb.append(">");
+        builder.append(">");
         if (Strings.isFilled(value)) {
             if (Strings.isFilled(trend)) {
-                sb.append("<span>");
-                sb.append(Strings.cleanup(value, StringCleanup::escapeXml));
-                sb.append("</span> (<span class=\"");
-                sb.append(Strings.cleanup(classes, StringCleanup::escapeXml));
-                sb.append("\">");
-                sb.append(Strings.cleanup(trend, StringCleanup::escapeXml));
-                sb.append("</span>)");
+                builder.append("<span>");
+                builder.append(Strings.cleanup(value, StringCleanup::escapeXml));
+                builder.append("</span> (<span class=\"");
+                builder.append(Strings.cleanup(classes, StringCleanup::escapeXml));
+                builder.append("\">");
+                builder.append(Strings.cleanup(trend, StringCleanup::escapeXml));
+                builder.append("</span>)");
             } else {
-                sb.append(Strings.cleanup(value, StringCleanup::escapeXml));
+                builder.append(Strings.cleanup(value, StringCleanup::escapeXml));
             }
         } else {
-            sb.append("<span class=\"");
-            sb.append(Strings.cleanup(classes, StringCleanup::escapeXml));
-            sb.append("\">");
-            sb.append(Strings.cleanup(trend, StringCleanup::escapeXml));
-            sb.append("</span>");
+            builder.append("<span class=\"");
+            builder.append(Strings.cleanup(classes, StringCleanup::escapeXml));
+            builder.append("\">");
+            builder.append(Strings.cleanup(trend, StringCleanup::escapeXml));
+            builder.append("</span>");
         }
         if (Strings.isFilled(icon)) {
             if (Strings.isEmpty(trend)) {
-                sb.append("<span class=\"");
-                sb.append(Strings.cleanup(classes, StringCleanup::escapeXml));
-                sb.append("\">");
+                builder.append("<span class=\"");
+                builder.append(Strings.cleanup(classes, StringCleanup::escapeXml));
+                builder.append("\">");
             }
-            sb.append(" <i class=\"" + icon + "\"></i>");
+            builder.append(" <i class=\"" + icon + "\"></i>");
             if (Strings.isEmpty(trend)) {
-                sb.append("</span>");
+                builder.append("</span>");
             }
         }
 
-        sb.append("</div>");
-        return sb.toString();
+        builder.append("</div>");
+        return builder.toString();
     }
 
     @Override

--- a/src/main/java/sirius/biz/analytics/reports/TrendCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/TrendCellFormat.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.reports;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.StringCleanup;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
@@ -30,11 +30,11 @@ public class TrendCellFormat implements CellFormat {
 
     @Override
     public String format(ObjectNode data) {
-        String classes = data.path(KEY_CLASSES).asText();
-        String value = data.path(KEY_VALUE).asText();
-        String trend = data.path(KEY_TREND).asText();
-        String hint = data.path(KEY_HINT).asText();
-        String icon = data.path(KEY_ICON).asText();
+        String classes = data.path(KEY_CLASSES).asString();
+        String value = data.path(KEY_VALUE).asString();
+        String trend = data.path(KEY_TREND).asString();
+        String hint = data.path(KEY_HINT).asString();
+        String icon = data.path(KEY_ICON).asString();
 
         StringBuilder sb = new StringBuilder("<div class=\"text-end\"");
         if (Strings.isFilled(hint)) {
@@ -80,7 +80,7 @@ public class TrendCellFormat implements CellFormat {
 
     @Override
     public String rawValue(ObjectNode data) {
-        return data.path(KEY_VALUE).asText(null);
+        return data.path(KEY_VALUE).asString(null);
     }
 
     @Nonnull

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsBatchExecutor.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsBatchExecutor.java
@@ -45,9 +45,9 @@ public abstract class AnalyticsBatchExecutor implements DistributedTaskExecutor 
 
     @Override
     public void executeWork(ObjectNode context) throws Exception {
-        String schedulerName = context.path(AnalyticalEngine.CONTEXT_SCHEDULER_NAME).asString();
+        String schedulerName = context.path(AnalyticalEngine.CONTEXT_SCHEDULER_NAME).asString("");
         LocalDate date =
-                Value.of(NLS.parseMachineString(LocalDate.class, context.path(AnalyticalEngine.CONTEXT_DATE).asString()))
+                Value.of(NLS.parseMachineString(LocalDate.class, context.path(AnalyticalEngine.CONTEXT_DATE).asString("")))
                      .asLocalDate(LocalDate.now());
         int level = context.path(AnalyticalEngine.CONTEXT_LEVEL).asInt();
 

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsBatchExecutor.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsBatchExecutor.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.cluster.work.DistributedTaskExecutor;
 import sirius.biz.cluster.work.DistributedTasks;
 import sirius.biz.cluster.work.NamedRegions;
@@ -45,9 +45,9 @@ public abstract class AnalyticsBatchExecutor implements DistributedTaskExecutor 
 
     @Override
     public void executeWork(ObjectNode context) throws Exception {
-        String schedulerName = context.path(AnalyticalEngine.CONTEXT_SCHEDULER_NAME).asText();
+        String schedulerName = context.path(AnalyticalEngine.CONTEXT_SCHEDULER_NAME).asString();
         LocalDate date =
-                Value.of(NLS.parseMachineString(LocalDate.class, context.path(AnalyticalEngine.CONTEXT_DATE).asText()))
+                Value.of(NLS.parseMachineString(LocalDate.class, context.path(AnalyticalEngine.CONTEXT_DATE).asString()))
                      .asLocalDate(LocalDate.now());
         int level = context.path(AnalyticalEngine.CONTEXT_LEVEL).asInt();
 

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsScheduler.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.di.std.AutoRegister;
 import sirius.kernel.di.std.Named;
 

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsSchedulerExecutor.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsSchedulerExecutor.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.cluster.work.DistributedTaskExecutor;
 import sirius.biz.cluster.work.DistributedTasks;
 import sirius.kernel.commons.Json;
@@ -38,9 +38,9 @@ public abstract class AnalyticsSchedulerExecutor implements DistributedTaskExecu
 
     @Override
     public void executeWork(ObjectNode context) throws Exception {
-        String schedulerName = context.path(AnalyticalEngine.CONTEXT_SCHEDULER_NAME).asText();
+        String schedulerName = context.path(AnalyticalEngine.CONTEXT_SCHEDULER_NAME).asString();
         LocalDate date =
-                Value.of(NLS.parseMachineString(LocalDate.class, context.path(AnalyticalEngine.CONTEXT_DATE).asText()))
+                Value.of(NLS.parseMachineString(LocalDate.class, context.path(AnalyticalEngine.CONTEXT_DATE).asString()))
                      .asLocalDate(LocalDate.now());
         int level = context.path(AnalyticalEngine.CONTEXT_LEVEL).asInt();
         AnalyticsScheduler scheduler = globalContext.findPart(schedulerName, AnalyticsScheduler.class);

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsSchedulerExecutor.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsSchedulerExecutor.java
@@ -38,9 +38,9 @@ public abstract class AnalyticsSchedulerExecutor implements DistributedTaskExecu
 
     @Override
     public void executeWork(ObjectNode context) throws Exception {
-        String schedulerName = context.path(AnalyticalEngine.CONTEXT_SCHEDULER_NAME).asString();
+        String schedulerName = context.path(AnalyticalEngine.CONTEXT_SCHEDULER_NAME).asString("");
         LocalDate date =
-                Value.of(NLS.parseMachineString(LocalDate.class, context.path(AnalyticalEngine.CONTEXT_DATE).asString()))
+                Value.of(NLS.parseMachineString(LocalDate.class, context.path(AnalyticalEngine.CONTEXT_DATE).asString("")))
                      .asLocalDate(LocalDate.now());
         int level = context.path(AnalyticalEngine.CONTEXT_LEVEL).asInt();
         AnalyticsScheduler scheduler = globalContext.findPart(schedulerName, AnalyticsScheduler.class);

--- a/src/main/java/sirius/biz/analytics/scheduler/BaseAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/BaseAnalyticalTaskScheduler.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.Mixing;
 import sirius.kernel.commons.MultiMap;

--- a/src/main/java/sirius/biz/analytics/scheduler/BaseEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/BaseEntityBatchEmitter.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mixing.BaseEntity;
 import sirius.db.mixing.BaseMapper;
 import sirius.db.mixing.Mixing;
@@ -119,9 +119,9 @@ public abstract class BaseEntityBatchEmitter<I, C extends Constraint, B extends 
     public <E extends B> void evaluateBatch(ObjectNode batchDescription,
                                             @Nullable Consumer<Q> queryExtender,
                                             Consumer<E> entityConsumer) {
-        String startId = batchDescription.path(START_ID).asText(null);
-        String endId = batchDescription.path(END_ID).asText(null);
-        String typeName = batchDescription.path(TYPE).asText(null);
+        String startId = batchDescription.path(START_ID).asString(null);
+        String endId = batchDescription.path(END_ID).asString(null);
+        String typeName = batchDescription.path(TYPE).asString(null);
 
         Class<E> type = (Class<E>) mixing.getDescriptor(typeName).getType();
         Q query = (Q) getMapper().select(type);

--- a/src/main/java/sirius/biz/analytics/scheduler/ElasticEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/ElasticEntityBatchEmitter.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.Elastic;
 import sirius.db.es.ElasticEntity;
 import sirius.db.es.ElasticQuery;

--- a/src/main/java/sirius/biz/analytics/scheduler/MongoAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/MongoAnalyticalTaskScheduler.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mongo.MongoEntity;
 import sirius.db.mongo.MongoQuery;
 import sirius.kernel.commons.Explain;

--- a/src/main/java/sirius/biz/analytics/scheduler/MongoEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/MongoEntityBatchEmitter.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.mixing.BaseMapper;
 import sirius.db.mongo.Mango;
 import sirius.db.mongo.MongoEntity;

--- a/src/main/java/sirius/biz/analytics/scheduler/SQLAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/SQLAnalyticalTaskScheduler.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.jdbc.SQLEntity;
 import sirius.db.jdbc.SmartQuery;
 import sirius.kernel.commons.Explain;

--- a/src/main/java/sirius/biz/analytics/scheduler/SQLEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/SQLEntityBatchEmitter.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.analytics.scheduler;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.jdbc.OMA;
 import sirius.db.jdbc.SQLEntity;
 import sirius.db.jdbc.SmartQuery;

--- a/src/main/java/sirius/biz/cluster/Interconnect.java
+++ b/src/main/java/sirius/biz/cluster/Interconnect.java
@@ -96,7 +96,7 @@ public class Interconnect implements Subscriber {
     }
 
     private void dispatchLocally(ObjectNode event) {
-        String type = event.path(HANDLER).asString();
+        String type = event.path(HANDLER).asString("");
         if (Strings.isEmpty(type)) {
             throw new IllegalArgumentException("handler must not be empty!");
         }

--- a/src/main/java/sirius/biz/cluster/Interconnect.java
+++ b/src/main/java/sirius/biz/cluster/Interconnect.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.redis.Redis;
 import sirius.db.redis.Subscriber;
 import sirius.kernel.commons.Explain;
@@ -96,7 +96,7 @@ public class Interconnect implements Subscriber {
     }
 
     private void dispatchLocally(ObjectNode event) {
-        String type = event.path(HANDLER).asText();
+        String type = event.path(HANDLER).asString();
         if (Strings.isEmpty(type)) {
             throw new IllegalArgumentException("handler must not be empty!");
         }

--- a/src/main/java/sirius/biz/cluster/InterconnectCacheCoherence.java
+++ b/src/main/java/sirius/biz/cluster/InterconnectCacheCoherence.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.cache.Cache;
 import sirius.kernel.cache.CacheCoherence;

--- a/src/main/java/sirius/biz/cluster/InterconnectClusterManager.java
+++ b/src/main/java/sirius/biz/cluster/InterconnectClusterManager.java
@@ -8,9 +8,9 @@
 
 package sirius.biz.cluster;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
@@ -108,7 +108,7 @@ public class InterconnectClusterManager implements ClusterManager, InterconnectH
 
     @Override
     public void handleEvent(ObjectNode event) {
-        String messageType = event.path(MESSAGE_TYPE).asText(null);
+        String messageType = event.path(MESSAGE_TYPE).asString(null);
         if (Strings.areEqual(messageType, TYPE_PING)) {
             lastPing = LocalDateTime.now();
             interconnect.dispatch(getName(),
@@ -117,15 +117,15 @@ public class InterconnectClusterManager implements ClusterManager, InterconnectH
                                       .put(MESSAGE_NAME, CallContext.getNodeName())
                                       .put(MESSAGE_ADDRESS, getLocalAddress()));
         } else if (Strings.areEqual(messageType, TYPE_PONG)) {
-            String address = event.path(MESSAGE_ADDRESS).asText(null);
+            String address = event.path(MESSAGE_ADDRESS).asString(null);
             if (!Strings.areEqual(address, getLocalAddress()) && Strings.isFilled(address)) {
-                String nodeName = event.path(MESSAGE_NAME).asText(null);
+                String nodeName = event.path(MESSAGE_NAME).asString(null);
                 if (!Strings.areEqual(members.put(nodeName, address), address)) {
                     Cluster.LOG.INFO("Discovered a new node: %s - %s", nodeName, address);
                 }
             }
         } else if (Strings.areEqual(messageType, TYPE_KILL)) {
-            members.remove(event.path(MESSAGE_NAME).asText(null));
+            members.remove(event.path(MESSAGE_NAME).asString(null));
         }
     }
 

--- a/src/main/java/sirius/biz/cluster/InterconnectHandler.java
+++ b/src/main/java/sirius/biz/cluster/InterconnectHandler.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.di.std.Named;
 
 /**

--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -491,7 +491,7 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
                                    jsonObject.path(ClusterController.RESPONSE_DETAILED_VERSION).asString(null));
         Json.getArray(jsonObject, ClusterController.RESPONSE_JOBS).forEach(job -> {
             try {
-                String name = job.required(ClusterController.RESPONSE_NAME).asString();
+                String name = job.required(ClusterController.RESPONSE_NAME).asString("");
                 result.jobs.put(name,
                                 new BackgroundJobInfo(name,
                                                       job.path(ClusterController.RESPONSE_DESCRIPTION).asString(null),

--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.cluster.work.DistributedQueueInfo;
 import sirius.biz.cluster.work.DistributedTasks;
 import sirius.db.redis.Redis;
@@ -118,15 +118,15 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
 
     @Override
     public void handleEvent(ObjectNode event) {
-        String name = event.path(MESSAGE_NAME).asText(null);
+        String name = event.path(MESSAGE_NAME).asString(null);
         boolean enabled = event.path(MESSAGE_ENABLED).asBoolean();
-        String messageType = event.path(MESSAGE_TYPE).asText(null);
+        String messageType = event.path(MESSAGE_TYPE).asString(null);
         if (Strings.areEqual(messageType, TYPE_GLOBAL)) {
             globallyEnabledState.put(name, enabled);
             return;
         }
 
-        String messsageNode = event.path(MESSAGE_NODE).asText(null);
+        String messsageNode = event.path(MESSAGE_NODE).asString(null);
         if (Strings.areEqual(messageType, TYPE_LOCAL) && Strings.areEqual(messsageNode, CallContext.getNodeName())) {
             if (enabled) {
                 localOverwrite.put(name, true);
@@ -476,7 +476,7 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
 
     private BackgroundInfo parseBackgroundInfos(ObjectNode jsonObject) {
         if (jsonObject.path(InterconnectClusterManager.RESPONSE_ERROR).asBoolean()) {
-            return new BackgroundInfo(jsonObject.path(InterconnectClusterManager.RESPONSE_NODE_NAME).asText(null),
+            return new BackgroundInfo(jsonObject.path(InterconnectClusterManager.RESPONSE_NODE_NAME).asString(null),
                                       false,
                                       0,
                                       "-",
@@ -485,24 +485,24 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
         }
 
         BackgroundInfo result =
-                new BackgroundInfo(jsonObject.path(InterconnectClusterManager.RESPONSE_NODE_NAME).asText(null),
+                new BackgroundInfo(jsonObject.path(InterconnectClusterManager.RESPONSE_NODE_NAME).asString(null),
                                    jsonObject.path(ClusterController.RESPONSE_BLEEDING).asBoolean(),
                                    jsonObject.path(ClusterController.RESPONSE_ACTIVE_BACKGROUND_TASKS).asInt(),
-                                   jsonObject.path(ClusterController.RESPONSE_UPTIME).asText(null),
-                                   jsonObject.path(ClusterController.RESPONSE_VERSION).asText(null),
-                                   jsonObject.path(ClusterController.RESPONSE_DETAILED_VERSION).asText(null));
+                                   jsonObject.path(ClusterController.RESPONSE_UPTIME).asString(null),
+                                   jsonObject.path(ClusterController.RESPONSE_VERSION).asString(null),
+                                   jsonObject.path(ClusterController.RESPONSE_DETAILED_VERSION).asString(null));
         Json.getArray(jsonObject, ClusterController.RESPONSE_JOBS).forEach(job -> {
             try {
-                String name = job.required(ClusterController.RESPONSE_NAME).asText();
+                String name = job.required(ClusterController.RESPONSE_NAME).asString();
                 result.jobs.put(name,
                                 new BackgroundJobInfo(name,
-                                                      job.path(ClusterController.RESPONSE_DESCRIPTION).asText(null),
+                                                      job.path(ClusterController.RESPONSE_DESCRIPTION).asString(null),
                                                       SynchronizeType.valueOf(job.path(ClusterController.RESPONSE_LOCAL)
-                                                                                 .asText(null)),
+                                                                                 .asString(null)),
                                                       job.path(ClusterController.RESPONSE_LOCAL_OVERWRITE).asBoolean(),
                                                       job.path(ClusterController.RESPONSE_GLOBALLY_ENABLED).asBoolean(),
                                                       job.path(ClusterController.RESPONSE_EXECUTION_INFO)
-                                                         .asText(null)));
+                                                         .asString(null)));
             } catch (Exception exception) {
                 Exceptions.handle(Cluster.LOG, exception);
             }

--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -127,8 +127,8 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
             return;
         }
 
-        String messsageNode = event.path(MESSAGE_NODE).asString(null);
-        if (Strings.areEqual(messageType, TYPE_LOCAL) && Strings.areEqual(messsageNode, CallContext.getNodeName())) {
+        String messageNode = event.path(MESSAGE_NODE).asString(null);
+        if (Strings.areEqual(messageType, TYPE_LOCAL) && Strings.areEqual(messageNode, CallContext.getNodeName())) {
             if (enabled) {
                 localOverwrite.put(name, true);
             } else {
@@ -136,7 +136,7 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
             }
         }
 
-        if (Strings.areEqual(messageType, TYPE_BLEED) && Strings.areEqual(messsageNode, CallContext.getNodeName())) {
+        if (Strings.areEqual(messageType, TYPE_BLEED) && Strings.areEqual(messageNode, CallContext.getNodeName())) {
             bleeding = enabled;
         }
     }

--- a/src/main/java/sirius/biz/cluster/RedisUserMessageCache.java
+++ b/src/main/java/sirius/biz/cluster/RedisUserMessageCache.java
@@ -8,9 +8,9 @@
 
 package sirius.biz.cluster;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.redis.Redis;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
@@ -71,9 +71,9 @@ public class RedisUserMessageCache implements DistributedUserMessageCache {
                    .valueStream()
                    .filter(JsonNode::isObject)
                    .map(ObjectNode.class::cast)
-                   .map(object -> new Message(Value.of(object.path(FIELD_TYPE).asText(null))
+                   .map(object -> new Message(Value.of(object.path(FIELD_TYPE).asString(null))
                                                    .getEnum(MessageLevel.class)
-                                                   .orElse(MessageLevel.INFO), object.path(FIELD_HTML).asText(null)))
+                                                   .orElse(MessageLevel.INFO), object.path(FIELD_HTML).asString(null)))
                    .toList();
     }
 

--- a/src/main/java/sirius/biz/cluster/work/DistributedTaskExecutor.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTaskExecutor.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Represents an executor which performs tasks which have been queued via {@link DistributedTasks}.

--- a/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
@@ -160,7 +160,7 @@ public class DistributedTasks implements MetricProvider {
         protected void execute() {
             try {
                 DistributedTaskExecutor exec =
-                        ctx.getPart(task.required(KEY_EXECUTOR).asString(), DistributedTaskExecutor.class);
+                        ctx.getPart(task.required(KEY_EXECUTOR).asString(""), DistributedTaskExecutor.class);
                 tryExecute(exec);
             } catch (Exception exception) {
                 Exceptions.handle()

--- a/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.cluster.NeighborhoodWatch;
 import sirius.db.redis.Redis;
 import sirius.kernel.Sirius;
@@ -160,7 +160,7 @@ public class DistributedTasks implements MetricProvider {
         protected void execute() {
             try {
                 DistributedTaskExecutor exec =
-                        ctx.getPart(task.required(KEY_EXECUTOR).asText(), DistributedTaskExecutor.class);
+                        ctx.getPart(task.required(KEY_EXECUTOR).asString(), DistributedTaskExecutor.class);
                 tryExecute(exec);
             } catch (Exception exception) {
                 Exceptions.handle()
@@ -184,7 +184,7 @@ public class DistributedTasks implements MetricProvider {
                                   Json.write(task))
                           .handle();
             } finally {
-                releasePenaltyToken(queue.getName(), task.path(KEY_PENALTY_TOKEN).asText(null));
+                releasePenaltyToken(queue.getName(), task.path(KEY_PENALTY_TOKEN).asString(null));
                 releaseConcurrencyToken(queue.getConcurrencyToken());
             }
         }

--- a/src/main/java/sirius/biz/cluster/work/FifoQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/FifoQueue.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/src/main/java/sirius/biz/cluster/work/LocalFifoQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/LocalFifoQueue.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Explain;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/sirius/biz/cluster/work/LocalPrioritizedQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/LocalPrioritizedQueue.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.ComparableTuple;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;

--- a/src/main/java/sirius/biz/cluster/work/PrioritizedQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/PrioritizedQueue.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/src/main/java/sirius/biz/cluster/work/RedisFifoQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/RedisFifoQueue.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.redis.Redis;
 import sirius.kernel.commons.Json;
 

--- a/src/main/java/sirius/biz/cluster/work/RedisPrioritizedQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/RedisPrioritizedQueue.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import redis.clients.jedis.Jedis;
 import sirius.db.KeyGenerator;
 import sirius.db.redis.Redis;

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.codelists;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.jupiter.IDBTable;
 import sirius.biz.jupiter.Jupiter;
 import sirius.kernel.commons.Json;

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -623,9 +623,9 @@ public abstract class LookupTable {
             if (translations.isObject()) {
                 return translations.properties()
                                    .stream()
-                                   .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asString()));
+                                   .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asString("")));
             } else {
-                return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, translations.asString());
+                return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, translations.asString(""));
             }
         }).orElseGet(() -> {
             return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, "");
@@ -668,7 +668,7 @@ public abstract class LookupTable {
         JsonNode jsonNode = optionalJsonNode.get();
         if (jsonNode.isArray()) {
             return transformArrayToStringList((ArrayNode) jsonNode);
-        } else if (jsonNode.isString() && Strings.isFilled(jsonNode.asString())) {
+        } else if (jsonNode.isString() && Strings.isFilled(jsonNode.asString(""))) {
             return Collections.singletonList(jsonNode.asString(null));
         } else {
             return Collections.emptyList();
@@ -676,7 +676,7 @@ public abstract class LookupTable {
     }
 
     private static List<String> transformArrayToStringList(ArrayNode array) {
-        return array.valueStream().map(JsonNode::asString).filter(Strings::isFilled).toList();
+        return array.valueStream().map(jsonNode -> jsonNode.asString("")).filter(Strings::isFilled).toList();
     }
 
     /**
@@ -697,8 +697,8 @@ public abstract class LookupTable {
         if (jsonNode.isObject()) {
             return jsonNode.properties()
                            .stream()
-                           .filter(entry -> Strings.isFilled(entry.getValue().asString()))
-                           .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asString()));
+                           .filter(entry -> Strings.isFilled(entry.getValue().asString("")))
+                           .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asString("")));
         } else {
             return Collections.emptyMap();
         }

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -8,10 +8,10 @@
 
 package sirius.biz.codelists;
 
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Strings;
@@ -623,9 +623,9 @@ public abstract class LookupTable {
             if (translations.isObject()) {
                 return translations.properties()
                                    .stream()
-                                   .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asText()));
+                                   .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asString()));
             } else {
-                return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, translations.asText());
+                return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, translations.asString());
             }
         }).orElseGet(() -> {
             return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, "");
@@ -668,15 +668,15 @@ public abstract class LookupTable {
         JsonNode jsonNode = optionalJsonNode.get();
         if (jsonNode.isArray()) {
             return transformArrayToStringList((ArrayNode) jsonNode);
-        } else if (jsonNode.isTextual() && Strings.isFilled(jsonNode.asText())) {
-            return Collections.singletonList(jsonNode.asText(null));
+        } else if (jsonNode.isString() && Strings.isFilled(jsonNode.asString())) {
+            return Collections.singletonList(jsonNode.asString(null));
         } else {
             return Collections.emptyList();
         }
     }
 
     private static List<String> transformArrayToStringList(ArrayNode array) {
-        return array.valueStream().map(JsonNode::asText).filter(Strings::isFilled).toList();
+        return array.valueStream().map(JsonNode::asString).filter(Strings::isFilled).toList();
     }
 
     /**
@@ -697,8 +697,8 @@ public abstract class LookupTable {
         if (jsonNode.isObject()) {
             return jsonNode.properties()
                            .stream()
-                           .filter(entry -> Strings.isFilled(entry.getValue().asText()))
-                           .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asText()));
+                           .filter(entry -> Strings.isFilled(entry.getValue().asString()))
+                           .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asString()));
         } else {
             return Collections.emptyMap();
         }

--- a/src/main/java/sirius/biz/codelists/LookupTableEntry.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableEntry.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.codelists;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import sirius.kernel.commons.Json;

--- a/src/main/java/sirius/biz/elastic/ElasticIndexSizeReportJobFactory.java
+++ b/src/main/java/sirius/biz/elastic/ElasticIndexSizeReportJobFactory.java
@@ -8,8 +8,8 @@
 
 package sirius.biz.elastic;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.analytics.reports.Cell;
 import sirius.biz.analytics.reports.Report;
 import sirius.biz.jobs.StandardCategories;
@@ -77,7 +77,7 @@ public class ElasticIndexSizeReportJobFactory extends ReportJobFactory {
     }
 
     private Cell determineClusterStatus(ObjectNode clusterHealth) {
-        String status = clusterHealth.path("status").asText();
+        String status = clusterHealth.path("status").asString();
         if (Strings.areEqual(status, "green")) {
             return cells.green(status);
         }

--- a/src/main/java/sirius/biz/elastic/ElasticIndexSizeReportJobFactory.java
+++ b/src/main/java/sirius/biz/elastic/ElasticIndexSizeReportJobFactory.java
@@ -77,7 +77,7 @@ public class ElasticIndexSizeReportJobFactory extends ReportJobFactory {
     }
 
     private Cell determineClusterStatus(ObjectNode clusterHealth) {
-        String status = clusterHealth.path("status").asString();
+        String status = clusterHealth.path("status").asString("");
         if (Strings.areEqual(status, "green")) {
             return cells.green(status);
         }

--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -8,8 +8,8 @@
 
 package sirius.biz.jobs;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.jobs.infos.JobInfo;
 import sirius.biz.jobs.infos.JobInfoCollector;
 import sirius.biz.jobs.params.BooleanParameter;

--- a/src/main/java/sirius/biz/jobs/JobConfigData.java
+++ b/src/main/java/sirius/biz/jobs/JobConfigData.java
@@ -158,7 +158,7 @@ public class JobConfigData extends Composite {
                         configMap.put(entry.getKey(),
                                       entry.getValue()
                                            .valueStream()
-                                           .map(JsonNode::asString)
+                                           .map(jsonNode -> jsonNode.asString(""))
                                            .filter(Strings::isFilled)
                                            .toList());
                     } else {

--- a/src/main/java/sirius/biz/jobs/JobConfigData.java
+++ b/src/main/java/sirius/biz/jobs/JobConfigData.java
@@ -8,8 +8,8 @@
 
 package sirius.biz.jobs;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.jobs.batch.BatchProcessJobFactory;
 import sirius.biz.process.PersistencePeriod;
 import sirius.biz.web.Autoloaded;
@@ -158,11 +158,11 @@ public class JobConfigData extends Composite {
                         configMap.put(entry.getKey(),
                                       entry.getValue()
                                            .valueStream()
-                                           .map(JsonNode::asText)
+                                           .map(JsonNode::asString)
                                            .filter(Strings::isFilled)
                                            .toList());
                     } else {
-                        configMap.put(entry.getKey(), Stream.ofNullable(entry.getValue().asText(null)).toList());
+                        configMap.put(entry.getKey(), Stream.ofNullable(entry.getValue().asString(null)).toList());
                     }
                 });
             }

--- a/src/main/java/sirius/biz/jobs/JobFactory.java
+++ b/src/main/java/sirius/biz/jobs/JobFactory.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.jobs;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import sirius.biz.jobs.infos.JobInfo;
 import sirius.biz.jobs.params.Parameter;
 import sirius.kernel.commons.Value;

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.jobs.batch;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.cluster.work.DistributedTaskExecutor;
 import sirius.biz.cluster.work.DistributedTasks;
 import sirius.biz.jobs.BasicJobFactory;

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessTaskExecutor.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessTaskExecutor.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.jobs.batch;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.cluster.work.DistributedTaskExecutor;
 import sirius.biz.jobs.BasicJobFactory;
 import sirius.biz.jobs.Jobs;
@@ -38,8 +38,8 @@ public abstract class BatchProcessTaskExecutor implements DistributedTaskExecuto
 
     @Override
     public void executeWork(ObjectNode context) throws Exception {
-        String factoryId = context.path(BatchProcessJobFactory.CONTEXT_JOB_FACTORY).asText(null);
-        String processId = context.path(BatchProcessJobFactory.CONTEXT_PROCESS).asText(null);
+        String factoryId = context.path(BatchProcessJobFactory.CONTEXT_JOB_FACTORY).asString(null);
+        String processId = context.path(BatchProcessJobFactory.CONTEXT_PROCESS).asString(null);
 
         setupTaskContext(factoryId);
 

--- a/src/main/java/sirius/biz/jupiter/JupiterConnector.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnector.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.jupiter;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;

--- a/src/main/java/sirius/biz/process/ExportLogsAsFileTaskExecutor.java
+++ b/src/main/java/sirius/biz/process/ExportLogsAsFileTaskExecutor.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.process;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.analytics.reports.Cells;
 import sirius.biz.cluster.work.DistributedTaskExecutor;
 import sirius.biz.jobs.batch.ExportBatchProcessFactory;
@@ -84,13 +84,13 @@ public class ExportLogsAsFileTaskExecutor implements DistributedTaskExecutor {
 
     @Override
     public void executeWork(ObjectNode context) throws Exception {
-        String processId = context.path(CONTEXT_PROCESS).asText(null);
+        String processId = context.path(CONTEXT_PROCESS).asString(null);
         processes.purgeProcessFromFirstLevelCache(processId);
         processes.execute(processId, process -> executeInProcess(context, process));
     }
 
     private void executeInProcess(ObjectNode context, ProcessContext processContext) {
-        String outputName = context.path(CONTEXT_OUTPUT).asText(null);
+        String outputName = context.path(CONTEXT_OUTPUT).asString(null);
         ProcessOutput processOutput = Strings.isFilled(outputName) ?
                                       processContext.fetchOutput(outputName)
                                                     .orElseThrow(() -> new IllegalArgumentException(Strings.apply(

--- a/src/main/java/sirius/biz/process/ProcessController.java
+++ b/src/main/java/sirius/biz/process/ProcessController.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.process;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/sirius/biz/process/output/ChartOutput.java
+++ b/src/main/java/sirius/biz/process/output/ChartOutput.java
@@ -8,8 +8,8 @@
 
 package sirius.biz.process.output;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.analytics.metrics.Dataset;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.logs.ProcessLog;

--- a/src/main/java/sirius/biz/process/output/ChartProcessOutputType.java
+++ b/src/main/java/sirius/biz/process/output/ChartProcessOutputType.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.process.output;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.process.Process;
 import sirius.biz.process.ProcessContext;
 import sirius.biz.process.logs.ProcessLog;

--- a/src/main/java/sirius/biz/scripting/Scripting.java
+++ b/src/main/java/sirius/biz/scripting/Scripting.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.scripting;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.cluster.Interconnect;
 import sirius.biz.cluster.InterconnectHandler;
 import sirius.biz.tenants.Tenants;
@@ -172,19 +172,19 @@ public class Scripting implements InterconnectHandler {
 
     @Override
     public void handleEvent(ObjectNode event) {
-        if (TASK_TYPE_MSG.equals(event.path(TASK_TYPE).asText())) {
+        if (TASK_TYPE_MSG.equals(event.path(TASK_TYPE).asString())) {
             handleMessageTask(event);
-        } else if (TASK_TYPE_EXEC.equals(event.path(TASK_TYPE).asText())) {
+        } else if (TASK_TYPE_EXEC.equals(event.path(TASK_TYPE).asString())) {
             tasks.defaultExecutor().start(() -> handleExecTask(event));
         }
     }
 
     private void handleMessageTask(ObjectNode event) {
         synchronized (messages) {
-            messages.add(new TranscriptMessage(event.path(TASK_NODE).asText(null),
-                                               event.path(TASK_JOB).asText(null),
+            messages.add(new TranscriptMessage(event.path(TASK_NODE).asString(null),
+                                               event.path(TASK_JOB).asString(null),
                                                event.path(TASK_TIMESTAMP).asLong(),
-                                               event.path(TASK_MESSAGE).asText(null)));
+                                               event.path(TASK_MESSAGE).asString(null)));
             if (messages.size() > MAX_MESSAGES) {
                 messages.removeFirst();
             }
@@ -203,8 +203,8 @@ public class Scripting implements InterconnectHandler {
     }
 
     private void handleExecTask(ObjectNode event) {
-        String nodeName = event.path(TASK_NODE).asText(null);
-        String jobNumber = event.path(TASK_JOB).asText(null);
+        String nodeName = event.path(TASK_NODE).asString(null);
+        String jobNumber = event.path(TASK_JOB).asString(null);
         if (!ALL_NODES.equals(nodeName) && !Strings.areEqual(CallContext.getNodeName(), nodeName)) {
             return;
         }
@@ -249,7 +249,7 @@ public class Scripting implements InterconnectHandler {
 
     private Callable compileScript(ObjectNode event) throws CompileException {
         CompilationContext compilationContext =
-                new CompilationContext(SourceCodeInfo.forInlineCode(event.path(TASK_SCRIPT).asText(null),
+                new CompilationContext(SourceCodeInfo.forInlineCode(event.path(TASK_SCRIPT).asString(null),
                                                                     SandboxMode.DISABLED));
         NoodleCompiler compiler = new NoodleCompiler(compilationContext);
         Callable callable = compiler.compileScript();

--- a/src/main/java/sirius/biz/scripting/Scripting.java
+++ b/src/main/java/sirius/biz/scripting/Scripting.java
@@ -172,9 +172,9 @@ public class Scripting implements InterconnectHandler {
 
     @Override
     public void handleEvent(ObjectNode event) {
-        if (TASK_TYPE_MSG.equals(event.path(TASK_TYPE).asString())) {
+        if (TASK_TYPE_MSG.equals(event.path(TASK_TYPE).asString(""))) {
             handleMessageTask(event);
-        } else if (TASK_TYPE_EXEC.equals(event.path(TASK_TYPE).asString())) {
+        } else if (TASK_TYPE_EXEC.equals(event.path(TASK_TYPE).asString(""))) {
             tasks.defaultExecutor().start(() -> handleExecTask(event));
         }
     }

--- a/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskExecutor.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskExecutor.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.storage.layer1.replication;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.cluster.work.DistributedTaskExecutor;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.kernel.di.std.Framework;

--- a/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskStorage.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.storage.layer1.replication;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.di.std.AutoRegister;
 
 /**

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
@@ -104,7 +104,7 @@ public class SQLReplicationTaskStorage
 
     @Override
     public void executeBatch(ObjectNode batch) {
-        String txnId = batch.path(TRANSACTION_ID).asString();
+        String txnId = batch.path(TRANSACTION_ID).asString("");
         if (Strings.isFilled(txnId)) {
             SmartQuery<SQLReplicationTask> query = oma.select(SQLReplicationTask.class);
             query.eq(SQLReplicationTask.FAILED, false);

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.storage.layer1.replication.jdbc;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.storage.layer1.replication.BaseReplicationTaskStorage;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.db.jdbc.OMA;
@@ -104,7 +104,7 @@ public class SQLReplicationTaskStorage
 
     @Override
     public void executeBatch(ObjectNode batch) {
-        String txnId = batch.path(TRANSACTION_ID).asText();
+        String txnId = batch.path(TRANSACTION_ID).asString();
         if (Strings.isFilled(txnId)) {
             SmartQuery<SQLReplicationTask> query = oma.select(SQLReplicationTask.class);
             query.eq(SQLReplicationTask.FAILED, false);

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
@@ -110,7 +110,7 @@ public class MongoReplicationTaskStorage
 
     @Override
     public void executeBatch(ObjectNode batch) {
-        String txnId = batch.path(TRANSACTION_ID).asString();
+        String txnId = batch.path(TRANSACTION_ID).asString("");
         if (Strings.isFilled(txnId)) {
             MongoQuery<MongoReplicationTask> query = mango.select(MongoReplicationTask.class);
             query.eq(MongoReplicationTask.FAILED, false);

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.storage.layer1.replication.mongo;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.storage.layer1.replication.BaseReplicationTaskStorage;
 import sirius.biz.storage.util.StorageUtils;
 import sirius.db.mongo.Mango;
@@ -110,7 +110,7 @@ public class MongoReplicationTaskStorage
 
     @Override
     public void executeBatch(ObjectNode batch) {
-        String txnId = batch.path(TRANSACTION_ID).asText();
+        String txnId = batch.path(TRANSACTION_ID).asString();
         if (Strings.isFilled(txnId)) {
             MongoQuery<MongoReplicationTask> query = mango.select(MongoReplicationTask.class);
             query.eq(MongoReplicationTask.FAILED, false);

--- a/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.storage.layer2;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.db.es.ESPropertyInfo;
 import sirius.db.es.IndexMappings;
 import sirius.db.es.annotations.IndexMode;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccount.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccount.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.tenants.jdbc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import sirius.biz.analytics.flags.jdbc.SQLPerformanceData;
 import sirius.biz.codelists.LookupValue;
 import sirius.biz.protocol.JournalData;
@@ -29,6 +28,7 @@ import sirius.kernel.di.std.Framework;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 import sirius.web.controller.Message;
+import tools.jackson.core.JacksonException;
 
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -117,7 +117,7 @@ public class SQLUserAccount extends SQLTenantAware implements UserAccount<Long, 
                .where(SQLUserAccount.ID, id)
                .executeUpdate();
             TenantUserManager.flushCacheForUserAccount(this);
-        } catch (SQLException | JsonProcessingException exception) {
+        } catch (SQLException | JacksonException exception) {
             throw Exceptions.handle()
                             .to(Log.SYSTEM)
                             .error(exception)
@@ -129,8 +129,7 @@ public class SQLUserAccount extends SQLTenantAware implements UserAccount<Long, 
         }
     }
 
-    private String computeUpdatedPreferences(Map<String, Object> preferences, String key, Object value)
-            throws JsonProcessingException {
+    private String computeUpdatedPreferences(Map<String, Object> preferences, String key, Object value) {
         if (Strings.isEmpty(value)) {
             preferences.remove(key);
         } else {

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.tenants.mongo;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import sirius.biz.analytics.flags.mongo.MongoPerformanceData;
 import sirius.biz.codelists.LookupValue;
 import sirius.biz.mongo.CustomSortValues;
@@ -34,6 +33,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 import sirius.web.controller.Message;
+import tools.jackson.core.JacksonException;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -163,7 +163,7 @@ public class MongoUserAccount extends MongoTenantAware implements UserAccount<St
                  .where(MongoUserAccount.ID, id)
                  .executeForOne(MongoUserAccount.class);
             TenantUserManager.flushCacheForUserAccount(this);
-        } catch (JsonProcessingException exception) {
+        } catch (JacksonException exception) {
             throw Exceptions.handle()
                             .to(Log.SYSTEM)
                             .error(exception)
@@ -175,8 +175,7 @@ public class MongoUserAccount extends MongoTenantAware implements UserAccount<St
         }
     }
 
-    private String computeUpdatedPreferences(Map<String, Object> preferences, String key, Object value)
-            throws JsonProcessingException {
+    private String computeUpdatedPreferences(Map<String, Object> preferences, String key, Object value) {
         if (Strings.isEmpty(value)) {
             preferences.remove(key);
         } else {

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -268,7 +268,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty
         if (Strings.isFilled(fallbackAndMap.getSecond())) {
             Json.parseObject(fallbackAndMap.getSecond())
                 .properties()
-                .forEach(entry -> texts.put(entry.getKey(), entry.getValue().asString()));
+                .forEach(entry -> texts.put(entry.getKey(), entry.getValue().asString("")));
         }
 
         return texts;

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.translations;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.bson.Document;
 import sirius.biz.web.ComplexLoadProperty;
 import sirius.db.es.ESPropertyInfo;
@@ -268,7 +268,7 @@ public class MultiLanguageStringProperty extends BaseMapProperty
         if (Strings.isFilled(fallbackAndMap.getSecond())) {
             Json.parseObject(fallbackAndMap.getSecond())
                 .properties()
-                .forEach(entry -> texts.put(entry.getKey(), entry.getValue().asText()));
+                .forEach(entry -> texts.put(entry.getKey(), entry.getValue().asString()));
         }
 
         return texts;

--- a/src/main/java/sirius/biz/tycho/QuickAction.java
+++ b/src/main/java/sirius/biz/tycho/QuickAction.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.tycho;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 
 /**

--- a/src/main/java/sirius/biz/tycho/metrics/MetricsApiController.java
+++ b/src/main/java/sirius/biz/tycho/metrics/MetricsApiController.java
@@ -59,7 +59,7 @@ public class MetricsApiController extends BizController {
 
     private void fetchMetric(ObjectNode obj, JSONStructuredOutput output) {
         // For now, there are only "KeyMetrics" which may be lazy-loaded, but we might add some more in the future...
-        if ("KeyMetric".equals(obj.path("type").asString())) {
+        if ("KeyMetric".equals(obj.path("type").asString(""))) {
             fetchKeyMetric(obj, output);
         } else {
             output.beginObject("task").endObject();

--- a/src/main/java/sirius/biz/tycho/metrics/MetricsApiController.java
+++ b/src/main/java/sirius/biz/tycho/metrics/MetricsApiController.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.tycho.metrics;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.web.BizController;
 import sirius.kernel.commons.Json;
 import sirius.kernel.di.std.Part;
@@ -59,7 +59,7 @@ public class MetricsApiController extends BizController {
 
     private void fetchMetric(ObjectNode obj, JSONStructuredOutput output) {
         // For now, there are only "KeyMetrics" which may be lazy-loaded, but we might add some more in the future...
-        if ("KeyMetric".equals(obj.path("type").asText())) {
+        if ("KeyMetric".equals(obj.path("type").asString())) {
             fetchKeyMetric(obj, output);
         } else {
             output.beginObject("task").endObject();
@@ -68,9 +68,9 @@ public class MetricsApiController extends BizController {
 
     private void fetchKeyMetric(ObjectNode obj, JSONStructuredOutput output) {
         try {
-            KeyMetric metric = keyMetrics.resolveKeyMetric(obj.path("provider").asText(null),
-                                                           obj.path("target").asText(null),
-                                                           obj.path("metric").asText(null));
+            KeyMetric metric = keyMetrics.resolveKeyMetric(obj.path("provider").asString(null),
+                                                           obj.path("target").asString(null),
+                                                           obj.path("metric").asString(null));
             metric.writeJson(output);
         } catch (Exception exception) {
             Exceptions.handle()

--- a/src/main/java/sirius/biz/tycho/search/OpenSearchController.java
+++ b/src/main/java/sirius/biz/tycho/search/OpenSearchController.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.tycho.search;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.biz.web.BizController;
 import sirius.kernel.async.CombinedFuture;

--- a/src/main/java/sirius/biz/util/ReportUnusedNLSKeysJob.java
+++ b/src/main/java/sirius/biz/util/ReportUnusedNLSKeysJob.java
@@ -85,14 +85,14 @@ public class ReportUnusedNLSKeysJob extends SimpleBatchProcessJobFactory {
                       .forEach(missingKeysOfNode -> {
                           Set<String> keysOfNode = Json.getArray(missingKeysOfNode, "unused")
                                                        .valueStream()
-                                                       .map(JsonNode::asString)
+                                                       .map(jsonNode -> jsonNode.asString(""))
                                                        .collect(Collectors.toSet());
 
                           process.log(ProcessLog.info()
                                                 .withFormattedMessage("Received %s keys from %s",
                                                                       keysOfNode.size(),
                                                                       missingKeysOfNode.path(InterconnectClusterManager.RESPONSE_NODE_NAME)
-                                                                                       .asString()));
+                                                                                       .asString("")));
                           missingKeys.retainAll(keysOfNode);
                       });
 

--- a/src/main/java/sirius/biz/util/ReportUnusedNLSKeysJob.java
+++ b/src/main/java/sirius/biz/util/ReportUnusedNLSKeysJob.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.util;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import sirius.biz.cluster.InterconnectClusterManager;
 import sirius.biz.jobs.StandardCategories;
 import sirius.biz.jobs.batch.SimpleBatchProcessJobFactory;
@@ -85,14 +85,14 @@ public class ReportUnusedNLSKeysJob extends SimpleBatchProcessJobFactory {
                       .forEach(missingKeysOfNode -> {
                           Set<String> keysOfNode = Json.getArray(missingKeysOfNode, "unused")
                                                        .valueStream()
-                                                       .map(JsonNode::asText)
+                                                       .map(JsonNode::asString)
                                                        .collect(Collectors.toSet());
 
                           process.log(ProcessLog.info()
                                                 .withFormattedMessage("Received %s keys from %s",
                                                                       keysOfNode.size(),
                                                                       missingKeysOfNode.path(InterconnectClusterManager.RESPONSE_NODE_NAME)
-                                                                                       .asText()));
+                                                                                       .asString()));
                           missingKeys.retainAll(keysOfNode);
                       });
 

--- a/src/test/kotlin/sirius/biz/cluster/work/DistributedTasksTest.kt
+++ b/src/test/kotlin/sirius/biz/cluster/work/DistributedTasksTest.kt
@@ -8,7 +8,7 @@
 
 package sirius.biz.cluster.work
 
-import com.fasterxml.jackson.databind.node.ObjectNode
+import tools.jackson.databind.node.ObjectNode
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -38,7 +38,7 @@ class DistributedTasksTest {
             override fun queueName(): String = "fifo-test"
 
             override fun executeWork(context: ObjectNode) {
-                if (context.path("test").asText() == "test") {
+                if (context.path("test").asString() == "test") {
                     fifoSynchronizer.success()
                 }
             }

--- a/src/test/kotlin/sirius/biz/cluster/work/DistributedTasksTest.kt
+++ b/src/test/kotlin/sirius/biz/cluster/work/DistributedTasksTest.kt
@@ -38,7 +38,7 @@ class DistributedTasksTest {
             override fun queueName(): String = "fifo-test"
 
             override fun executeWork(context: ObjectNode) {
-                if (context.path("test").asString() == "test") {
+                if (context.path("test").asString("") == "test") {
                     fifoSynchronizer.success()
                 }
             }

--- a/src/test/kotlin/sirius/biz/web/autoloading/AutoloadControllerTest.kt
+++ b/src/test/kotlin/sirius/biz/web/autoloading/AutoloadControllerTest.kt
@@ -30,7 +30,7 @@ class AutoloadControllerTests {
                 .withParameter("intField", 42)
                 .withParameter("listField", listOf("listItem1", "listItem2"))
                 .execute()
-        val id = response.contentAsJson.path("id").asText(null)
+        val id = response.contentAsJson.path("id").asString(null)
         assertNotNull(id)
         mango.find(AutoLoadEntity::class.java, id).get().apply {
             assertEquals("string1", stringField)
@@ -53,7 +53,7 @@ class AutoloadControllerTests {
                 .withParameter("intField", 1)
                 .withParameter("listField", listOf("listItem3", "listItem4"))
                 .execute()
-        val id = response.contentAsJson.path("id").asText(null)
+        val id = response.contentAsJson.path("id").asString(null)
         assertNotNull(id)
         mango.find(AutoLoadEntity::class.java, id).get().apply {
             assertEquals("string-autoloaded", stringField)


### PR DESCRIPTION
### BREAKING CHANGES

Upgrades Jackson from 2.22.0 to 3.2.0 across the sirius stack. Jackson 3 uses new Maven coordinates and Java packages — see the official [Jackson 3 migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md) and [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0) for the complete list of renames and behavioral changes.

What applications using the sirius framework have to change:

- Rename imports `com.fasterxml.jackson.*` → `tools.jackson.*` (annotations stay on `com.fasterxml.jackson.annotation`); drop `jackson-datatype-jsr310` and `JavaTimeModule` registrations (built-in now).
- Fix the resulting compile errors: unchecked exceptions (`JsonProcessingException` → `JacksonException`, dead `catch (IOException)` blocks), method renames (`asText()` → `asString()` etc., `writeFieldName()` → `writeName()` etc.), builder-based mapper/generator configuration — see the migration guide for details.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1149](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1149)
- This PR is related to PRs:
  - https://github.com/scireum/sirius-parent/pull/79
  - https://github.com/scireum/sirius-kernel/pull/628

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.