### PR TITLE
Add tests for PersonData and (international) AddressData + fix

### DIFF
--- a/src/main/java/sirius/biz/model/InternationalAddressData.java
+++ b/src/main/java/sirius/biz/model/InternationalAddressData.java
@@ -75,12 +75,12 @@ public class InternationalAddressData extends AddressData {
 
     @Override
     public boolean areAllFieldsEmpty() {
-        return super.areAllFieldsEmpty() && Strings.isEmpty(country);
+        return super.areAllFieldsEmpty() && Strings.isEmpty(country.getValue());
     }
 
     @Override
     public boolean isAnyFieldEmpty() {
-        return super.isAnyFieldEmpty() || Strings.isEmpty(country);
+        return super.isAnyFieldEmpty() || Strings.isEmpty(country.getValue());
     }
 
     @Override
@@ -203,7 +203,7 @@ public class InternationalAddressData extends AddressData {
             return false;
         }
 
-        return Strings.areEqual(country, ((InternationalAddressData) obj).country);
+        return Strings.areEqual(country.getValue(), ((InternationalAddressData) obj).country.getValue());
     }
 
     @Override

--- a/src/main/java/sirius/biz/model/PersonData.java
+++ b/src/main/java/sirius/biz/model/PersonData.java
@@ -231,15 +231,14 @@ public class PersonData extends Composite {
         }
 
         return Strings.areEqual(title, ((PersonData) obj).title)
-               && Strings.areEqual(salutation,
-                                   ((PersonData) obj).salutation)
+               && Strings.areEqual(salutation.getValue(), ((PersonData) obj).salutation.getValue())
                && Strings.areEqual(firstname, ((PersonData) obj).firstname)
                && Strings.areEqual(lastname, ((PersonData) obj).lastname);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(title, salutation, firstname, lastname);
