### PR TITLE
Replace spy exit badges with plain HTML forms

### DIFF
--- a/src/main/resources/default/extensions/tycho-page/tenant-info.html.pasta
+++ b/src/main/resources/default/extensions/tycho-page/tenant-info.html.pasta
@@ -10,23 +10,31 @@
                                       .map(|spyUser| spyUser.getRootUser().getUserId() == user().getUserId())
                                       .orElse(false)"/>
                 <i:if test="@isTenantSpy">
-                    <t:editForm url="/tenants/select/main" class="d-inline">
+                    <form action="/tenants/select/main"
+                          method="post"
+                          id="spyTenantExitForm"
+                          class="d-inline">
                         <button class="badge border-0 text-white bg-sirius-orange-light text-decoration-none"
                                 type="submit">
                             @currentUserName()
                             <i:if test="isFilled(user().getTenantName())">(@user().getTenantName())</i:if>
                             <i class="ms-1 fa-solid fa-times"></i>
                         </button>
-                    </t:editForm>
+                        <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
+                    </form>
                     <i:else>
-                        <t:editForm url="/user-accounts/select/main" class="d-inline">
+                        <form action="/user-accounts/select/main"
+                              method="post"
+                              id="spyUserExitForm"
+                              class="d-inline">
                             <button class="badge border-0 text-white bg-sirius-orange-light text-decoration-none"
                                     type="submit">
                                 @currentUserName()
                                 <i:if test="isFilled(user().getTenantName())">(@user().getTenantName())</i:if>
                                 <i class="ms-1 fa-solid fa-times"></i>
                             </button>
-                        </t:editForm>
+                            <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
+                        </form>
                     </i:else>
                 </i:if>
             </t:permission>

--- a/src/main/resources/default/templates/biz/tenants/select-tenant.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/select-tenant.html.pasta
@@ -19,9 +19,13 @@
 
         <t:searchHeader page="tenants" baseUrl="/tenants/select">
             <i:if test="isSpy">
-                <t:editForm url="/tenants/select/main" class="d-inline">
+                <form action="/tenants/select/main"
+                      method="post"
+                      id="spyTenantExitForm"
+                      class="d-inline">
                     <button class="btn btn-primary" type="submit">@i18n("Tenant.selectMain")</button>
-                </t:editForm>
+                    <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
+                </form>
             </i:if>
         </t:searchHeader>
 

--- a/src/main/resources/default/templates/biz/tenants/select-user-account.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/select-user-account.html.pasta
@@ -17,9 +17,13 @@
         </i:block>
         <t:searchHeader page="users" baseUrl="/user-accounts/select">
             <i:if test="isSpy">
-                <t:editForm url="/user-accounts/select/main" class="d-inline">
+                <form action="/user-accounts/select/main"
+                      method="post"
+                      id="spyUserExitForm"
+                      class="d-inline">
                     <button class="btn btn-primary" type="submit">@i18n("UserAccount.selectMain")</button>
-                </t:editForm>
+                    <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
+                </form>
             </i:if>
         </t:searchHeader>
 


### PR DESCRIPTION
### Description
Spy exit actions previously used `t:editForm`, which always adds `class="edit-form"` and defaults to `id="mainEditForm"`. For spy users that collided with the page editor form and with JS that targets `.edit-form` / `#mainEditForm` (e.g. blob image fields, Query Tool, Jobs).

This PR switches the spy exit UI to plain HTML forms with dedicated IDs and an explicit CSRF token, matching the Wondergem spy badge approach:
- Tycho nav badge (`tenant-info`)
- Select-tenant / select-user-account “back to main” buttons
- Behavior of the spy exit itself is unchanged (same POST targets and CSRF).

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1242](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1242)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
