### PR TITLE
Add MultiSelectEntityParameter for entity multi-selects with autocomplete

### DIFF
--- a/src/main/java/sirius/biz/jobs/params/EntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameter.java
@@ -56,10 +56,10 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * Provides the shared mechanics of entity based parameters (autocompleter resolution, descriptor and
      * mapper access, entity lookups and tenant checks).
      */
-    protected final EntityParameterUtil<V> entityParameterUtil = new EntityParameterUtil<>(this::getType,
-                                                                                           this::getAutocompleter,
-                                                                                           this::getCustomAutocompleteUri,
-                                                                                           this::getLabel);
+    protected final EntityParameterProxy<V> entityParameterProxy = new EntityParameterProxy<>(this::getType,
+                                                                                              this::getAutocompleter,
+                                                                                              this::getCustomAutocompleteUri,
+                                                                                              this::getLabel);
 
     /**
      * Creates a new parameter with the given name and label.
@@ -115,7 +115,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
     }
 
     protected Optional<? extends Autocompleter<V>> findAutocompleter() {
-        return entityParameterUtil.findAutocompleter();
+        return entityParameterProxy.findAutocompleter();
     }
 
     /**
@@ -124,7 +124,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @return the autocomplete URL used to provide suggestions for user input
      */
     public final String getAutocompleteUrl() {
-        return entityParameterUtil.getAutocompleteUrl();
+        return entityParameterProxy.determineAutocompleteUrl();
     }
 
     /**
@@ -140,7 +140,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @return the mapper of the represented entity
      */
     protected BaseMapper<V, ?, ?> getMapper() {
-        return entityParameterUtil.getMapper();
+        return entityParameterProxy.getMapper();
     }
 
     /**
@@ -165,7 +165,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @return the label or textual representation to use for the given entity
      */
     protected String createLabel(V entity) {
-        return entityParameterUtil.createLabel(entity);
+        return entityParameterProxy.createLabel(entity);
     }
 
     @Override
@@ -183,12 +183,12 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
 
     @Override
     protected Optional<V> resolveFromString(Value input) {
-        return entityParameterUtil.findEntity(input);
+        return entityParameterProxy.findEntity(input);
     }
 
     @Override
     protected String checkAndTransformValue(Value input) {
-        V entity = entityParameterUtil.findEntityOrFail(input);
+        V entity = entityParameterProxy.findEntityOrFail(input);
         if (entity == null) {
             return null;
         }
@@ -204,7 +204,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @param entity the entity to check
      */
     protected void assertAccess(V entity) {
-        entityParameterUtil.assertTenantAccess(entity);
+        entityParameterProxy.assertTenantAccess(entity);
     }
 
     /**
@@ -214,6 +214,6 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @return the entity descriptor for the parameter type
      */
     protected EntityDescriptor getDescriptor() {
-        return entityParameterUtil.getDescriptor();
+        return entityParameterProxy.getDescriptor();
     }
 }

--- a/src/main/java/sirius/biz/jobs/params/EntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameter.java
@@ -9,7 +9,6 @@
 package sirius.biz.jobs.params;
 
 import sirius.biz.tenants.Tenants;
-import sirius.biz.web.TenantAware;
 import sirius.db.es.Elastic;
 import sirius.db.jdbc.OMA;
 import sirius.db.mixing.BaseEntity;
@@ -21,9 +20,7 @@ import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
-import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Part;
-import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nullable;
@@ -55,10 +52,10 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
     @Nullable
     protected static Tenants<?, ?, ?> tenants;
 
-    @Part
-    private static GlobalContext globalContext;
-
-    private EntityDescriptor descriptor;
+    protected final EntityParameterUtil<V> entityParameterUtil = new EntityParameterUtil<>(this::getType,
+                                                                                           this::getAutocompleter,
+                                                                                           this::getCustomAutocompleteUri,
+                                                                                           this::getLabel);
 
     /**
      * Creates a new parameter with the given name and label.
@@ -113,14 +110,8 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
         return null;
     }
 
-    @SuppressWarnings("unchecked")
     protected Optional<? extends Autocompleter<V>> findAutocompleter() {
-        return Optional.ofNullable(getAutocompleter())
-                       .flatMap(type -> globalContext.getParts(Autocompleter.class)
-                                                     .stream()
-                                                     .filter(type::isInstance)
-                                                     .map(autocompleter -> (Autocompleter<V>) autocompleter)
-                                                     .findFirst());
+        return entityParameterUtil.findAutocompleter();
     }
 
     /**
@@ -129,9 +120,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @return the autocomplete URL used to provide suggestions for user input
      */
     public final String getAutocompleteUrl() {
-        return findAutocompleter().map(Autocompleter::getName)
-                                  .map(name -> "/jobs/parameter-autocomplete/" + name)
-                                  .orElseGet(this::getCustomAutocompleteUri);
+        return entityParameterUtil.getAutocompleteUrl();
     }
 
     /**
@@ -147,7 +136,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @return the mapper of the represented entity
      */
     protected BaseMapper<V, ?, ?> getMapper() {
-        return getDescriptor().getMapper();
+        return entityParameterUtil.getMapper();
     }
 
     /**
@@ -172,7 +161,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @return the label or textual representation to use for the given entity
      */
     protected String createLabel(V entity) {
-        return findAutocompleter().map(autocompleter -> autocompleter.toLabel(entity)).orElseGet(entity::toString);
+        return entityParameterUtil.createLabel(entity);
     }
 
     @Override
@@ -190,21 +179,13 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
 
     @Override
     protected Optional<V> resolveFromString(Value input) {
-        return getMapper().find(getType(), input.get());
+        return entityParameterUtil.findEntity(input);
     }
 
     @Override
     protected String checkAndTransformValue(Value input) {
-        V entity = getMapper().find(getType(), input.get()).orElse(null);
-
+        V entity = entityParameterUtil.findEntityOrFail(input);
         if (entity == null) {
-            if (input.isFilled()) {
-                throw Exceptions.createHandled()
-                                .withNLSKey("Parameter.invalidValue")
-                                .set("name", getLabel())
-                                .set("message", NLS.get("EntityParameter.mustExist"))
-                                .handle();
-            }
             return null;
         }
 
@@ -219,9 +200,7 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @param entity the entity to check
      */
     protected void assertAccess(V entity) {
-        if (entity instanceof TenantAware tenantAware) {
-            tenants.assertTenant(tenantAware);
-        }
+        entityParameterUtil.assertTenantAccess(entity);
     }
 
     /**
@@ -231,10 +210,6 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
      * @return the entity descriptor for the parameter type
      */
     protected EntityDescriptor getDescriptor() {
-        if (descriptor == null) {
-            descriptor = mixing.getDescriptor(getType());
-        }
-
-        return descriptor;
+        return entityParameterUtil.getDescriptor();
     }
 }

--- a/src/main/java/sirius/biz/jobs/params/EntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameter.java
@@ -3,7 +3,7 @@
  * by scireum in Remshalden, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/EntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameter.java
@@ -52,6 +52,10 @@ public abstract class EntityParameter<V extends BaseEntity<?>, P extends EntityP
     @Nullable
     protected static Tenants<?, ?, ?> tenants;
 
