### PR TITLE
Reject only calls that exceed the configured rate limit

### DIFF
--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -41,6 +41,8 @@ import java.util.function.Supplier;
  * ({@code epochSeconds / intervalSeconds}). Therefore, windows are globally aligned to wall clock time and not
  * "sliding" per caller.
  * <p>
+ * A limit of {@code n} permits {@code n} calls within the interval; the {@code (n + 1)}-th call is rejected.
+ * <p>
  * Caveats:
  * <ul>
  *     <li>Boundary bursts are possible: calls right before and right after a bucket switch are counted in separate windows.</li>
@@ -65,8 +67,8 @@ public class Isenguard {
     /**
      * Signals that the limit as given in the system configuration should be used.
      * <p>
-     * This is used by {@link #registerCallAndCheckRateLimitReached(String, String, int, Supplier)} and
-     * {@link #registerCallAndCheckRateLimitReached(String, String, int, Runnable, Supplier)}.
+     * This is used by {@link #registerCallAndCheckRateLimitExceeded(String, String, int, Supplier)} and
+     * {@link #registerCallAndCheckRateLimitExceeded(String, String, int, Runnable, Supplier)}.
      */
     public static final int USE_LIMIT_FROM_CONFIG = 0;
 
@@ -166,28 +168,28 @@ public class Isenguard {
                                     String realm,
                                     int explicitLimit,
                                     Supplier<RateLimitingInfo> infoSupplier) {
-        if (registerCallAndCheckRateLimitReached(scope, realm, explicitLimit, infoSupplier)) {
+        if (registerCallAndCheckRateLimitExceeded(scope, realm, explicitLimit, infoSupplier)) {
             throw createException(realm, explicitLimit);
         }
     }
 
     /**
-     * Creates an exception which indicates that the rate limit for the given realm is reached.
+     * Creates an exception which indicates that the rate limit for the given realm is exceeded.
      *
      * @param realm the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>
-     * @return an exception which indicates that the rate limit for the given realm is reached
+     * @return an exception which indicates that the rate limit for the given realm is exceeded
      */
     public HandledException createException(String realm) {
         return createException(realm, USE_LIMIT_FROM_CONFIG);
     }
 
     /**
-     * Creates an exception which indicates that the rate limit for the given realm is reached.
+     * Creates an exception which indicates that the rate limit for the given realm is exceeded.
      *
      * @param realm         the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>
      * @param explicitLimit the explicit limit which overwrites the limit given in the config.
      *                      Use {@link #USE_LIMIT_FROM_CONFIG} if no explicit limit is set
-     * @return an exception which indicates that the rate limit for the given realm is reached
+     * @return an exception which indicates that the rate limit for the given realm is exceeded
      */
     public HandledException createException(String realm, int explicitLimit) {
         Limit limit = fetchLimit(realm, explicitLimit);
@@ -201,9 +203,9 @@ public class Isenguard {
     }
 
     /**
-     * Registers an event and determines if the rate limit of the given realm for the given scope is reached.
+     * Registers an event and determines if the rate limit of the given realm for the given scope is exceeded.
      * <p>
-     * Note that invoking this method counts towards the limit. Use {@link #checkRateLimitReached(String, String, int)}
+     * Note that invoking this method counts towards the limit. Use {@link #checkRateLimitExceeded(String, String, int)}
      * if you only want to check the current state without counting the call.
      *
      * @param scope         the key which is used for grouping multiple events - e.g. the IP of the caller
@@ -211,38 +213,37 @@ public class Isenguard {
      * @param explicitLimit the explicit limit which overwrites the limit given in the config.
      *                      Use {@link #USE_LIMIT_FROM_CONFIG} if no explicit limit is set
      * @param infoSupplier  a supplier which is invoked to provide additional incident data once the rate limit is first hit
-     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is reached,
-     * <tt>false</tt> otherwise. Note, that once the limit was reached, an {@link AuditLog audit log entry} will be
+     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is exceeded,
+     * <tt>false</tt> otherwise. Note, that once the limit was exceeded, an {@link AuditLog audit log entry} will be
      * created.
      */
-    public boolean registerCallAndCheckRateLimitReached(String scope,
+    public boolean registerCallAndCheckRateLimitExceeded(String scope,
                                                         String realm,
                                                         int explicitLimit,
                                                         Supplier<RateLimitingInfo> infoSupplier) {
-        return registerCallAndCheckRateLimitReached(scope, realm, explicitLimit, null, infoSupplier);
+        return registerCallAndCheckRateLimitExceeded(scope, realm, explicitLimit, null, infoSupplier);
     }
 
     /**
-     * Registers an event and determines if the rate limit of the given realm for the given scope is reached.
+     * Registers an event and determines if the rate limit of the given realm for the given scope is exceeded.
      * <p>
-     * Note that invoking this method counts towards the limit. Use {@link #checkRateLimitReached(String, String, int)}
+     * Note that invoking this method counts towards the limit. Use {@link #checkRateLimitExceeded(String, String, int)}
      * if you only want to check the current state without counting the call.
      *
      * @param scope            the key which is used for grouping multiple events - e.g. the IP of the caller
      * @param realm            the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>
      * @param explicitLimit    the explicit limit which overwrites the limit given in the config.
      *                         Use {@link #USE_LIMIT_FROM_CONFIG} if no explicit limit is set
-     * @param limitReachedOnce specifies an action which is executed once the limit was reached, but then skipped for
+     * @param limitExceededOnce specifies an action which is executed once the limit was exceeded, but then skipped for
      *                         this scope, realm and check interval.
      * @param infoSupplier     a supplier which is invoked to provide additional incident data once the rate limit is first hit
-     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is reached,
-     * <tt>false</tt> otherwise. Note, that once the limit was reached, an {@link AuditLog audit log entry} will be
+     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is exceeded,
+     * <tt>false</tt> otherwise. Note, that once the limit was exceeded, an {@link AuditLog audit log entry} will be
      * created.
      */
-    public boolean registerCallAndCheckRateLimitReached(String scope,
+    public boolean registerCallAndCheckRateLimitExceeded(String scope,
                                                         String realm,
-                                                        int explicitLimit,
-                                                        Runnable limitReachedOnce,
+                                                        int explicitLimit, Runnable limitExceededOnce,
                                                         Supplier<RateLimitingInfo> infoSupplier) {
         try {
             Limit limit = fetchLimit(realm, explicitLimit);
@@ -250,11 +251,11 @@ public class Isenguard {
                 return false;
             }
 
-            return registerCallAndCheckLimit(scope, realm, limit.intervalSeconds, limit.maxCalls, () -> {
-                handleLimitReached(scope, realm, limit, infoSupplier.get());
+            return registerCallAndCheckLimitExceeded(scope, realm, limit.intervalSeconds, limit.maxCalls, () -> {
+                handleLimitExceeded(scope, realm, limit, infoSupplier.get());
 
-                if (limitReachedOnce != null) {
-                    limitReachedOnce.run();
+                if (limitExceededOnce != null) {
+                    limitExceededOnce.run();
                 }
             });
         } catch (Exception exception) {
@@ -268,30 +269,30 @@ public class Isenguard {
     }
 
     /**
-     * Determines if the rate limit of the given realm for the given scope is reached. This check does not have side
+     * Determines if the rate limit of the given realm for the given scope is exceeded. This check does not have side
      * effects.
      *
      * @param scope the key which is used for grouping multiple events - e.g. the IP of the caller
      * @param realm the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>
-     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is reached,
+     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is exceeded,
      * <tt>false</tt> otherwise
      */
-    public boolean checkRateLimitReached(String scope, String realm) {
-        return checkRateLimitReached(scope, realm, USE_LIMIT_FROM_CONFIG);
+    public boolean checkRateLimitExceeded(String scope, String realm) {
+        return checkRateLimitExceeded(scope, realm, USE_LIMIT_FROM_CONFIG);
     }
 
     /**
-     * Determines if the rate limit of the given realm for the given scope is reached. This check does not have side
+     * Determines if the rate limit of the given realm for the given scope is exceeded. This check does not have side
      * effects.
      *
      * @param scope         the key which is used for grouping multiple events - e.g. the IP of the caller
      * @param realm         the realm which defines the limit and check interval (<tt>isenguard.limit.[realm]</tt>
      * @param explicitLimit the explicit limit which overwrites the limit given in the config.
      *                      Use {@link #USE_LIMIT_FROM_CONFIG} if no explicit limit is set
-     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is reached,
+     * @return <tt>true</tt> if the rate limit for the given scope, realm and check interval is exceeded,
      * <tt>false</tt> otherwise
      */
-    public boolean checkRateLimitReached(String scope, String realm, int explicitLimit) {
+    public boolean checkRateLimitExceeded(String scope, String realm, int explicitLimit) {
         try {
             Limit limit = fetchLimit(realm, explicitLimit);
             if (!limit.isValid()) {
@@ -321,8 +322,8 @@ public class Isenguard {
         return new Limit(setting.getInt("limit"), (int) (setting.getMilliseconds("interval") / 1000));
     }
 
-    private void handleLimitReached(String scope, String realm, Limit limit, RateLimitingInfo info) {
-        LOG.WARN("Scope %s reached its rate-limit (%s) for realm '%s'. IP: %s, Tenant: %s, Location: %s",
+    private void handleLimitExceeded(String scope, String realm, Limit limit, RateLimitingInfo info) {
+        LOG.WARN("Scope %s exceeded its rate-limit (%s) for realm '%s'. IP: %s, Tenant: %s, Location: %s",
                  scope,
                  limit.format(),
                  realm,
@@ -343,16 +344,16 @@ public class Isenguard {
 
     private boolean checkLimit(String scope, String realm, int intervalInSeconds, int limit) {
         String key = computeRateLimitingKey(scope, realm, intervalInSeconds);
-        return limiter.readCallCount(key) >= limit;
+        return limiter.readCallCount(key) > limit;
     }
 
-    private boolean registerCallAndCheckLimit(String scope,
-                                              String realm,
-                                              int intervalInSeconds,
-                                              int limit,
-                                              Runnable limitReachedOnce) {
+    private boolean registerCallAndCheckLimitExceeded(String scope,
+                                                      String realm,
+                                                      int intervalInSeconds,
+                                                      int limit,
+                                                      Runnable limitExceededOnce) {
         String key = computeRateLimitingKey(scope, realm, intervalInSeconds);
-        return limiter.registerCallAndCheckLimit(key, intervalInSeconds, limit, limitReachedOnce);
+        return limiter.registerCallAndCheckLimitExceeded(key, intervalInSeconds, limit, limitExceededOnce);
     }
 
     private String computeRateLimitingKey(String scope, String realm, int intervalInSeconds) {

--- a/src/main/java/sirius/biz/isenguard/IsenguardFirewall.java
+++ b/src/main/java/sirius/biz/isenguard/IsenguardFirewall.java
@@ -34,13 +34,13 @@ public class IsenguardFirewall implements Firewall {
     @Override
     public boolean handleRateLimiting(WebContext webContext, String realm) {
         String ip = webContext.getRemoteIP().getHostAddress();
-        boolean rateLimitReached = isenguard.registerCallAndCheckRateLimitReached(ip,
-                                                                                  realm,
-                                                                                  Isenguard.USE_LIMIT_FROM_CONFIG,
-                                                                                  () -> RateLimitingInfo.fromWebContext(
-                                                                                          webContext,
-                                                                                          null));
-        if (rateLimitReached) {
+        boolean rateLimitExceeded = isenguard.registerCallAndCheckRateLimitExceeded(ip,
+                                                                                    realm,
+                                                                                    Isenguard.USE_LIMIT_FROM_CONFIG,
+                                                                                    () -> RateLimitingInfo.fromWebContext(
+                                                                                            webContext,
+                                                                                            null));
+        if (rateLimitExceeded) {
             webContext.respondWith().error(HttpResponseStatus.TOO_MANY_REQUESTS);
             return true;
         }

--- a/src/main/java/sirius/biz/isenguard/Limiter.java
+++ b/src/main/java/sirius/biz/isenguard/Limiter.java
@@ -51,6 +51,25 @@ public interface Limiter extends Named {
     boolean registerCallAndCheckLimit(String key, int intervalInSeconds, int limit, Runnable limitReachedOnce);
 
     /**
+     * Increases the call counter for the current interval and determines if the given limit was exceeded.
+     * <p>
+     * In contrast to {@link #registerCallAndCheckLimit(String, int, int, Runnable)}, a limit of {@code n} permits
+     * exactly {@code n} calls and only the {@code (n + 1)}-th call is reported as exceeded.
+     *
+     * @param key               the unique name of this counter which represents the scope, realm and check-interval
+     * @param intervalInSeconds the duration of this interval in seconds (used to remove outdated counters)
+     * @param limit             the limit i.e. the max number of permitted calls
+     * @param limitExceededOnce the handler to execute once if the limit for this interval is exceeded
+     * @return <tt>true</tt> if the limit was exceeded, <tt>false</tt> otherwise
+     */
+    default boolean registerCallAndCheckLimitExceeded(String key,
+                                                      int intervalInSeconds,
+                                                      int limit,
+                                                      Runnable limitExceededOnce) {
+        return registerCallAndCheckLimit(key, intervalInSeconds, limit + 1, limitExceededOnce);
+    }
+
+    /**
      * Reads the current call count for the given key.
      *
      * @param key the unique name of this counter which represents the scope, realm and check-interval

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -638,7 +638,7 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
             return null;
         }
 
-        verifyLoginRateLimitNotReached(webContext);
+        verifyLoginRateLimitNotExceeded(webContext);
 
         UserInfo result = findUserByNameForPasswordLogin(webContext, user);
         if (result == null) {
@@ -697,13 +697,13 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         return null;
     }
 
-    private void verifyLoginRateLimitNotReached(@Nullable WebContext webContext) {
+    private void verifyLoginRateLimitNotExceeded(@Nullable WebContext webContext) {
         if (webContext == null) {
             return;
         }
 
         String ip = webContext.getRemoteIP().getHostAddress();
-        if (isenguard.checkRateLimitReached(ip, SECURITY_RATE_LIMIT_REALM)) {
+        if (isenguard.checkRateLimitExceeded(ip, SECURITY_RATE_LIMIT_REALM)) {
             throw isenguard.createException(SECURITY_RATE_LIMIT_REALM);
         }
     }
@@ -714,13 +714,13 @@ public abstract class TenantUserManager<I extends Serializable, T extends BaseEn
         }
 
         String ip = webContext.getRemoteIP().getHostAddress();
-        boolean rateLimitReached = isenguard.registerCallAndCheckRateLimitReached(ip,
+        boolean rateLimitExceeded = isenguard.registerCallAndCheckRateLimitExceeded(ip,
                                                                                   SECURITY_RATE_LIMIT_REALM,
                                                                                   Isenguard.USE_LIMIT_FROM_CONFIG,
                                                                                   () -> RateLimitingInfo.fromWebContext(
                                                                                           webContext,
                                                                                           null));
-        if (rateLimitReached) {
+        if (rateLimitExceeded) {
             throw isenguard.createException(SECURITY_RATE_LIMIT_REALM);
         }
     }

--- a/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
+++ b/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
@@ -29,54 +29,63 @@ class IsenguardTest {
         val realm = "test"
 
         val counter = AtomicInteger()
-        isenguard.registerCallAndCheckRateLimitReached(
+        isenguard.registerCallAndCheckRateLimitExceeded(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        isenguard.registerCallAndCheckRateLimitReached(
+        isenguard.registerCallAndCheckRateLimitExceeded(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        isenguard.registerCallAndCheckRateLimitReached(
+        isenguard.registerCallAndCheckRateLimitExceeded(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        val thirdCheck = isenguard.checkRateLimitReached(scope, realm)
-        val fourth = isenguard.registerCallAndCheckRateLimitReached(
+        val thirdCheck = isenguard.checkRateLimitExceeded(scope, realm)
+        val fourth = isenguard.registerCallAndCheckRateLimitExceeded(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        val fourthCheck = isenguard.checkRateLimitReached(scope, realm)
-        val fifth = isenguard.registerCallAndCheckRateLimitReached(
+        val fourthCheck = isenguard.checkRateLimitExceeded(scope, realm)
+        val fifth = isenguard.registerCallAndCheckRateLimitExceeded(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        val fifthCheck = isenguard.checkRateLimitReached(scope, realm)
-        val sixth = isenguard.registerCallAndCheckRateLimitReached(
+        val fifthCheck = isenguard.checkRateLimitExceeded(scope, realm)
+        val sixth = isenguard.registerCallAndCheckRateLimitExceeded(
             scope,
             realm,
             Isenguard.USE_LIMIT_FROM_CONFIG,
             { counter.incrementAndGet() },
             { RateLimitingInfo(null, null, null) })
-        val sixthCheck = isenguard.checkRateLimitReached(scope, realm)
+        val sixthCheck = isenguard.checkRateLimitExceeded(scope, realm)
+        val seventh = isenguard.registerCallAndCheckRateLimitExceeded(
+            scope,
+            realm,
+            Isenguard.USE_LIMIT_FROM_CONFIG,
+            { counter.incrementAndGet() },
+            { RateLimitingInfo(null, null, null) })
+        val seventhCheck = isenguard.checkRateLimitExceeded(scope, realm)
 
         assertFalse { thirdCheck }
         assertFalse { fourth }
         assertFalse { fourthCheck }
-        assertTrue { fifth }
-        assertTrue { fifthCheck }
+        assertFalse { fifth }
+        assertFalse { fifthCheck }
         assertTrue { sixth }
         assertTrue { sixthCheck }
+        assertTrue { seventh }
+        assertTrue { seventhCheck }
         assertEquals(1, counter.get())
     }
 

--- a/src/test/kotlin/sirius/biz/tenants/TenantUserManagerTest.kt
+++ b/src/test/kotlin/sirius/biz/tenants/TenantUserManagerTest.kt
@@ -51,9 +51,10 @@ class TenantUserManagerTest {
         assertNotNull(userManager.findUserByCredentials(webContext, "test", "test"))
         assertNull(userManager.findUserByCredentials(webContext, "test", "wrong-password-1"))
         assertNull(userManager.findUserByCredentials(webContext, "test", "wrong-password-2"))
+        assertNull(userManager.findUserByCredentials(webContext, "test", "wrong-password-3"))
 
         assertThrows<HandledException> {
-            userManager.findUserByCredentials(webContext, "test", "wrong-password-3")
+            userManager.findUserByCredentials(webContext, "test", "wrong-password-4")
         }
     }
 }


### PR DESCRIPTION
### Description

Isenguard blocked a call as soon as the counter reached the limit, which meant a configured limit effectively allowed one call too few. The facade now checks for exceeded, so a limit of n permits n calls and only rejects the one after that. The new check is added as a default method on the Limiter SPI so existing implementations stay compatible.

## Migration for consumers (OXOMI, MEMOIO, sellsite)

Upgrading requires three kinds of adjustments:

**Renamed public methods on `Isenguard` (compile errors, both overloads each):**
- `registerCallAndCheckRateLimitReached(...)` is now called `registerCallAndCheckRateLimitExceeded(...)`
- `checkRateLimitReached(...)` is now called `checkRateLimitExceeded(...)`

**Same name, changed behavior (no compile error, silent shift):**
- `enforceRateLimiting(...)` keeps its name but now uses exceeded semantics. Callers compile unchanged but the effective limit shifts by one, so review every usage.

**Changed behavior and configuration (reached to exceeded):**
- A configured limit of `n` now permits `n` calls and only rejects the `(n + 1)`-th, whereas it previously permitted only `n - 1`.
- To keep the exact previous behavior, lower every `isenguard.limit.<realm>.limit` by 1.

**Not affected:**
- The `Limiter` SPI stays backwards compatible. `registerCallAndCheckLimitExceeded` is a default method, so custom `Limiter` implementations keep working without any change.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1236](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1236) 

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
