### PR TITLE
Upgrade Jupiter and Redis containers; refactor Redis client usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.2.6-alpine
+    image: redis:8.8.0-alpine
     ports:
       - "6379"
     hostname: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     hostname: redis
 
   redis-jupiter:
-    image: scireum/jupiter-io:3.1.4
+    image: scireum/jupiter-io:4.1.4
     ports:
       - "2410"
     hostname: redis-jupiter

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sirius.kernel>52.1.1</sirius.kernel>
         <sirius.web>106.0.4</sirius.web>
-        <sirius.db>68.2.0</sirius.db>
+        <sirius.db>69.0.0</sirius.db>
         <aws.sdk>2.46.21</aws.sdk>
         <commonmark>0.29.0</commonmark>
     </properties>

--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -9,6 +9,7 @@
 package sirius.biz.cluster;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import redis.clients.jedis.params.SetParams;
 import sirius.biz.cluster.work.DistributedQueueInfo;
 import sirius.biz.cluster.work.DistributedTasks;
 import sirius.db.redis.Redis;
@@ -326,9 +327,10 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
             }
 
             return redis.query(() -> "Write last execution of " + syncName, db -> {
-                long update =
-                        db.setnx(syncName + EXECUTION_TIMESTAMP_SUFFIX, String.valueOf(System.currentTimeMillis()));
-                if (update == 1L) {
+                String reply = db.set(syncName + EXECUTION_TIMESTAMP_SUFFIX,
+                                      String.valueOf(System.currentTimeMillis()),
+                                      SetParams.setParams().nx());
+                if ("OK".equals(reply)) {
                     db.expire(syncName + EXECUTION_TIMESTAMP_SUFFIX,
                               TimeUnit.HOURS.toSeconds(MIN_WAIT_DAILY_TASK_HOURS));
                     return true;

--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -329,14 +329,10 @@ public class NeighborhoodWatch implements Orchestration, Initializable, Intercon
             return redis.query(() -> "Write last execution of " + syncName, db -> {
                 String reply = db.set(syncName + EXECUTION_TIMESTAMP_SUFFIX,
                                       String.valueOf(System.currentTimeMillis()),
-                                      SetParams.setParams().nx());
-                if ("OK".equals(reply)) {
-                    db.expire(syncName + EXECUTION_TIMESTAMP_SUFFIX,
-                              TimeUnit.HOURS.toSeconds(MIN_WAIT_DAILY_TASK_HOURS));
-                    return true;
-                } else {
-                    return false;
-                }
+                                      SetParams.setParams()
+                                               .nx()
+                                               .ex(TimeUnit.HOURS.toSeconds(MIN_WAIT_DAILY_TASK_HOURS)));
+                return "OK".equals(reply);
             });
         } catch (Exception exception) {
             Exceptions.handle(Cluster.LOG, exception);

--- a/src/main/java/sirius/biz/cluster/RedisUserMessageCache.java
+++ b/src/main/java/sirius/biz/cluster/RedisUserMessageCache.java
@@ -11,6 +11,7 @@ package sirius.biz.cluster;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import redis.clients.jedis.params.SetParams;
 import sirius.db.redis.Redis;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
@@ -52,7 +53,7 @@ public class RedisUserMessageCache implements DistributedUserMessageCache {
         }
 
         redis.exec(() -> "Write to RedisUserMessageCache",
-                   jedis -> jedis.setex(CACHE_NAME + key, DEFAULT_TTL, Json.write(array)));
+                   jedis -> jedis.set(CACHE_NAME + key, Json.write(array), SetParams.setParams().ex(DEFAULT_TTL)));
     }
 
     @Override

--- a/src/main/java/sirius/biz/cluster/work/RedisNamedCounters.java
+++ b/src/main/java/sirius/biz/cluster/work/RedisNamedCounters.java
@@ -8,8 +8,8 @@
 
 package sirius.biz.cluster.work;
 
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Transaction;
+import redis.clients.jedis.AbstractTransaction;
+import redis.clients.jedis.UnifiedJedis;
 import sirius.db.redis.Redis;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Wait;
@@ -43,11 +43,10 @@ class RedisNamedCounters implements NamedCounters {
     @Override
     public long get(String counter) {
         return redis.query(() -> Strings.apply("Read counter %s for %s", counter, name),
-                           db -> readCounter(db, counter).orElse(0L));
+                           db -> parseCounter(db.hget(name, counter), counter).orElse(0L));
     }
 
-    private Optional<Long> readCounter(Jedis db, String counter) {
-        String value = db.hget(name, counter);
+    private Optional<Long> parseCounter(String value, String counter) {
         if (value == null) {
             return Optional.empty();
         } else {
@@ -89,27 +88,35 @@ class RedisNamedCounters implements NamedCounters {
                         .handle();
     }
 
-    private Long tryToDecrement(String counter, Jedis db) {
-        db.watch(name);
-        Optional<Long> counterValue = readCounter(db, counter);
-        if (counterValue.isEmpty()) {
-            db.unwatch();
-            return 0L;
-        }
+    private Long tryToDecrement(String counter, UnifiedJedis db) {
+        // We need to WATCH, read and MULTI/EXEC on the very same connection, therefore we obtain a
+        // transaction with manual control (doMulti = false) which pins a single connection instead
+        // of letting each command borrow an arbitrary connection from the pool.
+        try (AbstractTransaction transaction = db.transaction(false)) {
+            transaction.watch(name);
 
-        long nextCounterValue = Math.max(0, counterValue.get() - 1);
-        Transaction transaction = db.multi();
-        if (nextCounterValue == 0) {
-            transaction.hdel(name, counter);
-        } else {
-            transaction.hset(name, counter, String.valueOf(nextCounterValue));
-        }
+            // Commands issued before multi() are executed immediately, so we can read the current
+            // value through the very same (watched) connection.
+            Optional<Long> counterValue = parseCounter(transaction.hget(name, counter).get(), counter);
+            if (counterValue.isEmpty()) {
+                transaction.unwatch();
+                return 0L;
+            }
 
-        List<?> response = transaction.exec();
-        if (response == null || response.isEmpty()) {
-            return null;
-        } else {
-            return nextCounterValue;
+            long nextCounterValue = Math.max(0, counterValue.get() - 1);
+            transaction.multi();
+            if (nextCounterValue == 0) {
+                transaction.hdel(name, counter);
+            } else {
+                transaction.hset(name, counter, String.valueOf(nextCounterValue));
+            }
+
+            List<?> response = transaction.exec();
+            if (response == null || response.isEmpty()) {
+                return null;
+            } else {
+                return nextCounterValue;
+            }
         }
     }
 }

--- a/src/main/java/sirius/biz/cluster/work/RedisPrioritizedQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/RedisPrioritizedQueue.java
@@ -9,7 +9,7 @@
 package sirius.biz.cluster.work;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 import sirius.db.KeyGenerator;
 import sirius.db.redis.Redis;
 import sirius.kernel.commons.Json;
@@ -59,7 +59,7 @@ class RedisPrioritizedQueue implements PrioritizedQueue {
         return "distributed_prioritized_queue_" + queueName;
     }
 
-    private String storeTask(Jedis db, ObjectNode task) {
+    private String storeTask(UnifiedJedis db, ObjectNode task) {
         int retries = MAX_ATTEMPTS_TO_GENERATE_UNIQUE_TASK_ID;
         String taskMap = getRedisTaskMapKeyName();
         String taskData = Json.write(task);

--- a/src/main/java/sirius/biz/isenguard/RedisLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/RedisLimiter.java
@@ -102,7 +102,7 @@ public class RedisLimiter implements Limiter {
     @Override
     public Set<String> getBlockedIPs() {
         return getDB().query(() -> "Query blocked IPs",
-                             db -> new HashSet<>(db.zrange(BLOCKED_IPS, ZRangeParams.zrangeParams(0, 50))));
+                             db -> new HashSet<>(db.zrange(BLOCKED_IPS, ZRangeParams.zrangeParams(0, 50).rev())));
     }
 
     public boolean isConfigured() {

--- a/src/main/java/sirius/biz/isenguard/RedisLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/RedisLimiter.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.isenguard;
 
+import redis.clients.jedis.params.ZRangeParams;
 import sirius.db.redis.Redis;
 import sirius.db.redis.RedisDB;
 import sirius.kernel.commons.Strings;
@@ -100,7 +101,8 @@ public class RedisLimiter implements Limiter {
 
     @Override
     public Set<String> getBlockedIPs() {
-        return getDB().query(() -> "Query blocked IPs", db -> new HashSet<>(db.zrevrange(BLOCKED_IPS, 0, 50)));
+        return getDB().query(() -> "Query blocked IPs",
+                             db -> new HashSet<>(db.zrange(BLOCKED_IPS, ZRangeParams.zrangeParams(0, 50))));
     }
 
     public boolean isConfigured() {

--- a/src/main/java/sirius/biz/jupiter/IDBTable.java
+++ b/src/main/java/sirius/biz/jupiter/IDBTable.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.jupiter;
 
-import redis.clients.jedis.Connection;
 import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.PullBasedSpliterator;
 import sirius.kernel.commons.Strings;
@@ -413,7 +412,7 @@ public class IDBTable {
         });
     }
 
-    private List<Values> parseQueryResult(Connection redis) {
+    private List<Values> parseQueryResult(JupiterConnection redis) {
         Object result = redis.getOne();
         if (result instanceof List) {
             return ((List<?>) result).stream().map(this::parseRow).toList();

--- a/src/main/java/sirius/biz/jupiter/JupiterConnection.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnection.java
@@ -1,0 +1,118 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jupiter;
+
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.util.List;
+
+/**
+ * Provides raw command access to a {@link UnifiedJedis} while emulating the request/response API which was
+ * previously provided by the low-level {@code redis.clients.jedis.Connection}.
+ * <p>
+ * Since Jedis 7.5, {@code RedisDB} hands out a managed, shared {@link UnifiedJedis} instead of a poolable
+ * connection. As {@link UnifiedJedis} executes each command atomically (borrow a connection, write, read, return),
+ * the classic two-step pattern of first sending a command and then fetching the reply no longer maps to a single
+ * connection. This adapter bridges that gap by executing the command in {@link #sendCommand} and buffering the raw
+ * reply so that it can subsequently be retrieved via the various {@code getXXXReply} methods used throughout the
+ * Jupiter package.
+ * <p>
+ * The raw reply produced by {@link UnifiedJedis#sendCommand} uses the identical wire representation (RESP2) as the
+ * former {@code Connection}: simple and bulk strings are returned as <tt>byte[]</tt>, integers as <tt>Long</tt> and
+ * arrays as <tt>List</tt>. Therefore, all existing parsing (see {@link Jupiter#read}) remains valid.
+ * <p>
+ * An instance is stateful (it buffers the last reply) and therefore must not be shared across threads. A fresh
+ * instance is created for every command execution by {@link JupiterConnector}.
+ */
+public class JupiterConnection {
+
+    private final UnifiedJedis jedis;
+    private Object lastReply;
+
+    protected JupiterConnection(UnifiedJedis jedis) {
+        this.jedis = jedis;
+    }
+
+    /**
+     * Executes the given command and buffers its reply for later retrieval.
+     *
+     * @param command the command to execute
+     * @param args    the arguments to pass to the command
+     */
+    public void sendCommand(ProtocolCommand command, String... args) {
+        this.lastReply = jedis.executeCommand(new CommandArguments(command).addObjects((Object[]) args));
+    }
+
+    /**
+     * Returns the buffered reply of the last command interpreted as a status code (simple string).
+     *
+     * @return the status code reply or <tt>null</tt> if none was received
+     */
+    public String getStatusCodeReply() {
+        return decodeString(lastReply);
+    }
+
+    /**
+     * Returns the buffered reply of the last command interpreted as a bulk string.
+     *
+     * @return the bulk string reply or <tt>null</tt> if none was received
+     */
+    public String getBulkReply() {
+        return decodeString(lastReply);
+    }
+
+    /**
+     * Returns the buffered reply of the last command interpreted as an integer.
+     *
+     * @return the integer reply or <tt>null</tt> if none was received
+     */
+    public Long getIntegerReply() {
+        return (Long) lastReply;
+    }
+
+    /**
+     * Returns the buffered reply of the last command interpreted as an array of arbitrary objects.
+     *
+     * @return the array reply as a list of raw objects
+     */
+    @SuppressWarnings("unchecked")
+    public List<Object> getObjectMultiBulkReply() {
+        return (List<Object>) lastReply;
+    }
+
+    /**
+     * Returns the buffered reply of the last command interpreted as an array of integers.
+     *
+     * @return the array reply as a list of integers
+     */
+    @SuppressWarnings("unchecked")
+    public List<Long> getIntegerMultiBulkReply() {
+        return (List<Long>) lastReply;
+    }
+
+    /**
+     * Returns the raw buffered reply of the last command.
+     *
+     * @return the raw reply object which is either a <tt>byte[]</tt>, a <tt>Long</tt> or a <tt>List</tt>
+     */
+    public Object getOne() {
+        return lastReply;
+    }
+
+    private static String decodeString(Object reply) {
+        if (reply == null) {
+            return null;
+        }
+
+        return SafeEncoder.encode((byte[]) reply);
+    }
+}

--- a/src/main/java/sirius/biz/jupiter/JupiterConnector.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnector.java
@@ -9,8 +9,7 @@
 package sirius.biz.jupiter;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import redis.clients.jedis.Connection;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import sirius.db.redis.RedisDB;
 import sirius.kernel.Sirius;
@@ -105,7 +104,7 @@ public class JupiterConnector {
      * @param <T>         the generic type of the result
      * @return a result computed by <tt>task</tt>
      */
-    public <T> T query(Supplier<String> description, Function<Connection, T> task) {
+    public <T> T query(Supplier<String> description, Function<JupiterConnection, T> task) {
         if (fallbackRedis == null) {
             return queryDirect(description, task);
         }
@@ -129,12 +128,12 @@ public class JupiterConnector {
     }
 
     private <T> T performWithFailover(Supplier<String> description,
-                                      Function<Connection, T> task,
+                                      Function<JupiterConnection, T> task,
                                       RedisDB main,
                                       RedisDB fallback,
                                       Runnable executeOnFailover) {
-        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME); Jedis jedis = main.getConnection()) {
-            return perform(description, jedis, task);
+        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME)) {
+            return perform(description, main.getConnection(), task);
         } catch (JedisConnectionException _) {
             executeOnFailover.run();
             return performWithoutFailover(description, task, fallback);
@@ -143,19 +142,20 @@ public class JupiterConnector {
         }
     }
 
-    private <T> T performWithoutFailover(Supplier<String> description, Function<Connection, T> task, RedisDB redis) {
-        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME);
-             Jedis jedis = redis.getConnection()) {
-            return perform(description, jedis, task);
+    private <T> T performWithoutFailover(Supplier<String> description,
+                                         Function<JupiterConnection, T> task,
+                                         RedisDB redis) {
+        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME)) {
+            return perform(description, redis.getConnection(), task);
         } catch (Exception exception) {
             throw Exceptions.handle(Jupiter.LOG, exception);
         }
     }
 
-    private <T> T perform(Supplier<String> description, Jedis jedis, Function<Connection, T> task) {
+    private <T> T perform(Supplier<String> description, UnifiedJedis jedis, Function<JupiterConnection, T> task) {
         Watch watch = Watch.start();
         try {
-            return task.apply(jedis.getClient());
+            return task.apply(new JupiterConnection(jedis));
         } catch (JedisConnectionException exception) {
             throw exception;
         } catch (Exception exception) {
@@ -179,10 +179,9 @@ public class JupiterConnector {
      * @param <T>         the generic type of the result
      * @return a result computed by <tt>task</tt>
      */
-    public <T> T queryDirect(Supplier<String> description, Function<Connection, T> task) {
-        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME);
-             Jedis jedis = redis.getConnection()) {
-            return perform(description, jedis, task);
+    public <T> T queryDirect(Supplier<String> description, Function<JupiterConnection, T> task) {
+        try (var _ = new Operation(description, EXPECTED_JUPITER_COMMAND_RUNTIME)) {
+            return perform(description, redis.getConnection(), task);
         } catch (Exception error) {
             throw Exceptions.handle()
                             .to(Jupiter.LOG)
@@ -204,7 +203,7 @@ public class JupiterConnector {
      * @param description a description of the actions performed used for debugging and tracing
      * @param task        the actual task to perform using redis
      */
-    public void exec(Supplier<String> description, Consumer<Connection> task) {
+    public void exec(Supplier<String> description, Consumer<JupiterConnection> task) {
         query(description, client -> {
             task.accept(client);
             return null;
@@ -220,7 +219,7 @@ public class JupiterConnector {
      * @param description a description of the actions performed used for debugging and tracing
      * @param task        the actual task to perform using redis
      */
-    public void execDirect(Supplier<String> description, Consumer<Connection> task) {
+    public void execDirect(Supplier<String> description, Consumer<JupiterConnection> task) {
         queryDirect(description, client -> {
             task.accept(client);
             return null;

--- a/src/main/java/sirius/biz/jupiter/JupiterConnector.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnector.java
@@ -26,12 +26,12 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Permits to access a <b>Jupiter</b> instance.
+ * Permits accessing a <b>Jupiter</b> instance.
  * <p>
  * This connector is in charge of taking of about the connection management. It also permits failing over to
  * a fallback instance in case the main instance isn't reachable.
  * <p>
- * If a failover is performed, we will continue to use the fallback for up to 60s before we attempt to switch
+ * If a fail-over is performed, we will continue to use the fallback for up to 60 seconds before we attempt to switch
  * back to the main instance.
  * <p>
  * A connector is usually obtained via {@link Jupiter#getConnector(String)} or {@link Jupiter#getDefault()}.
@@ -42,9 +42,9 @@ public class JupiterConnector {
     private static final JupiterCommand CMD_PYRUN = new JupiterCommand("PY.RUN");
 
     /**
-     * If a failover is performed, we keep using the fallback instance for a certain amount of time to prevent
+     * If a fail-over is performed, we keep using the fallback instance for a certain amount of time to prevent
      * constant switching back and forth in case of network problems (etc.). This constant determines the interval
-     * before a failover back to the main instance is attempted.
+     * before a fail-over back to the main instance is attempted.
      */
     private static final int FAILOVER_TRIGGER_REARM_INTERVAL = 60_000;
 
@@ -169,9 +169,9 @@ public class JupiterConnector {
     }
 
     /**
-     * Executes one or more commands and returns a value of the given type without attempting a failover.
+     * Executes one or more commands and returns a value of the given type without attempting a fail-over.
      * <p>
-     * If the main connection pool isn't available, this will not perform a failover but abort immediately.
+     * If the main connection pool isn't available, this will not perform a fail-over but abort immediately.
      * This can be used to execute administrative commands, which have to be executed on the target instance.
      *
      * @param description a description of the actions performed used for debugging and tracing
@@ -213,7 +213,7 @@ public class JupiterConnector {
     /**
      * Executes one or more Jupiter commands without any return value.
      * <p>
-     * If the main connection pool isn't available, this will not perform a failover but abort immediately.
+     * If the main connection pool isn't available, this will not perform a fail-over but abort immediately.
      * This can be used to execute administrative commands, which have to be executed on the target instance.
      *
      * @param description a description of the actions performed used for debugging and tracing

--- a/src/main/java/sirius/biz/jupiter/JupiterConnector.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnector.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
 /**
  * Permits accessing a <b>Jupiter</b> instance.
  * <p>
- * This connector is in charge of taking of about the connection management. It also permits failing over to
+ * This connector is in charge of taking care of the connection management. It also permits failing over to
  * a fallback instance in case the main instance isn't reachable.
  * <p>
  * If a fail-over is performed, we will continue to use the fallback for up to 60 seconds before we attempt to switch

--- a/src/main/java/sirius/biz/saml/SamlReplayProtector.java
+++ b/src/main/java/sirius/biz/saml/SamlReplayProtector.java
@@ -8,7 +8,7 @@
 
 package sirius.biz.saml;
 
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.params.SetParams;
 import sirius.db.redis.Redis;
 import sirius.kernel.commons.Strings;
@@ -84,7 +84,7 @@ public class SamlReplayProtector {
      * @param ttlSeconds the number of seconds until the reservation expires
      * @return <tt>true</tt> if the key was created, <tt>false</tt> if it already existed
      */
-    private boolean reserveKey(Jedis db, String key, long ttlSeconds) {
+    private boolean reserveKey(UnifiedJedis db, String key, long ttlSeconds) {
         String result = db.set(key, VALUE, SetParams.setParams().nx().ex(ttlSeconds));
         return REDIS_RESPONSE_SUCCESS.equals(result);
     }

--- a/src/main/java/sirius/biz/util/RedisController.java
+++ b/src/main/java/sirius/biz/util/RedisController.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.util;
 
+import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.util.SafeEncoder;
 import sirius.biz.tenants.TenantUserManager;
 import sirius.biz.web.BizController;
@@ -69,9 +70,9 @@ public class RedisController extends BizController {
         Object result = pool.query(() -> "Executing query via /system/redis", db -> {
             try {
                 CommandParser parser = new CommandParser(query);
-                db.getClient().sendCommand(() -> SafeEncoder.encode(parser.parseCommand()), parser.getArgArray());
-
-                return db.getClient().getOne();
+                CommandArguments command =
+                        new CommandArguments(() -> SafeEncoder.encode(parser.parseCommand())).addObjects((Object[]) parser.getArgArray());
+                return db.executeCommand(command);
             } catch (Exception exception) {
                 // In case of an invalid query, we do not want to log this into the syslog but
                 // rather just directly output the message to the user....

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.2.6-alpine
+    image: redis:8.8.0-alpine
     ports:
       - "6379"
     hostname: redis

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     hostname: redis
 
   redis-jupiter:
-    image: scireum/jupiter-io:3.1.4
+    image: scireum/jupiter-io:4.1.4
     ports:
       - "2410"
     hostname: redis-jupiter


### PR DESCRIPTION
### Description

This pull request includes the following changes:
- Upgraded the Jupiter container to version 4.1.4 and the Redis container to version 8.8.0.
- Fixed typos in related code.
- Refactored Jupiter to support a new Redis client by introducing a `JupiterConnection` to bridge command calls and their replies. This change optimizes interactions as Jupiter uses the Redis protocol for communication but does not use a Redis server.
- Replaced `Jedis` with `UnifiedJedis` and updated deprecated calls accordingly.

### Additional Notes

- This PR fixes or works on the following ticket(s): [SIRI-1196](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1196)
- This PR is related to PR: https://github.com/scireum/sirius-db/pull/760

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.