### PR TITLE
Use POST for card clicks on tenant and user select pages

### DIFF
--- a/src/main/java/sirius/biz/tenants/TenantController.java
+++ b/src/main/java/sirius/biz/tenants/TenantController.java
@@ -442,7 +442,7 @@ public abstract class TenantController<I extends Serializable, T extends BaseEnt
 
         if (isSwitchToMain) {
             switchBackToMainTenant(webContext);
-            webContext.respondWith().redirectTemporarily(redirectTarget);
+            webContext.respondWith().redirectToGet(redirectTarget);
             return;
         }
 
@@ -461,12 +461,12 @@ public abstract class TenantController<I extends Serializable, T extends BaseEnt
         if (Strings.areEqual(getUser().getTenantId(), tenantId)) {
             // The tenant of the current user we are spying is the same as the one we want to switch to,
             // so we simply navigate to the target URL.
-            webContext.respondWith().redirectTemporarily(redirectTarget);
+            webContext.respondWith().redirectToGet(redirectTarget);
             return;
         }
 
         switchToTenant(webContext, effectiveTenant);
-        webContext.respondWith().redirectTemporarily(redirectTarget);
+        webContext.respondWith().redirectToGet(redirectTarget);
     }
 
     private void switchBackToMainTenant(WebContext webContext) {

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -739,7 +739,7 @@ public abstract class UserAccountController<I extends Serializable, T extends Ba
 
         if ("main".equals(accountId)) {
             if (!isCurrentlySpying(webContext)) {
-                webContext.respondWith().redirectTemporarily(redirectTarget);
+                webContext.respondWith().redirectToGet(redirectTarget);
                 return;
             }
 
@@ -753,7 +753,7 @@ public abstract class UserAccountController<I extends Serializable, T extends Ba
 
             webContext.setSessionValue(UserContext.getCurrentScope().getScopeId() + TenantUserManager.SPY_ID_SUFFIX,
                                        null);
-            webContext.respondWith().redirectTemporarily(redirectTarget);
+            webContext.respondWith().redirectToGet(redirectTarget);
             return;
         }
 
@@ -775,7 +775,7 @@ public abstract class UserAccountController<I extends Serializable, T extends Ba
 
         webContext.setSessionValue(UserContext.getCurrentScope().getScopeId() + TenantUserManager.SPY_ID_SUFFIX,
                                    effectiveUser.getUniqueName());
-        webContext.respondWith().redirectTemporarily(redirectTarget);
+        webContext.respondWith().redirectToGet(redirectTarget);
     }
 
     private Optional<U> resolveSelectableUser(WebContext webContext, String accountId) {

--- a/src/main/resources/default/templates/biz/tenants/select-tenant.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/select-tenant.html.pasta
@@ -33,6 +33,7 @@
                   tenants="tenants"
                   paginationBaseUrl="@('/tenants/select')"
                   cardBaseUrl="@('/tenants/select')"
-                  enableCardActions="false"/>
+                  enableCardActions="false"
+                  cardLinkViaPost="true"/>
     </t:sidebar>
 </t:page>

--- a/src/main/resources/default/templates/biz/tenants/select-user-account.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/select-user-account.html.pasta
@@ -31,6 +31,7 @@
                   accounts="users"
                   paginationBaseUrl="@('/user-accounts/select')"
                   cardBaseUrl="@('/user-accounts/select')"
-                  cardActionsType="select"/>
+                  cardActionsType="select"
+                  cardLinkViaPost="true"/>
     </t:sidebar>
 </t:page>

--- a/src/main/resources/default/templates/biz/tenants/tenants-list.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/tenants-list.html.pasta
@@ -2,6 +2,7 @@
 <i:arg type="String" name="paginationBaseUrl"/>
 <i:arg type="String" name="cardBaseUrl"/>
 <i:arg type="boolean" name="enableCardActions"/>
+<i:arg type="boolean" name="cardLinkViaPost" default="false"/>
 
 <t:emptyCheck data="tenants">
     <t:datacards>
@@ -9,7 +10,8 @@
             <t:datacard subTitle="@tenant.getTenantData().getAccountNumber()"
                         headerLeft="true"
                         headerLeftAlignmentClass="align-items-stretch text-break break-word"
-                        link="@apply('%s/%s', cardBaseUrl, tenant.getIdAsString())">
+                        link="@apply('%s/%s', cardBaseUrl, tenant.getIdAsString())"
+                        sendPostRequest="@cardLinkViaPost">
                 <i:block name="header">
                     <div class="ps-2 pe-1 align-self-center">
                         <div class="d-flex flex-column align-items-center justify-content-center"

--- a/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
+++ b/src/main/resources/default/templates/biz/tenants/user-accounts-list.html.pasta
@@ -2,6 +2,7 @@
 <i:arg type="String" name="paginationBaseUrl"/>
 <i:arg type="String" name="cardBaseUrl"/>
 <i:arg type="String" name="cardActionsType"/>
+<i:arg type="boolean" name="cardLinkViaPost" default="false"/>
 
 <t:emptyCheck data="@accounts">
     <t:datacards>
@@ -10,7 +11,8 @@
                     subTitle="@account.getUserAccountData().getLogin().getUsername()"
                     headerLeft="true"
                     headerLeftAlignmentClass="align-items-stretch text-break break-word"
-                    link="@apply('%s/%s', cardBaseUrl , account.getIdAsString())">
+                    link="@apply('%s/%s', cardBaseUrl , account.getIdAsString())"
+                    sendPostRequest="@cardLinkViaPost">
                 <i:block name="header">
                     <div class="ps-3 pe-1 align-self-center">
                         <div class="d-flex flex-column align-items-center justify-content-center"


### PR DESCRIPTION
### Description

- Adds `cardLinkViaPost` parameter to `tenants-list` and `user-accounts-list`
- Enables POST card navigation on `/tenants/select` and `/user-accounts/select` via `cardLinkViaPost="true"`
- Fixes post-takeover redirect in `TenantController` and `UserAccountController` to use `redirectToGet()` instead of `redirectTemporarily()`

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1242](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1242)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1692
### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