+        return Objects.hash(title, salutation.getValue(), firstname, lastname);
     }
 
     /**

--- a/src/test/kotlin/sirius/biz/model/AddressDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/AddressDataTest.kt
@@ -28,14 +28,6 @@ import kotlin.test.assertTrue
 @ExtendWith(SiriusExtension::class)
 class AddressDataTest {
 
-    private fun address(street: String? = null, zip: String? = null, city: String? = null): AddressData {
-        return AddressData().apply {
-            this.street = street
-            this.zip = zip
-            this.city = city
-        }
-    }
-
     @Test
     fun `toString combines all filled parts`() {
         assertEquals(
@@ -89,7 +81,11 @@ class AddressDataTest {
 
     @Test
     fun `verifyFullAddress rejects an incomplete address`() {
-        assertFailsWith<HandledException> { address(street = "Museumstraße 1", city = "Stuttgart").verifyFullAddress(null) }
+        assertFailsWith<HandledException> {
+            address(street = "Museumstraße 1", city = "Stuttgart").verifyFullAddress(
+                null
+            )
+        }
         assertFailsWith<HandledException> { address().verifyFullAddress(null) }
     }
 
@@ -171,5 +167,13 @@ class AddressDataTest {
         assertEquals("Museumstraße 1", addressData.street)
         assertEquals("70000", addressData.zip)
         assertEquals("Stuttgart", addressData.city)
+    }
+
+    private fun address(street: String? = null, zip: String? = null, city: String? = null): AddressData {
+        return AddressData().apply {
+            this.street = street
+            this.zip = zip
+            this.city = city
+        }
     }
 }

--- a/src/test/kotlin/sirius/biz/model/AddressDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/AddressDataTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
+import sirius.kernel.health.HandledException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [AddressData] class.
+ *
+ * The <tt>verifyXXX</tt> / <tt>validateXXX</tt> methods emit localized messages via NLS, hence the
+ * [SiriusExtension] is required to boot the framework.
+ */
+@ExtendWith(SiriusExtension::class)
+class AddressDataTest {
+
+    private fun address(street: String? = null, zip: String? = null, city: String? = null): AddressData {
+        return AddressData().apply {
+            this.street = street
+            this.zip = zip
+            this.city = city
+        }
+    }
+
+    @Test
+    fun `toString combines all filled parts`() {
+        assertEquals(
+            "Museumstraße 1 70000 Stuttgart",
+            address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").toString()
+        )
+    }
+
+    @Test
+    fun `toString omits empty parts`() {
+        assertEquals("70000 Stuttgart", address(zip = "70000", city = "Stuttgart").toString())
+        assertEquals("Stuttgart", address(city = "Stuttgart").toString())
+        assertEquals("", address().toString())
+    }
+
+    @Test
+    fun `isAnyFieldEmpty reflects whether at least one field is empty`() {
+        assertFalse { address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").isAnyFieldEmpty }
+        assertTrue { address(street = "Museumstraße 1", city = "Stuttgart").isAnyFieldEmpty }
+        assertTrue { address().isAnyFieldEmpty }
+    }
+
+    @Test
+    fun `areAllFieldsEmpty reflects whether all fields are empty`() {
+        assertTrue { address().areAllFieldsEmpty() }
+        assertFalse { address(city = "Stuttgart").areAllFieldsEmpty() }
+        assertFalse { address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").areAllFieldsEmpty() }
+    }
+
+    @Test
+    fun `isPartiallyFilled is only true for a partially filled address`() {
+        assertTrue { address(city = "Stuttgart").isPartiallyFilled }
+        assertFalse { address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").isPartiallyFilled }
+        assertFalse { address().isPartiallyFilled }
+    }
+
+    @Test
+    fun `clear resets all fields`() {
+        val addressData = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart")
+        addressData.clear()
+        assertNull(addressData.street)
+        assertNull(addressData.zip)
+        assertNull(addressData.city)
+        assertTrue { addressData.areAllFieldsEmpty() }
+    }
+
+    @Test
+    fun `verifyFullAddress accepts a fully filled address`() {
+        address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").verifyFullAddress(null)
+    }
+
+    @Test
+    fun `verifyFullAddress rejects an incomplete address`() {
+        assertFailsWith<HandledException> { address(street = "Museumstraße 1", city = "Stuttgart").verifyFullAddress(null) }
+        assertFailsWith<HandledException> { address().verifyFullAddress(null) }
+    }
+
+    @Test
+    fun `validateFullAddress collects a message only for an incomplete address`() {
+        val messages = mutableListOf<String>()
+
+        address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").validateFullAddress(null) {
+            messages.add(it)
+        }
+        assertTrue { messages.isEmpty() }
+
+        address(street = "Museumstraße 1", city = "Stuttgart").validateFullAddress(null) { messages.add(it) }
+        assertEquals(1, messages.size)
+    }
+
+    @Test
+    fun `validateFullAddress uses the given field label in the message`() {
+        val messages = mutableListOf<String>()
+
+        address(street = "Museumstraße 1", city = "Stuttgart").validateFullAddress("Rechnungsadresse") {
+            messages.add(it)
+        }
+        assertEquals(1, messages.size)
+        assertTrue { messages[0].contains("Rechnungsadresse") }
+    }
+
+    @Test
+    fun `verifyNonPartialAddress accepts a fully filled or a completely empty address`() {
+        address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").verifyNonPartialAddress(null)
+        address().verifyNonPartialAddress(null)
+    }
+
+    @Test
+    fun `verifyNonPartialAddress rejects a partially filled address`() {
+        assertFailsWith<HandledException> { address(city = "Stuttgart").verifyNonPartialAddress(null) }
+    }
+
+    @Test
+    fun `validateNonPartialAddress collects a message only for a partially filled address`() {
+        val messages = mutableListOf<String>()
+
+        address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").validateNonPartialAddress(null) {
+            messages.add(it)
+        }
+        address().validateNonPartialAddress(null) { messages.add(it) }
+        assertTrue { messages.isEmpty() }
+
+        address(city = "Stuttgart").validateNonPartialAddress(null) { messages.add(it) }
+        assertEquals(1, messages.size)
+    }
+
+    @Test
+    fun `equals is true for equal addresses`() {
+        val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart")
+        val other = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart")
+        assertEquals(one, other)
+        assertEquals(one.hashCode(), other.hashCode())
+    }
+
+    @Test
+    fun `equals is false for differing addresses`() {
+        val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart")
+        assertNotEquals(one, address(street = "Museumstraße 2", zip = "70000", city = "Stuttgart"))
+        assertNotEquals(one, address(street = "Museumstraße 1", zip = "12345", city = "Wo Auch Immer"))
+        assertNotEquals(one, address(street = "Museumstraße 1", zip = "70000", city = "Berlin"))
+    }
+
+    @Test
+    fun `equals handles null and foreign types`() {
+        val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart")
+        assertFalse { one.equals(null) }
+        assertFalse { one.equals("Museumstraße 1 70000 Stuttgart") }
+    }
+
+    @Test
+    fun `getters return the values set via the setters`() {
+        val addressData = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart")
+        assertEquals("Museumstraße 1", addressData.street)
+        assertEquals("70000", addressData.zip)
+        assertEquals("Stuttgart", addressData.city)
+    }
+}

--- a/src/test/kotlin/sirius/biz/model/InternationalAddressDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/InternationalAddressDataTest.kt
@@ -39,20 +39,6 @@ class InternationalAddressDataTest {
         CallContext.getCurrent().setLanguage("de")
     }
 
-    private fun address(
-        street: String? = null,
-        zip: String? = null,
-        city: String? = null,
-        country: String? = null
-    ): InternationalAddressData {
-        return InternationalAddressData().apply {
-            this.street = street
-            this.zip = zip
-            this.city = city
-            country?.let { this.country.value = it }
-        }
-    }
-
     @Test
     fun `the default constructor uses the active countries lookup table`() {
         assertEquals(Countries.LOOKUP_TABLE_ACTIVE_COUNTRIES, InternationalAddressData().country.tableName)
@@ -197,5 +183,19 @@ class InternationalAddressDataTest {
         val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
         assertFalse { one.equals(null) }
         assertFalse { one.equals("Museumstraße 1 70000 Stuttgart") }
+    }
+
+    private fun address(
+        street: String? = null,
+        zip: String? = null,
+        city: String? = null,
+        country: String? = null
+    ): InternationalAddressData {
+        return InternationalAddressData().apply {
+            this.street = street
+            this.zip = zip
+            this.city = city
+            country?.let { this.country.value = it }
+        }
     }
 }

--- a/src/test/kotlin/sirius/biz/model/InternationalAddressDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/InternationalAddressDataTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.model
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.biz.util.Countries
+import sirius.kernel.SiriusExtension
+import sirius.kernel.async.CallContext
+import sirius.kernel.health.HandledException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [InternationalAddressData] class.
+ *
+ * The <tt>countries</tt> and <tt>active-countries</tt> lookup tables are provided with config based test data
+ * (see <tt>test.conf</tt>): "de" resolves to "Germany" / "Deutschland" and accepts a five-digit ZIP code,
+ * "at" resolves to "Austria" / "Österreich" and accepts a four-digit ZIP code. The current language is pinned
+ * to german (the configured default, see develop.conf) so that translations are asserted deterministically
+ * regardless of the environment's default language.
+ */
+@ExtendWith(SiriusExtension::class)
+class InternationalAddressDataTest {
+
+    @BeforeEach
+    fun pinLanguage() {
+        CallContext.getCurrent().setLanguage("de")
+    }
+
+    private fun address(
+        street: String? = null,
+        zip: String? = null,
+        city: String? = null,
+        country: String? = null
+    ): InternationalAddressData {
+        return InternationalAddressData().apply {
+            this.street = street
+            this.zip = zip
+            this.city = city
+            country?.let { this.country.value = it }
+        }
+    }
+
+    @Test
+    fun `the default constructor uses the active countries lookup table`() {
+        assertEquals(Countries.LOOKUP_TABLE_ACTIVE_COUNTRIES, InternationalAddressData().country.tableName)
+    }
+
+    @Test
+    fun `a custom constructor uses the given lookup table`() {
+        assertEquals("countries", InternationalAddressData("countries").country.tableName)
+    }
+
+    @Test
+    fun `isAnyFieldEmpty is false only when street, zip, city and country are filled`() {
+        assertFalse {
+            address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de").isAnyFieldEmpty
+        }
+        assertTrue { address(zip = "70000", city = "Stuttgart", country = "de").isAnyFieldEmpty }
+    }
+
+    @Test
+    fun `clear also resets the country`() {
+        val addressData = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
+        addressData.clear()
+        assertNull(addressData.street)
+        assertNull(addressData.zip)
+        assertNull(addressData.city)
+        assertNull(addressData.country.value)
+    }
+
+    @Test
+    fun `getTranslatedCountry resolves the country in the current language`() {
+        assertEquals("Deutschland", address(country = "de").translatedCountry)
+    }
+
+    @Test
+    fun `getTranslatedCountry is null for an empty country`() {
+        assertNull(address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").translatedCountry)
+    }
+
+    @Test
+    fun `getTranslatedCountry returns an empty string for an unknown value`() {
+        // A code that is not part of the lookup table resolves to an empty name (see ConfigLookupTable).
+        assertEquals("", address(country = "xx").translatedCountry)
+    }
+
+    @Test
+    fun `verifyCountry accepts a known or empty country`() {
+        address(country = "de").verifyCountry(null)
+        address().verifyCountry(null)
+    }
+
+    @Test
+    fun `verifyCountry rejects an unknown country`() {
+        assertFailsWith<HandledException> { address(country = "unknown").verifyCountry(null) }
+    }
+
+    @Test
+    fun `validateCountry collects a message only for an unknown country`() {
+        val messages = mutableListOf<String>()
+
+        address(country = "de").validateCountry(null) { messages.add(it) }
+        address().validateCountry(null) { messages.add(it) }
+        assertTrue { messages.isEmpty() }
+
+        address(country = "unknown").validateCountry(null) { messages.add(it) }
+        assertEquals(1, messages.size)
+    }
+
+    @Test
+    fun `verifyZip accepts a ZIP matching the country pattern`() {
+        address(country = "de", zip = "70000").verifyZip(null)
+        // A four-digit ZIP is valid for Austria...
+        address(country = "at", zip = "1010").verifyZip(null)
+        // ...an empty ZIP is always accepted...
+        address(country = "de").verifyZip(null)
+        // ...and so is any ZIP if no country is selected.
+        address(zip = "not-a-zip").verifyZip(null)
+    }
+
+    @Test
+    fun `verifyZip rejects a ZIP violating the country pattern`() {
+        assertFailsWith<HandledException> { address(country = "de", zip = "ABC").verifyZip(null) }
+        // A four-digit ZIP is too short for Germany.
+        assertFailsWith<HandledException> { address(country = "de", zip = "1010").verifyZip(null) }
+    }
+
+    @Test
+    fun `validateZIP collects a message only for an invalid ZIP`() {
+        val messages = mutableListOf<String>()
+
+        address(country = "de", zip = "70000").validateZIP(null) { messages.add(it) }
+        assertTrue { messages.isEmpty() }
+
+        address(country = "de", zip = "ABC").validateZIP(null) { messages.add(it) }
+        assertEquals(1, messages.size)
+    }
+
+    @Test
+    fun `equals is reflexive`() {
+        // Note: equals() currently compares the country LookupValue by reference (Strings.areEqual falls back
+        // to Objects.equals and LookupValue has no equals/hashCode), so two value-identical instances are NOT
+        // considered equal - even though hashCode() is value based. See SIRI-1258. Hence, only reflexivity is
+        // asserted here.
+        val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
+        assertEquals(one, one)
+    }
+
+    @Test
+    fun `hashCode is based on the field values including the country`() {
+        // Note: unlike equals(), hashCode() is value based (uses country.getValue()), so two value-identical
+        // instances share a hash code. See SIRI-1258 for the resulting equals/hashCode inconsistency.
+        val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
+        val other = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
+        assertEquals(one.hashCode(), other.hashCode())
+    }
+
+    @Test
+    fun `equals is false for a differing country`() {
+        val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
+        val other = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "at")
+        assertNotEquals(one, other)
+    }
+
+    @Test
+    fun `equals is false compared to a plain address data`() {
+        val international = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart")
+        val plain = AddressData().apply {
+            street = "Museumstraße 1"
+            zip = "70000"
+            city = "Stuttgart"
+        }
+        assertNotEquals(international, plain)
+    }
+
+    @Test
+    fun `equals handles null and foreign types`() {
+        val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
+        assertFalse { one.equals(null) }
+        assertFalse { one.equals("Museumstraße 1 70000 Stuttgart") }
+    }
+}

--- a/src/test/kotlin/sirius/biz/model/InternationalAddressDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/InternationalAddressDataTest.kt
@@ -69,6 +69,7 @@ class InternationalAddressDataTest {
             address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de").isAnyFieldEmpty
         }
         assertTrue { address(zip = "70000", city = "Stuttgart", country = "de").isAnyFieldEmpty }
+        assertTrue { address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").isAnyFieldEmpty }
     }
 
     @Test
@@ -150,22 +151,27 @@ class InternationalAddressDataTest {
     }
 
     @Test
-    fun `equals is reflexive`() {
-        // Note: equals() currently compares the country LookupValue by reference (Strings.areEqual falls back
-        // to Objects.equals and LookupValue has no equals/hashCode), so two value-identical instances are NOT
-        // considered equal - even though hashCode() is value based. See SIRI-1258. Hence, only reflexivity is
-        // asserted here.
+    fun `equals is true for equal addresses including the country`() {
         val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
-        assertEquals(one, one)
+        val other = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
+        assertEquals(one, other)
+        assertEquals(one.hashCode(), other.hashCode())
     }
 
     @Test
-    fun `hashCode is based on the field values including the country`() {
-        // Note: unlike equals(), hashCode() is value based (uses country.getValue()), so two value-identical
-        // instances share a hash code. See SIRI-1258 for the resulting equals/hashCode inconsistency.
-        val one = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
-        val other = address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de")
-        assertEquals(one.hashCode(), other.hashCode())
+    fun `areAllFieldsEmpty is true only for a completely empty address`() {
+        assertTrue { address().areAllFieldsEmpty() }
+        assertFalse { address(country = "de").areAllFieldsEmpty() }
+        assertFalse { address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart").areAllFieldsEmpty() }
+    }
+
+    @Test
+    fun `isPartiallyFilled reflects a partially filled address`() {
+        assertFalse { address().isPartiallyFilled }
+        assertFalse {
+            address(street = "Museumstraße 1", zip = "70000", city = "Stuttgart", country = "de").isPartiallyFilled
+        }
+        assertTrue { address(country = "de").isPartiallyFilled }
     }
 
     @Test

--- a/src/test/kotlin/sirius/biz/model/PersonDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/PersonDataTest.kt
@@ -37,20 +37,6 @@ class PersonDataTest {
         CallContext.getCurrent().setLanguage("de")
     }
 
-    private fun person(
-        title: String? = null,
-        salutation: String? = null,
-        firstname: String? = null,
-        lastname: String? = null
-    ): PersonData {
-        return PersonData().apply {
-            this.title = title
-            this.firstname = firstname
-            this.lastname = lastname
-            salutation?.let { this.salutation.value = it }
-        }
-    }
-
     @Test
     fun `getShortName combines firstname and lastname`() {
         assertEquals("Skip Baker", person(firstname = "Skip", lastname = "Baker").shortName)
@@ -190,5 +176,19 @@ class PersonDataTest {
         assertEquals("Skip", personData.firstname)
         assertEquals("Baker", personData.lastname)
         assertEquals("SIR", personData.salutation.value)
+    }
+
+    private fun person(
+        title: String? = null,
+        salutation: String? = null,
+        firstname: String? = null,
+        lastname: String? = null
+    ): PersonData {
+        return PersonData().apply {
+            this.title = title
+            this.firstname = firstname
+            this.lastname = lastname
+            salutation?.let { this.salutation.value = it }
+        }
     }
 }

--- a/src/test/kotlin/sirius/biz/model/PersonDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/PersonDataTest.kt
@@ -162,12 +162,11 @@ class PersonDataTest {
     }
 
     @Test
-    fun `equals is reflexive`() {
-        // Note: equals() currently compares the salutation LookupValue by reference (Strings.areEqual falls back
-        // to Objects.equals and LookupValue has no equals/hashCode), so two value-identical instances are NOT
-        // considered equal. See SIRI-1258. Hence, only reflexivity can be asserted here.
+    fun `equals is true for equal person data`() {
         val one = person(title = "Prof.", salutation = "SIR", firstname = "Skip", lastname = "Baker")
-        assertEquals(one, one)
+        val other = person(title = "Prof.", salutation = "SIR", firstname = "Skip", lastname = "Baker")
+        assertEquals(one, other)
+        assertEquals(one.hashCode(), other.hashCode())
     }
 
     @Test

--- a/src/test/kotlin/sirius/biz/model/PersonDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/PersonDataTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.model
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
+import sirius.kernel.async.CallContext
+import sirius.kernel.health.HandledException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [PersonData] class.
+ *
+ * The <tt>salutations</tt> lookup table is provided with config based test data (see <tt>test.conf</tt>),
+ * so that the salutation "SIR" resolves to "Sir" (english) resp. "Herr" (german). The current language is
+ * pinned to german (the configured default, see develop.conf) so that translations are asserted
+ * deterministically regardless of the environment's default language.
+ */
+@ExtendWith(SiriusExtension::class)
+class PersonDataTest {
+
+    @BeforeEach
+    fun pinLanguage() {
+        CallContext.getCurrent().setLanguage("de")
+    }
+
+    private fun person(
+        title: String? = null,
+        salutation: String? = null,
+        firstname: String? = null,
+        lastname: String? = null
+    ): PersonData {
+        return PersonData().apply {
+            this.title = title
+            this.firstname = firstname
+            this.lastname = lastname
+            salutation?.let { this.salutation.value = it }
+        }
+    }
+
+    @Test
+    fun `getShortName combines firstname and lastname`() {
+        assertEquals("Skip Baker", person(firstname = "Skip", lastname = "Baker").shortName)
+    }
+
+    @Test
+    fun `getShortName returns only the lastname if no firstname is present`() {
+        assertEquals("Baker", person(lastname = "Baker").shortName)
+    }
+
+    @Test
+    fun `getShortName is empty if no lastname is present`() {
+        assertEquals("", person(firstname = "Skip").shortName)
+        assertEquals("", person().shortName)
+    }
+
+    @Test
+    fun `getInitials returns up to two uppercase initials`() {
+        assertEquals("SB", person(firstname = "skip", lastname = "baker").initials)
+    }
+
+    @Test
+    fun `getInitials handles partially filled names`() {
+        assertEquals("S", person(firstname = "Skip").initials)
+        assertEquals("B", person(lastname = "Baker").initials)
+        assertEquals("", person().initials)
+    }
+
+    @Test
+    fun `getTranslatedSalutation resolves the salutation in the current and given language`() {
+        val personData = person(salutation = "SIR")
+        assertEquals("Herr", personData.translatedSalutation)
+        assertEquals("Herr", personData.getTranslatedSalutation("de"))
+        assertEquals("Sir", personData.getTranslatedSalutation("en"))
+    }
+
+    @Test
+    fun `getTranslatedSalutation is null for an empty salutation`() {
+        assertNull(person().translatedSalutation)
+    }
+
+    @Test
+    fun `getTranslatedSalutation returns an empty string for an unknown value`() {
+        // A code that is not part of the lookup table resolves to an empty name (see ConfigLookupTable).
+        assertEquals("", person(salutation = "custom").translatedSalutation)
+    }
+
+    @Test
+    fun `getAddressableName is empty if no lastname is present`() {
+        assertEquals("", person(salutation = "SIR", title = "Prof.", firstname = "Skip").addressableName)
+    }
+
+    @Test
+    fun `getAddressableName combines the resolved salutation, title and lastname but omits the firstname`() {
+        assertEquals("Prof. Baker", person(title = "Prof.", firstname = "Skip", lastname = "Baker").addressableName)
+        assertEquals(
+            "Herr Prof. Baker",
+            person(salutation = "SIR", title = "Prof.", firstname = "Skip", lastname = "Baker").addressableName
+        )
+    }
+
+    @Test
+    fun `getAddressableName translates the salutation into the given language`() {
+        assertEquals(
+            "Sir Prof. Baker",
+            person(salutation = "SIR", title = "Prof.", firstname = "Skip", lastname = "Baker").getAddressableName("en")
+        )
+    }
+
+    @Test
+    fun `toString combines all filled parts and resolves the salutation`() {
+        assertEquals(
+            "Herr Prof. Skip Baker",
+            person(salutation = "SIR", title = "Prof.", firstname = "Skip", lastname = "Baker").toString()
+        )
+        assertEquals("Skip Baker", person(firstname = "Skip", lastname = "Baker").toString())
+        assertEquals("", person().toString())
+    }
+
+    @Test
+    fun `toTranslatedString resolves the salutation into the given language`() {
+        assertEquals(
+            "Sir Prof. Skip Baker",
+            person(salutation = "SIR", title = "Prof.", firstname = "Skip", lastname = "Baker").toTranslatedString("en")
+        )
+    }
+
+    @Test
+    fun `verifySalutation accepts a known or empty salutation`() {
+        person(salutation = "SIR").verifySalutation()
+        person().verifySalutation()
+    }
+
+    @Test
+    fun `verifySalutation rejects an unknown salutation`() {
+        assertFailsWith<HandledException> { person(salutation = "unknown").verifySalutation() }
+    }
+
+    @Test
+    fun `validateSalutation collects a message only for an unknown salutation`() {
+        val messages = mutableListOf<String>()
+
+        person(salutation = "SIR").validateSalutation { messages.add(it) }
+        person().validateSalutation { messages.add(it) }
+        assertTrue { messages.isEmpty() }
+
+        person(salutation = "unknown").validateSalutation { messages.add(it) }
+        assertEquals(1, messages.size)
+    }
+
+    @Test
+    fun `equals is reflexive`() {
+        // Note: equals() currently compares the salutation LookupValue by reference (Strings.areEqual falls back
+        // to Objects.equals and LookupValue has no equals/hashCode), so two value-identical instances are NOT
+        // considered equal. See SIRI-1258. Hence, only reflexivity can be asserted here.
+        val one = person(title = "Prof.", salutation = "SIR", firstname = "Skip", lastname = "Baker")
+        assertEquals(one, one)
+    }
+
+    @Test
+    fun `equals is false for differing person data`() {
+        val one = person(firstname = "Skip", lastname = "Baker")
+        assertNotEquals(one, person(firstname = "Bob", lastname = "Baker"))
+        assertNotEquals(one, person(firstname = "Skip", lastname = "Miller"))
+    }
+
+    @Test
+    fun `equals handles null and foreign types`() {
+        val one = person(firstname = "Skip", lastname = "Baker")
+        assertFalse { one.equals(null) }
+        assertFalse { one.equals("Skip Baker") }
+    }
+
+    @Test
+    fun `getters return the values set via the setters`() {
+        val personData = person(title = "Prof.", salutation = "SIR", firstname = "Skip", lastname = "Baker")
+        assertEquals("Prof.", personData.title)
+        assertEquals("Skip", personData.firstname)
+        assertEquals("Baker", personData.lastname)
+        assertEquals("SIR", personData.salutation.value)
+    }
+}

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -259,6 +259,69 @@ lookup-tables {
             }
         }
     }
+
+    # Provide config based data for the salutations so that PersonData can be tested
+    # without requiring a populated code list.
+    salutations {
+        codeList = ""
+        data {
+            SIR {
+                name {
+                    en = "Sir"
+                    de = "Herr"
+                }
+            }
+            MADAM {
+                name {
+                    en = "Madam"
+                    de = "Frau"
+                }
+            }
+        }
+    }
+
+    # Provide config based data for the countries (used for ZIP validation) so that
+    # InternationalAddressData can be tested without requiring a populated code list.
+    countries {
+        codeList = ""
+        codeCase = "lower"
+        data {
+            de {
+                name {
+                    en = "Germany"
+                    de = "Deutschland"
+                }
+                zipCodeRegEx = "\\d{5}"
+            }
+            at {
+                name {
+                    en = "Austria"
+                    de = "Österreich"
+                }
+                zipCodeRegEx = "\\d{4}"
+            }
+        }
+    }
+
+    # Provide config based data for the active countries (used by the country lookup value).
+    active-countries {
+        codeList = ""
+        codeCase = "lower"
+        data {
+            de {
+                name {
+                    en = "Germany"
+                    de = "Deutschland"
+                }
+            }
+            at {
+                name {
+                    en = "Austria"
+                    de = "Österreich"
+                }
+            }
+        }
+    }
 }
 
 jupiter {


### PR DESCRIPTION
therefore also populate salutations and (active-)countries lookups via config to proper test the methods

BREAKING:
PersonData and InternationalAddressData now use value-based equals/hashCode, so instances with identical content are correctly treated as equal. In addition, the empty/completeness checks of InternationalAddressData now take the country into account: a completely empty address is no longer incorrectly reported as partially filled, and an address without a country is considered incomplete.

### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1258](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1258)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
