### PR TITLE
Bump mongo image version from 8.0.10 to 8.3.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     hostname: redis-jupiter
 
   mongo:
-    image: mongo:8.0.10
+    image: mongo:8.3.7
     ports:
       - "27017"
     hostname: mongo

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <sirius.kernel>52.1.1</sirius.kernel>
-        <sirius.web>106.1.0</sirius.web>
-        <sirius.db>69.0.1</sirius.db>
+        <sirius.web>106.3.0</sirius.web>
+        <sirius.db>69.1.0</sirius.db>
         <aws.sdk>2.48.0</aws.sdk>
         <commonmark>0.29.0</commonmark>
     </properties>

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     hostname: redis-jupiter
 
   mongo:
-    image: mongo:8.0.10
+    image: mongo:8.3.7
     ports:
       - "27017"
     hostname: mongo


### PR DESCRIPTION
### Description

Bumps the MongoDB test image (docker-compose.yml and src/test/resources/docker-compose.yml) from 8.0.8 to 8.3.7, a security-relevant patch release.

This is related to [scireum/sirius-db#765](https://github.com/scireum/sirius-db/pull/765), which bumps the `mongodb-driver-sync` dependency to 5.9.0 and the same test image version in sirius-db. That PR is not yet merged/released, so this PR does not bump the `sirius.db` version here — it will follow once sirius-db#765 ships a release.

Per the ticket's Patch Tasks, a feature compatibility version (FCV) change is required on deployed MongoDB instances:
- Before upgrade: verify FCV is `8.0` via `db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 })`, set with `db.adminCommand({ setFeatureCompatibilityVersion: "8.0", confirm: true })` if needed.
- After upgrade: `db.adminCommand({ setFeatureCompatibilityVersion: "8.3", confirm: true })`

### Additional Notes

- This PR fixes or works on the following ticket(s): [SIRI-1198](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1198)
- This PR is related to PR: scireum/sirius-db#765

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & best practices
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.