+    /**
+     * Provides the shared mechanics of entity based parameters (autocompleter resolution, descriptor and
+     * mapper access, entity lookups and tenant checks).
+     */
     protected final EntityParameterUtil<V> entityParameterUtil = new EntityParameterUtil<>(this::getType,
                                                                                            this::getAutocompleter,
                                                                                            this::getCustomAutocompleteUri,

--- a/src/main/java/sirius/biz/jobs/params/EntityParameterProxy.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameterProxy.java
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
  *
  * @param <V> the type of entities handled by the parameter
  */
-public class EntityParameterUtil<V extends BaseEntity<?>> {
+public class EntityParameterProxy<V extends BaseEntity<?>> {
 
     @Part
     private static Mixing mixing;
@@ -83,10 +83,10 @@ public class EntityParameterUtil<V extends BaseEntity<?>> {
      * @param customAutocompleteUriSupplier provides the custom autocomplete URI to use (may supply <tt>null</tt>)
      * @param labelSupplier                 provides the label of the parameter (used in error messages)
      */
-    public EntityParameterUtil(Supplier<Class<V>> typeSupplier,
-                               Supplier<Class<? extends Autocompleter<V>>> autocompleterSupplier,
-                               Supplier<String> customAutocompleteUriSupplier,
-                               Supplier<String> labelSupplier) {
+    public EntityParameterProxy(Supplier<Class<V>> typeSupplier,
+                                Supplier<Class<? extends Autocompleter<V>>> autocompleterSupplier,
+                                Supplier<String> customAutocompleteUriSupplier,
+                                Supplier<String> labelSupplier) {
         this.typeSupplier = typeSupplier;
         this.autocompleterSupplier = autocompleterSupplier;
         this.customAutocompleteUriSupplier = customAutocompleteUriSupplier;
@@ -115,7 +115,7 @@ public class EntityParameterUtil<V extends BaseEntity<?>> {
      * {@link Autocompleter} nor a custom autocomplete URI is available
      */
     @Nullable
-    public String getAutocompleteUrl() {
+    public String determineAutocompleteUrl() {
         if (autocompleterSupplier.get() == null) {
             return customAutocompleteUriSupplier.get();
         }

--- a/src/main/java/sirius/biz/jobs/params/EntityParameterUtil.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameterUtil.java
@@ -49,11 +49,30 @@ public class EntityParameterUtil<V extends BaseEntity<?>> {
     @Part
     private static GlobalContext globalContext;
 
+    /**
+     * Provides the type of entities handled by the parameter.
+     */
     private final Supplier<Class<V>> typeSupplier;
+
+    /**
+     * Provides the {@link Autocompleter} type used to compute suggestions (may supply <tt>null</tt>).
+     */
     private final Supplier<Class<? extends Autocompleter<V>>> autocompleterSupplier;
+
+    /**
+     * Provides the custom autocomplete URI used if no {@link Autocompleter} is configured (may supply
+     * <tt>null</tt>).
+     */
     private final Supplier<String> customAutocompleteUriSupplier;
+
+    /**
+     * Provides the label of the parameter, used in error messages.
+     */
     private final Supplier<String> labelSupplier;
 
+    /**
+     * Caches the {@link EntityDescriptor} of the entity type as determined by {@link #getDescriptor()}.
+     */
     private EntityDescriptor descriptor;
 
     /**

--- a/src/main/java/sirius/biz/jobs/params/EntityParameterUtil.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameterUtil.java
@@ -116,21 +116,31 @@ public class EntityParameterUtil<V extends BaseEntity<?>> {
      */
     @Nullable
     public String getAutocompleteUrl() {
-        Class<? extends Autocompleter<V>> autocompleterType = autocompleterSupplier.get();
-        if (autocompleterType != null) {
-            Optional<? extends Autocompleter<V>> autocompleter = findAutocompleter();
-            if (autocompleter.isPresent()) {
-                return "/jobs/parameter-autocomplete/" + autocompleter.get().getName();
-            }
-
-            // surface the misconfiguration instead of silently degrading into a select without suggestions
-            Exceptions.handle()
-                      .withSystemErrorMessage(
-                              "The autocompleter %s used by the job parameter '%s' is not registered as part!",
-                              autocompleterType.getName(),
-                              labelSupplier.get())
-                      .handle();
+        if (autocompleterSupplier.get() == null) {
+            return customAutocompleteUriSupplier.get();
         }
+
+        return findAutocompleter().map(Autocompleter::getName)
+                                  .map(name -> "/jobs/parameter-autocomplete/" + name)
+                                  .orElseGet(this::handleUnregisteredAutocompleter);
+    }
+
+    /**
+     * Reports a configured but unregistered {@link Autocompleter} and provides the fallback URI.
+     * <p>
+     * The misconfiguration is reported as incident instead of silently degrading into a select without
+     * suggestions.
+     *
+     * @return the custom autocomplete URI as fallback (which is most probably <tt>null</tt>)
+     */
+    @Nullable
+    private String handleUnregisteredAutocompleter() {
+        Exceptions.handle()
+                  .withSystemErrorMessage(
+                          "The autocompleter %s used by the job parameter '%s' is not registered as part!",
+                          autocompleterSupplier.get().getName(),
+                          labelSupplier.get())
+                  .handle();
 
         return customAutocompleteUriSupplier.get();
     }

--- a/src/main/java/sirius/biz/jobs/params/EntityParameterUtil.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameterUtil.java
@@ -1,0 +1,196 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.params;
+
+import sirius.biz.tenants.Tenants;
+import sirius.biz.web.TenantAware;
+import sirius.db.mixing.BaseEntity;
+import sirius.db.mixing.BaseMapper;
+import sirius.db.mixing.EntityDescriptor;
+import sirius.db.mixing.Mixing;
+import sirius.kernel.commons.Value;
+import sirius.kernel.di.GlobalContext;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.nls.NLS;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Provides the common mechanics shared by all entity based job parameters.
+ * <p>
+ * {@link EntityParameter} and {@link MultiSelectEntityParameter} produce incompatible value types (a single
+ * entity vs. a list of entities) and therefore cannot share a common base class. Hence, the shared logic
+ * (autocompleter resolution, descriptor and mapper access, entity lookups and tenant checks) is provided via
+ * this support class which both parameter types delegate to.
+ * <p>
+ * The parameter callbacks are passed in as {@link Supplier suppliers} (i.e. method references onto the
+ * parameter itself) so that overrides in parameter subclasses are properly picked up.
+ *
+ * @param <V> the type of entities handled by the parameter
+ */
+public class EntityParameterUtil<V extends BaseEntity<?>> {
+
+    @Part
+    private static Mixing mixing;
+
+    @Part
+    @Nullable
+    private static Tenants<?, ?, ?> tenants;
+
+    @Part
+    private static GlobalContext globalContext;
+
+    private final Supplier<Class<V>> typeSupplier;
+    private final Supplier<Class<? extends Autocompleter<V>>> autocompleterSupplier;
+    private final Supplier<String> customAutocompleteUriSupplier;
+    private final Supplier<String> labelSupplier;
+
+    private EntityDescriptor descriptor;
+
+    /**
+     * Creates a new support instance using the given parameter callbacks.
+     *
+     * @param typeSupplier                  provides the type of entities handled by the parameter
+     * @param autocompleterSupplier         provides the {@link Autocompleter} type to use (may supply <tt>null</tt>)
+     * @param customAutocompleteUriSupplier provides the custom autocomplete URI to use (may supply <tt>null</tt>)
+     * @param labelSupplier                 provides the label of the parameter (used in error messages)
+     */
+    public EntityParameterUtil(Supplier<Class<V>> typeSupplier,
+                               Supplier<Class<? extends Autocompleter<V>>> autocompleterSupplier,
+                               Supplier<String> customAutocompleteUriSupplier,
+                               Supplier<String> labelSupplier) {
+        this.typeSupplier = typeSupplier;
+        this.autocompleterSupplier = autocompleterSupplier;
+        this.customAutocompleteUriSupplier = customAutocompleteUriSupplier;
+        this.labelSupplier = labelSupplier;
+    }
+
+    /**
+     * Determines the registered {@link Autocompleter} instance for the parameter (if one is configured).
+     *
+     * @return the autocompleter to use wrapped as optional or an empty optional if none is configured or registered
+     */
+    @SuppressWarnings("unchecked")
+    public Optional<? extends Autocompleter<V>> findAutocompleter() {
+        return Optional.ofNullable(autocompleterSupplier.get())
+                       .flatMap(type -> globalContext.getParts(Autocompleter.class)
+                                                     .stream()
+                                                     .filter(type::isInstance)
+                                                     .map(autocompleter -> (Autocompleter<V>) autocompleter)
+                                                     .findFirst());
+    }
+
+    /**
+     * Returns the autocompletion URL used to determine suggestions for inputs provided by the user.
+     *
+     * @return the autocomplete URL used to provide suggestions for user input or <tt>null</tt> if neither an
+     * {@link Autocompleter} nor a custom autocomplete URI is available
+     */
+    @Nullable
+    public String getAutocompleteUrl() {
+        Class<? extends Autocompleter<V>> autocompleterType = autocompleterSupplier.get();
+        if (autocompleterType != null) {
+            Optional<? extends Autocompleter<V>> autocompleter = findAutocompleter();
+            if (autocompleter.isPresent()) {
+                return "/jobs/parameter-autocomplete/" + autocompleter.get().getName();
+            }
+
+            // surface the misconfiguration instead of silently degrading into a select without suggestions
+            Exceptions.handle()
+                      .withSystemErrorMessage(
+                              "The autocompleter %s used by the job parameter '%s' is not registered as part!",
+                              autocompleterType.getName(),
+                              labelSupplier.get())
+                      .handle();
+        }
+
+        return customAutocompleteUriSupplier.get();
+    }
+
+    /**
+     * Determines the {@link EntityDescriptor} for the type of entities handled by the parameter.
+     *
+     * @return the entity descriptor for the parameter type
+     */
+    public EntityDescriptor getDescriptor() {
+        if (descriptor == null) {
+            descriptor = mixing.getDescriptor(typeSupplier.get());
+        }
+
+        return descriptor;
+    }
+
+    /**
+     * Returns the mapper which is to be used for the entities handled by the parameter.
+     *
+     * @return the mapper of the represented entity type
+     */
+    public BaseMapper<V, ?, ?> getMapper() {
+        return getDescriptor().getMapper();
+    }
+
+    /**
+     * Resolves the given input (an entity id) into an entity.
+     *
+     * @param input the entity id wrapped as <tt>Value</tt>
+     * @return the resolved entity wrapped as optional or an empty optional if the entity couldn't be resolved
+     */
+    public Optional<V> findEntity(Value input) {
+        return getMapper().find(typeSupplier.get(), input.get());
+    }
+
+    /**
+     * Resolves the given input (an entity id) into an entity and fails if a non-empty input cannot be resolved.
+     *
+     * @param input the entity id wrapped as <tt>Value</tt>
+     * @return the resolved entity or <tt>null</tt> if the input was empty
+     * @throws sirius.kernel.health.HandledException if a non-empty input doesn't resolve into an entity
+     */
+    @Nullable
+    public V findEntityOrFail(Value input) {
+        V entity = findEntity(input).orElse(null);
+        if (entity == null) {
+            if (input.isFilled()) {
+                throw Exceptions.createHandled()
+                                .withNLSKey("Parameter.invalidValue")
+                                .set("name", labelSupplier.get())
+                                .set("message", NLS.get("EntityParameter.mustExist"))
+                                .handle();
+            }
+            return null;
+        }
+
+        return entity;
+    }
+
+    /**
+     * Derives a label to show for a given entity.
+     *
+     * @param entity the entity to derive the label from
+     * @return the label or textual representation to use for the given entity
+     */
+    public String createLabel(V entity) {
+        return findAutocompleter().map(autocompleter -> autocompleter.toLabel(entity)).orElseGet(entity::toString);
+    }
+
+    /**
+     * Asserts that the given entity belongs to the current tenant (in case the entity is tenant aware and the
+     * tenants framework is active).
+     *
+     * @param entity the entity to check
+     */
+    public void assertTenantAccess(V entity) {
+        if (tenants != null && entity instanceof TenantAware tenantAware) {
+            tenants.assertTenant(tenantAware);
+        }
+    }
+}

--- a/src/main/java/sirius/biz/jobs/params/EntityParameterUtil.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameterUtil.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectEntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectEntityParameter.java
@@ -36,10 +36,10 @@ public abstract class MultiSelectEntityParameter<V extends BaseEntity<?>, P exte
      * Provides the shared mechanics of entity based parameters (autocompleter resolution, descriptor and
      * mapper access, entity lookups and tenant checks).
      */
-    protected final EntityParameterUtil<V> entityParameterUtil = new EntityParameterUtil<>(this::getType,
-                                                                                           this::getAutocompleter,
-                                                                                           this::getCustomAutocompleteUri,
-                                                                                           this::getLabel);
+    protected final EntityParameterProxy<V> entityParameterProxy = new EntityParameterProxy<>(this::getType,
+                                                                                              this::getAutocompleter,
+                                                                                              this::getCustomAutocompleteUri,
+                                                                                              this::getLabel);
 
     /**
      * Creates a new parameter with the given name and label.
@@ -63,7 +63,7 @@ public abstract class MultiSelectEntityParameter<V extends BaseEntity<?>, P exte
     @Override
     public String getLabel() {
         if (Strings.isEmpty(label)) {
-            return entityParameterUtil.getDescriptor().getPluralLabel();
+            return entityParameterProxy.getDescriptor().getPluralLabel();
         }
 
         return super.getLabel();
@@ -96,7 +96,7 @@ public abstract class MultiSelectEntityParameter<V extends BaseEntity<?>, P exte
 
     @Override
     public String getSuggestionUri() {
-        return Optional.ofNullable(entityParameterUtil.getAutocompleteUrl()).orElse("");
+        return Optional.ofNullable(entityParameterProxy.determineAutocompleteUrl()).orElse("");
     }
 
     /**
@@ -121,13 +121,13 @@ public abstract class MultiSelectEntityParameter<V extends BaseEntity<?>, P exte
 
     @Override
     protected String createValueLabel(V entity) {
-        return entityParameterUtil.createLabel(entity);
+        return entityParameterProxy.createLabel(entity);
     }
 
     @Nullable
     @Override
     protected String checkAndTransformSingleValue(Value input) {
-        V entity = entityParameterUtil.findEntityOrFail(input);
+        V entity = entityParameterProxy.findEntityOrFail(input);
         if (entity == null) {
             return null;
         }
@@ -138,7 +138,7 @@ public abstract class MultiSelectEntityParameter<V extends BaseEntity<?>, P exte
 
     @Override
     protected Optional<V> resolveSingleValueFromString(Value input) {
-        return entityParameterUtil.findEntity(input);
+        return entityParameterProxy.findEntity(input);
     }
 
     /**
@@ -147,6 +147,6 @@ public abstract class MultiSelectEntityParameter<V extends BaseEntity<?>, P exte
      * @param entity the entity to check
      */
     protected void assertAccess(V entity) {
-        entityParameterUtil.assertTenantAccess(entity);
+        entityParameterProxy.assertTenantAccess(entity);
     }
 }

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectEntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectEntityParameter.java
@@ -1,0 +1,148 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.params;
+
+import sirius.db.mixing.BaseEntity;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Value;
+import sirius.kernel.nls.NLS;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Provides a base class to implement multi select autocomplete parameters for {@link BaseEntity entities}.
+ * <p>
+ * In contrast to {@link MultiSelectStringParameter} this doesn't operate on a fixed list of selectable values
+ * but rather uses an autocomplete (either an {@link Autocompleter} or a custom autocomplete URI) to determine
+ * the selectable entities.
+ *
+ * @param <V> the type of entities selectable by this parameter
+ * @param <P> recursive type reference to support fluent method calls
+ */
+public abstract class MultiSelectEntityParameter<V extends BaseEntity<?>, P extends MultiSelectEntityParameter<V, P>>
+        extends MultiSelectParameter<V, P> {
+
+    protected final EntityParameterUtil<V> entityParameterUtil = new EntityParameterUtil<>(this::getType,
+                                                                                           this::getAutocompleter,
+                                                                                           this::getCustomAutocompleteUri,
+                                                                                           this::getLabel);
+
+    /**
+     * Creates a new parameter with the given name and label.
+     *
+     * @param name  the name of the parameter
+     * @param label the label of the parameter, which will be {@link NLS#smartGet(String) auto translated}
+     */
+    protected MultiSelectEntityParameter(String name, String label) {
+        super(name, label);
+    }
+
+    /**
+     * Creates a new parameter with the given name.
+     *
+     * @param name the name of the parameter
+     */
+    protected MultiSelectEntityParameter(String name) {
+        super(name, "");
+    }
+
+    @Override
+    public String getLabel() {
+        if (Strings.isEmpty(label)) {
+            return entityParameterUtil.getDescriptor().getPluralLabel();
+        }
+
+        return super.getLabel();
+    }
+
+    /**
+     * The type of {@link Autocompleter} to use for this parameter.
+     * <p>
+     * Note that this autocompleter needs to be @{@link sirius.kernel.di.std.Register registered} to be available
+     * to the framework.
+     *
+     * @return the type of autocompleter to use or <tt>null</tt> if there is none or a custom url via
+     * {@link #getCustomAutocompleteUri()} is being used.
+     */
+    @Nullable
+    protected Class<? extends Autocompleter<V>> getAutocompleter() {
+        return null;
+    }
+
+    /**
+     * Returns the custom autocompletion URL used to determine suggestions for inputs provided by the user.
+     *
+     * @return the autocomplete URL used to provide suggestions for user input. Note that this is only needed, if no
+     * {@link #getAutocompleter() autocompleter} is provided (which is the preferred way).
+     */
+    @Nullable
+    protected String getCustomAutocompleteUri() {
+        return null;
+    }
+
+    @Override
+    public String getSuggestionUri() {
+        return Optional.ofNullable(entityParameterUtil.getAutocompleteUrl()).orElse("");
+    }
+
+    /**
+     * Returns the type of entities represented by this parameter.
+     *
+     * @return the type of entities represented by this
+     */
+    protected abstract Class<V> getType();
+
+    @Override
+    public List<MultiSelectValue> getValues(Map<String, String> context) {
+        return get(context).orElseGet(Collections::emptyList)
+                           .stream()
+                           .map(entity -> new MultiSelectValue(createValueName(entity), createValueLabel(entity), true))
+                           .toList();
+    }
+
+    @Override
+    protected String createValueName(V entity) {
+        return entity.getIdAsString();
+    }
+
+    @Override
+    protected String createValueLabel(V entity) {
+        return entityParameterUtil.createLabel(entity);
+    }
+
+    @Nullable
+    @Override
+    protected String checkAndTransformSingleValue(Value input) {
+        V entity = entityParameterUtil.findEntityOrFail(input);
+        if (entity == null) {
+            return null;
+        }
+
+        assertAccess(entity);
+        return entity.getIdAsString();
+    }
+
+    @Override
+    protected Optional<V> resolveSingleValueFromString(Value input) {
+        return entityParameterUtil.findEntity(input);
+    }
+
+    /**
+     * Checks if the current user may use the given entity as value for this parameter.
+     *
+     * @param entity the entity to check
+     */
+    protected void assertAccess(V entity) {
+        entityParameterUtil.assertTenantAccess(entity);
+    }
+}

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectEntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectEntityParameter.java
@@ -32,6 +32,10 @@ import java.util.Optional;
 public abstract class MultiSelectEntityParameter<V extends BaseEntity<?>, P extends MultiSelectEntityParameter<V, P>>
         extends MultiSelectParameter<V, P> {
 
+    /**
+     * Provides the shared mechanics of entity based parameters (autocompleter resolution, descriptor and
+     * mapper access, entity lookups and tenant checks).
+     */
     protected final EntityParameterUtil<V> entityParameterUtil = new EntityParameterUtil<>(this::getType,
                                                                                            this::getAutocompleter,
                                                                                            this::getCustomAutocompleteUri,

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectEntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectEntityParameter.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectParameter.java
@@ -15,7 +15,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Provides a multi select parameter from a list of key-value pairs.
+ * Provides a base class for parameters which permit to select multiple values.
+ * <p>
+ * The selectable options are either rendered as a fixed list (as enumerated by {@link #getValues(Map)}, see
+ * {@link MultiSelectStringParameter}) or suggested dynamically via an autocomplete URI (as provided by
+ * {@link #getSuggestionUri()}, see {@link MultiSelectEntityParameter}).
  * <p>
  * The selected values are encoded in a single string, delimited by {@link #DELIMITER}. Subclasses only need to
  * provide the handling of a single value via {@link #checkAndTransformSingleValue(Value)} and

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectParameter.java
@@ -1,16 +1,36 @@
 package sirius.biz.jobs.params;
 
+import sirius.kernel.commons.Json;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Value;
+import tools.jackson.databind.node.ArrayNode;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Provides a multi select parameter from a list of key-value pairs.
+ * <p>
+ * The selected values are encoded in a single string, delimited by {@link #DELIMITER}. Subclasses only need to
+ * provide the handling of a single value via {@link #checkAndTransformSingleValue(Value)} and
+ * {@link #resolveSingleValueFromString(Value)}.
  *
  * @param <V> the type of values produced by this parameter
  * @param <P> recursive type reference to support fluent method calls
  */
 public abstract class MultiSelectParameter<V, P extends MultiSelectParameter<V, P>>
         extends ParameterBuilder<List<V>, P> {
+
+    /**
+     * Defines the character used to delimit multiple values while encoded in a single string.
+     */
+    protected static final String DELIMITER = "|";
 
     /**
      * Creates a new parameter with the given name and label.
@@ -33,10 +53,104 @@ public abstract class MultiSelectParameter<V, P extends MultiSelectParameter<V, 
      */
     public abstract List<MultiSelectValue> getValues(Map<String, String> context);
 
+    /**
+     * Returns the URI used to provide suggestions for user input.
+     *
+     * @return the suggestion URI or an empty string if the parameter solely operates on the fixed list of
+     * options rendered via {@link #getValues(Map)}
+     */
+    public String getSuggestionUri() {
+        return "";
+    }
+
     @Override
     public String getTemplateName() {
-        return "/templates/biz/jobs/params/selectMultiString.html.pasta";
+        return "/templates/biz/jobs/params/selectMulti.html.pasta";
     }
+
+    /**
+     * Returns the serialized name of the given value, used as the <tt>value</tt> of its option in the UI.
+     *
+     * @param value the value to derive the name from
+     * @return the serialized name of the given value
+     */
+    protected abstract String createValueName(V value);
+
+    /**
+     * Returns the label to display for the given value.
+     *
+     * @param value the value to derive the label from
+     * @return the displayable label of the given value
+     */
+    protected abstract String createValueLabel(V value);
+
+    @Override
+    public Optional<?> computeValueUpdate(Map<String, String> parameterContext) {
+        return updater.apply(parameterContext).map(values -> {
+            ArrayNode result = Json.createArray();
+            values.forEach(value -> result.add(Json.createObject()
+                                                   .put("value", createValueName(value))
+                                                   .put("text", createValueLabel(value))));
+            return result;
+        });
+    }
+
+    @Override
+    protected String checkAndTransformValue(Value input) {
+        List<?> rawValues;
+        if (input.get() instanceof List<?> list) {
+            rawValues = list;
+        } else {
+            rawValues = Arrays.asList(input.asString().split(Pattern.quote(DELIMITER)));
+        }
+
+        String verifiedInput = rawValues.stream()
+                                        .map(Value::of)
+                                        .map(this::checkAndTransformSingleValue)
+                                        .filter(Objects::nonNull)
+                                        .collect(Collectors.joining(DELIMITER));
+        return Strings.isFilled(verifiedInput) ? verifiedInput : null;
+    }
+
+    /**
+     * Checks and transforms a single selected value.
+     *
+     * @param input a single selected value wrapped as <tt>Value</tt>
+     * @return the serialized string representation of the given value or <tt>null</tt> to skip the value.
+     * Note that the representation must not contain the {@link #DELIMITER} as it is used to separate multiple values.
+     * @throws sirius.kernel.health.HandledException in case of invalid data which should be reported to the user
+     */
+    protected abstract String checkAndTransformSingleValue(Value input);
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note that values which can no longer be resolved (e.g. deleted entities) are silently skipped here, as
+     * this is also invoked when rendering the job form and therefore must not throw. Strict validation happens
+     * via {@link #checkAndTransformSingleValue(Value)} whenever a job is submitted or started. Also note that
+     * an empty optional (rather than an empty list) is returned if no value could be resolved at all, so that
+     * {@link #require(Map)} and presence checks properly detect values which became invalid after submission.
+     */
+    @Override
+    protected Optional<List<V>> resolveFromString(Value input) {
+        return input.asOptionalString()
+                    .map(encodedValues -> Stream.of(encodedValues.split(Pattern.quote(DELIMITER)))
+                                                .filter(Strings::isFilled)
+                                                .map(Value::of)
+                                                .map(this::resolveSingleValueFromString)
+                                                .flatMap(Optional::stream)
+                                                .toList())
+                    .filter(values -> !values.isEmpty());
+    }
+
+    /**
+     * Resolves a single serialized value (as created by {@link #checkAndTransformSingleValue(Value)}) into the
+     * actual parameter value.
+     *
+     * @param input the serialized string representation of a single value wrapped as <tt>Value</tt>
+     * @return the resolved value wrapped as optional or an empty optional if the value couldn't be resolved
+     */
+    protected abstract Optional<V> resolveSingleValueFromString(Value input);
 
     /**
      * Describes a selectable option for this parameter including whether it is currently selected.

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectParameter.java
@@ -1,3 +1,11 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
 package sirius.biz.jobs.params;
 
 import sirius.kernel.commons.Json;

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectStringParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectStringParameter.java
@@ -1,8 +1,6 @@
 package sirius.biz.jobs.params;
 
 import sirius.kernel.commons.CachingSupplier;
-import sirius.kernel.commons.Strings;
-import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
 import sirius.kernel.nls.NLS;
 
@@ -11,22 +9,14 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
- * Provides a multi select parameter from a list of key-value pairs.
+ * Provides a multi select parameter from a fixed list of key-value pairs.
  */
 public class MultiSelectStringParameter extends MultiSelectParameter<String, MultiSelectStringParameter> {
-
-    /**
-     * Defines the character used to delimit multiple values while encoded in a single string.
-     */
-    private static final String DELIMITER = "|";
 
     private final Map<String, String> entries = new LinkedHashMap<>();
 
@@ -100,17 +90,30 @@ public class MultiSelectStringParameter extends MultiSelectParameter<String, Mul
     /**
      * Enumerates all values provided by the parameter.
      *
-     * @return list of {@linkplain Tuple entries} with the key as first and display value as second tuple items.
+     * @return list of {@link MultiSelectValue entries} with the key as name and display value as label
      */
     @Override
     public List<MultiSelectValue> getValues(Map<String, String> context) {
-        return fetchEntriesMap().keySet().stream().map(entry -> {
-            String contextValue = context.get(getName());
-            boolean selected =
-                    contextValue != null && Arrays.asList(contextValue.split(Pattern.quote(DELIMITER))).contains(entry);
+        String contextValue = context.get(getName());
+        List<String> selectedValues =
+                contextValue == null ? List.of() : Arrays.asList(contextValue.split(Pattern.quote(DELIMITER)));
 
-            return new MultiSelectValue(entry, NLS.smartGet(fetchEntriesMap().get(entry)), selected);
-        }).toList();
+        return fetchEntriesMap().entrySet()
+                                .stream()
+                                .map(entry -> new MultiSelectValue(entry.getKey(),
+                                                                   NLS.smartGet(entry.getValue()),
+                                                                   selectedValues.contains(entry.getKey())))
+                                .toList();
+    }
+
+    @Override
+    protected String createValueName(String value) {
+        return value;
+    }
+
+    @Override
+    protected String createValueLabel(String value) {
+        return NLS.smartGet(fetchEntriesMap().getOrDefault(value, value));
     }
 
     @Override
@@ -118,19 +121,12 @@ public class MultiSelectStringParameter extends MultiSelectParameter<String, Mul
         if (input.isNull() && defaultValueProvider != null) {
             return String.join(DELIMITER, defaultValueProvider.get());
         }
-        if (!(input.get() instanceof List<?> list)) {
-            return checkAndTransformSingleValue(input);
-        }
 
-        String verifiedInput = list.stream()
-                                   .map(Value::of)
-                                   .map(this::checkAndTransformSingleValue)
-                                   .filter(Objects::nonNull)
-                                   .collect(Collectors.joining(DELIMITER));
-        return Strings.isFilled(verifiedInput) ? verifiedInput : null;
+        return super.checkAndTransformValue(input);
     }
 
-    private String checkAndTransformSingleValue(Value input) {
+    @Override
+    protected String checkAndTransformSingleValue(Value input) {
         String rawInput = input.asString().trim();
 
         // we can not allow the delimiter within values, as we obviously use it to separate values from each other
@@ -146,12 +142,7 @@ public class MultiSelectStringParameter extends MultiSelectParameter<String, Mul
     }
 
     @Override
-    protected Optional<List<String>> resolveFromString(@Nonnull Value input) {
-        return input.asOptionalString()
-                    .map(string -> Stream.of(string.split(Pattern.quote(DELIMITER)))
-                                         .map(Value::of)
-                                         .map(this::checkAndTransformSingleValue)
-                                         .filter(Objects::nonNull)
-                                         .toList());
+    protected Optional<String> resolveSingleValueFromString(@Nonnull Value input) {
+        return Optional.ofNullable(checkAndTransformSingleValue(input));
     }
 }

--- a/src/main/resources/default/templates/biz/jobs/params/selectMulti.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/params/selectMulti.html.pasta
@@ -2,7 +2,8 @@
 <i:arg name="context" type="Map"/>
 
 <i:invoke template="/templates/biz/jobs/params/paramMultiSelect.html.pasta" param="param" context="context"
-          optional="!param.isRequired()">
+          optional="!param.isRequired()"
+          suggestionUri="@param.as(sirius.biz.jobs.params.MultiSelectParameter.class).getSuggestionUri()">
     <i:for var="entry"
            type="sirius.biz.jobs.params.MultiSelectParameter$MultiSelectValue"
            items="@param.as(sirius.biz.jobs.params.MultiSelectParameter.class).getValues(context)">

--- a/src/test/java/sirius/biz/jobs/params/ParameterTestEntity.java
+++ b/src/test/java/sirius/biz/jobs/params/ParameterTestEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.params;
+
+import sirius.db.jdbc.SQLEntity;
+import sirius.db.mixing.Mapping;
+import sirius.db.mixing.annotations.NullAllowed;
+
+/**
+ * Represents an entity used to test {@link EntityParameter} and {@link MultiSelectEntityParameter}.
+ */
+public class ParameterTestEntity extends SQLEntity {
+
+    public static final Mapping NAME = Mapping.named("name");
+    @NullAllowed
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
+++ b/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
@@ -19,7 +19,7 @@ import sirius.kernel.SiriusExtension
 import sirius.kernel.async.BackgroundLoop
 import sirius.kernel.di.std.Part
 import java.time.Duration
-import java.util.*
+import java.util.Queue
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/src/test/kotlin/sirius/biz/importer/ImporterTest.kt
+++ b/src/test/kotlin/sirius/biz/importer/ImporterTest.kt
@@ -8,7 +8,10 @@
 
 package sirius.biz.importer
 
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import sirius.biz.tenants.Tenant
 import sirius.biz.tenants.TenantData
@@ -19,11 +22,10 @@ import sirius.kernel.SiriusExtension
 import sirius.kernel.di.std.Part
 import sirius.kernel.health.HandledException
 import java.time.Duration
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-
-private const val i1 = 200
 
 /**
  * Tests the [Importer] class.

--- a/src/test/kotlin/sirius/biz/jobs/params/EntityParameterTest.kt
+++ b/src/test/kotlin/sirius/biz/jobs/params/EntityParameterTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.params
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.db.jdbc.OMA
+import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.Value
+import sirius.kernel.di.std.Part
+import sirius.kernel.health.HandledException
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [EntityParameter] class.
+ */
+@ExtendWith(SiriusExtension::class)
+class EntityParameterTest {
+
+    @Test
+    fun `a valid entity id is accepted`() {
+        val entity = createEntity("First")
+        val parameter = ParameterTestEntityParameter("test", "Test").build()
+
+        assertEquals(entity.idAsString, parameter.checkAndTransform(Value.of(entity.idAsString)))
+    }
+
+    @Test
+    fun `an unknown entity id is rejected`() {
+        val deletedId = createDeletedEntityId()
+        val parameter = ParameterTestEntityParameter("test", "Test").build()
+
+        assertThrows<HandledException> {
+            parameter.checkAndTransform(Value.of(deletedId))
+        }
+    }
+
+    @Test
+    fun `empty input yields null`() {
+        val parameter = ParameterTestEntityParameter("test", "Test").build()
+
+        assertNull(parameter.checkAndTransform(Value.EMPTY))
+        assertNull(parameter.checkAndTransform(Value.of("")))
+    }
+
+    @Test
+    fun `a stored id resolves into the entity`() {
+        val entity = createEntity("First")
+        val parameter = ParameterTestEntityParameter("test", "Test").build()
+
+        assertEquals(entity.idAsString, parameter.get(mapOf("test" to entity.idAsString)).orElseThrow().idAsString)
+    }
+
+    @Test
+    fun `an unresolvable stored id resolves empty`() {
+        val deletedId = createDeletedEntityId()
+        val parameter = ParameterTestEntityParameter("test", "Test").build()
+
+        assertTrue(parameter.get(mapOf("test" to deletedId)).isEmpty)
+    }
+
+    @Test
+    fun `renderCurrentValue provides id and label of the selected entity`() {
+        val entity = createEntity("First")
+        val builder = ParameterTestEntityParameter("test", "Test")
+
+        val idAndLabel = builder.renderCurrentValue(mapOf("test" to entity.idAsString))
+
+        assertEquals(entity.idAsString, idAndLabel.first)
+        assertEquals("First", idAndLabel.second)
+    }
+
+    @Test
+    fun `the custom autocomplete uri is used as autocomplete url`() {
+        assertEquals(
+            "/test/autocomplete",
+            ParameterTestEntityParameter("test", "Test", "/test/autocomplete").autocompleteUrl
+        )
+    }
+
+    companion object {
+        @Part
+        @JvmStatic
+        private lateinit var oma: OMA
+    }
+
+    private fun createEntity(name: String): ParameterTestEntity {
+        val entity = ParameterTestEntity()
+        entity.name = name
+        oma.update(entity)
+        return entity
+    }
+
+    private fun createDeletedEntityId(): String {
+        val entity = createEntity("Deleted")
+        val id = entity.idAsString
+        oma.delete(entity)
+        return id
+    }
+}
+
+/**
+ * Provides a concrete [EntityParameter] for [ParameterTestEntity] to test the base class with.
+ */
+private class ParameterTestEntityParameter(
+    name: String,
+    label: String,
+    private val autocompleteUri: String? = null
+) :
+    EntityParameter<ParameterTestEntity, ParameterTestEntityParameter>(name, label) {
+
+    override fun getType(): Class<ParameterTestEntity> {
+        return ParameterTestEntity::class.java
+    }
+
+    override fun getCustomAutocompleteUri(): String? {
+        return autocompleteUri
+    }
+}

--- a/src/test/kotlin/sirius/biz/jobs/params/MultiSelectEntityParameterTest.kt
+++ b/src/test/kotlin/sirius/biz/jobs/params/MultiSelectEntityParameterTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.params
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.db.jdbc.OMA
+import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.Value
+import sirius.kernel.di.std.Part
+import sirius.kernel.health.HandledException
+import tools.jackson.databind.node.ArrayNode
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [MultiSelectEntityParameter] class.
+ */
+@ExtendWith(SiriusExtension::class)
+class MultiSelectEntityParameterTest {
+
+    @Test
+    fun `selected entities are serialized as delimited id string`() {
+        val first = createEntity("First")
+        val second = createEntity("Second")
+        val parameter = ParameterTestEntityMultiSelectParameter("test", "Test").build()
+
+        val serialized = parameter.checkAndTransform(Value.of(listOf(first.idAsString, second.idAsString)))
+
+        assertEquals("${first.idAsString}|${second.idAsString}", serialized)
+    }
+
+    @Test
+    fun `unknown entity ids are rejected`() {
+        val first = createEntity("First")
+        val unknownId = createDeletedEntityId()
+        val parameter = ParameterTestEntityMultiSelectParameter("test", "Test").build()
+
+        assertThrows<HandledException> {
+            parameter.checkAndTransform(Value.of(listOf(first.idAsString, unknownId)))
+        }
+    }
+
+    @Test
+    fun `empty input yields null`() {
+        val parameter = ParameterTestEntityMultiSelectParameter("test", "Test").build()
+
+        assertNull(parameter.checkAndTransform(Value.EMPTY))
+        assertNull(parameter.checkAndTransform(Value.of("")))
+        assertNull(parameter.checkAndTransform(Value.of(listOf<String>())))
+    }
+
+    @Test
+    fun `stored ids resolve into entities in selection order`() {
+        val first = createEntity("First")
+        val second = createEntity("Second")
+        val parameter = ParameterTestEntityMultiSelectParameter("test", "Test").build()
+
+        val resolved = parameter.get(mapOf("test" to "${second.idAsString}|${first.idAsString}")).orElseThrow()
+
+        assertEquals(listOf(second.idAsString, first.idAsString), resolved.map { it.idAsString })
+    }
+
+    @Test
+    fun `unresolvable ids are skipped on resolve`() {
+        val first = createEntity("First")
+        val deletedId = createDeletedEntityId()
+        val parameter = ParameterTestEntityMultiSelectParameter("test", "Test").build()
+
+        val resolved = parameter.get(mapOf("test" to "${first.idAsString}|$deletedId")).orElseThrow()
+
+        assertEquals(listOf(first.idAsString), resolved.map { it.idAsString })
+    }
+
+    @Test
+    fun `a selection of only unresolvable ids resolves empty`() {
+        val deletedId = createDeletedEntityId()
+        val parameter = ParameterTestEntityMultiSelectParameter("test", "Test").build()
+
+        assertTrue(parameter.get(mapOf("test" to deletedId)).isEmpty)
+    }
+
+    @Test
+    fun `getValues renders only the selected entities`() {
+        val first = createEntity("First")
+        val second = createEntity("Second")
+        val builder = ParameterTestEntityMultiSelectParameter("test", "Test")
+
+        val values = builder.getValues(mapOf("test" to "${first.idAsString}|${second.idAsString}"))
+
+        assertEquals(listOf(first.idAsString, second.idAsString), values.map { it.name() })
+        assertEquals(listOf("First", "Second"), values.map { it.label() })
+        assertTrue(values.all { it.selected() })
+    }
+
+    @Test
+    fun `getSuggestionUri uses the custom autocomplete uri or falls back to an empty string`() {
+        assertEquals(
+            "/test/autocomplete",
+            ParameterTestEntityMultiSelectParameter("test", "Test", "/test/autocomplete").suggestionUri
+        )
+        assertEquals("", ParameterTestEntityMultiSelectParameter("test", "Test").suggestionUri)
+    }
+
+    @Test
+    fun `computeValueUpdate produces id and label pairs`() {
+        val first = createEntity("First")
+        val parameter = ParameterTestEntityMultiSelectParameter("test", "Test").withUpdater { _ ->
+            Optional.of(listOf(first))
+        }.build()
+
+        val update = parameter.updateValue(mapOf()).orElseThrow() as ArrayNode
+
+        assertEquals(1, update.size())
+        assertEquals(first.idAsString, update.get(0).get("value").asString(""))
+        assertEquals("First", update.get(0).get("text").asString(""))
+    }
+
+    companion object {
+        @Part
+        @JvmStatic
+        private lateinit var oma: OMA
+    }
+
+    private fun createEntity(name: String): ParameterTestEntity {
+        val entity = ParameterTestEntity()
+        entity.name = name
+        oma.update(entity)
+        return entity
+    }
+
+    private fun createDeletedEntityId(): String {
+        val entity = createEntity("Deleted")
+        val id = entity.idAsString
+        oma.delete(entity)
+        return id
+    }
+}
+
+/**
+ * Provides a concrete [MultiSelectEntityParameter] for [ParameterTestEntity] to test the base class with.
+ */
+private class ParameterTestEntityMultiSelectParameter(
+    name: String,
+    label: String,
+    private val autocompleteUri: String? = null
+) :
+    MultiSelectEntityParameter<ParameterTestEntity, ParameterTestEntityMultiSelectParameter>(name, label) {
+
+    override fun getType(): Class<ParameterTestEntity> {
+        return ParameterTestEntity::class.java
+    }
+
+    override fun getCustomAutocompleteUri(): String? {
+        return autocompleteUri
+    }
+}

--- a/src/test/kotlin/sirius/biz/jobs/params/MultiSelectStringParameterTest.kt
+++ b/src/test/kotlin/sirius/biz/jobs/params/MultiSelectStringParameterTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.jobs.params
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.Value
+import tools.jackson.databind.node.ArrayNode
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [MultiSelectStringParameter] class (and thereby the encoding logic of [MultiSelectParameter]).
+ */
+@ExtendWith(SiriusExtension::class)
+class MultiSelectStringParameterTest {
+
+    @Test
+    fun `a list of selected values is serialized as delimited string`() {
+        val parameter = createParameter().build()
+
+        assertEquals("a|b", parameter.checkAndTransform(Value.of(listOf("a", "b"))))
+    }
+
+    @Test
+    fun `unknown values are silently dropped`() {
+        val parameter = createParameter().build()
+
+        assertEquals("a", parameter.checkAndTransform(Value.of(listOf("a", "x"))))
+    }
+
+    @Test
+    fun `an empty or fully invalid selection yields null`() {
+        val parameter = createParameter().build()
+
+        assertNull(parameter.checkAndTransform(Value.EMPTY))
+        assertNull(parameter.checkAndTransform(Value.of("")))
+        assertNull(parameter.checkAndTransform(Value.of(listOf("x", "y"))))
+    }
+
+    @Test
+    fun `a single plain value is accepted and trimmed`() {
+        val parameter = createParameter().build()
+
+        assertEquals("a", parameter.checkAndTransform(Value.of(" a ")))
+    }
+
+    @Test
+    fun `an already encoded string is split and validated per token`() {
+        val parameter = createParameter().build()
+
+        assertEquals("a|b", parameter.checkAndTransform(Value.of("a|b")))
+        assertEquals("a", parameter.checkAndTransform(Value.of("a|x")))
+    }
+
+    @Test
+    fun `list values containing the delimiter cannot be selected`() {
+        val parameter = createParameter().build()
+
+        assertNull(parameter.checkAndTransform(Value.of(listOf("a|b"))))
+    }
+
+    @Test
+    fun `the default provider kicks in for missing input`() {
+        val parameter = createParameter().withDefaultProvider { listOf("a", "b") }.build()
+
+        assertEquals("a|b", parameter.checkAndTransform(Value.EMPTY))
+    }
+
+    @Test
+    fun `stored values are resolved as list`() {
+        val parameter = createParameter().build()
+
+        assertEquals(listOf("a", "b"), parameter.get(mapOf("test" to "a|b")).orElseThrow())
+    }
+
+    @Test
+    fun `stale stored values are skipped on resolve`() {
+        val parameter = createParameter().build()
+
+        assertEquals(listOf("a"), parameter.get(mapOf("test" to "a|x")).orElseThrow())
+    }
+
+    @Test
+    fun `a stored value without any resolvable token resolves empty`() {
+        val parameter = createParameter().build()
+
+        assertTrue(parameter.get(mapOf("test" to "x")).isEmpty)
+        assertTrue(parameter.get(mapOf()).isEmpty)
+    }
+
+    @Test
+    fun `getValues enumerates all options with their selection state`() {
+        val builder = createParameter()
+
+        val values = builder.getValues(mapOf("test" to "a|c"))
+
+        assertEquals(listOf("a", "b", "c"), values.map { it.name() })
+        assertEquals(listOf("Label A", "Label B", "Label C"), values.map { it.label() })
+        assertTrue(values[0].selected())
+        assertFalse(values[1].selected())
+        assertTrue(values[2].selected())
+    }
+
+    @Test
+    fun `computeValueUpdate produces value and text pairs`() {
+        val parameter = createParameter().withUpdater { _ -> Optional.of(listOf("a", "b")) }.build()
+
+        val update = parameter.updateValue(mapOf()).orElseThrow() as ArrayNode
+
+        assertEquals(2, update.size())
+        assertEquals("a", update.get(0).get("value").asString(""))
+        assertEquals("Label A", update.get(0).get("text").asString(""))
+        assertEquals("b", update.get(1).get("value").asString(""))
+        assertEquals("Label B", update.get(1).get("text").asString(""))
+    }
+
+    private fun createParameter(): MultiSelectStringParameter {
+        return MultiSelectStringParameter("test", "Test").withEntry("a", "Label A")
+                                                                        .withEntry("b", "Label B")
+                                                                        .withEntry("c", "Label C")
+    }
+}

--- a/src/test/kotlin/sirius/biz/storage/layer1/ObjectStorageTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer1/ObjectStorageTest.kt
@@ -19,7 +19,7 @@ import sirius.kernel.di.std.Part
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.util.*
+import java.util.Random
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/src/test/kotlin/sirius/biz/storage/layer3/VirtualFileTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer3/VirtualFileTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import sirius.kernel.SiriusExtension
 import sirius.kernel.di.std.Part
 import java.net.URI
-import java.util.*
+import java.util.EnumSet
 import java.util.stream.Stream
 
 @ExtendWith(SiriusExtension::class)


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
Job parameters so far only supported multi-selects over a fixed list of string options (MultiSelectStringParameter) or single-entity selection with autocomplete (EntityParameter). This adds a base class for selecting multiple entities via autocomplete routes, needed e.g. to restrict export jobs to a set of linked entities.

New:
* MultiSelectEntityParameter: multi-select parameter for BaseEntity values. Uses an Autocompleter or a custom autocomplete URI for suggestions, serializes the selection as "|"-delimited entity ids and renders only the currently selected entities as preselected options (suggestions are provided at runtime via the autocomplete). Falls back to the plural label of the entity descriptor if no label is given.
* EntityParameterUtil: extracted the mechanics shared between EntityParameter and MultiSelectEntityParameter (autocompleter resolution, descriptor/mapper access, entity lookup incl. the "mustExist" error and the tenant access check). Both parameter types cannot share a base class due to incompatible value types (single entity vs. list), therefore the shared logic lives in this util which both delegate to. Parameter callbacks are passed as method references so that overrides in subclasses are picked up. The public/protected API of EntityParameter remains unchanged.

Changed:
* MultiSelectParameter now owns the complete "|"-encoding: it implements checkAndTransformValue (accepting both form value lists and already encoded strings) and resolveFromString, subclasses only implement checkAndTransformSingleValue / resolveSingleValueFromString for a single value. The contract is documented: return null to silently skip meaningless values, throw a HandledException whenever dropping a value would silently change the meaning of the job.
* MultiSelectParameter#computeValueUpdate now emits a [{value, text}] array for all multi-selects as expected by TokenAutocomplete#val - previously a plain string array would have silently cleared the field. The option name/label are derived via the new createValueName / createValueLabel hooks.
* The templates selectMultiString.html.pasta and the would-be entity variant are unified into selectMulti.html.pasta which passes the new MultiSelectParameter#getSuggestionUri (empty string for fixed option lists, autocomplete URL for entity parameters).

Fixed:
* assertTenantAccess no longer NPEs when the tenants framework is not part of the product.
* A configured but unregistered Autocompleter is now reported via an incident instead of silently degrading into a select without suggestions.
* MultiSelectStringParameter#getValues no longer fetches the entries map and splits the context value once per entry.

### Additional Notes
* Resolving a stored value now returns an empty optional instead of an empty list when no value can be resolved anymore, so require() and presence checks detect selections which became invalid after submission. Values which can no longer be resolved (e.g. deleted entities) are still skipped silently on resolve as this path is also used when rendering the job form; strict validation happens on every job submit/start via checkAndTransform.
* A single already-encoded string ("a|b", e.g. from a preset) is now split and validated per token by checkAndTransformValue instead of being rejected as a whole, consistent with resolveFromString.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


- This PR fixes or works on following ticket(s): [SE-15248](https://scireum.myjetbrains.com/youtrack/issue/SE-15248)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise --> https://github.com/scireum/sellsite/pull/14096

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
