### PR TITLE
SIRI-1255: Upgrade MariaDB to 11.8.8-noble

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     hostname: mongo
 
   mariadb:
-    image: mariadb:11.8.3-noble
+    image: mariadb:11.8.8-noble
     ports:
       - "3306"
     environment:

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     hostname: mongo
 
   mariadb:
-    image: mariadb:11.8.3-noble
+    image: mariadb:11.8.8-noble
     ports:
       - "3306"
     environment:


### PR DESCRIPTION
Part of SIRI-1255.

Upgrades the MariaDB Docker image `11.8.3-noble` -> `11.8.8-noble` (current 11.8 LTS patch) in `docker-compose.yml` and `src/test/resources/docker-compose.yml`. Only the image tag changed.