### PR TITLE
Guards the updates feed against malformed responses breaking the login page

### DIFF
--- a/src/main/java/sirius/biz/tycho/updates/UpdateManager.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdateManager.java
@@ -124,7 +124,9 @@ public class UpdateManager {
             }
             this.globalUpdates = nextUpdates;
             this.lastFetch = LocalDateTime.now();
-        } catch (IOException | URISyntaxException exception) {
+        } catch (IOException | URISyntaxException | RuntimeException exception) {
+            // Unchecked exceptions are caught deliberately, as this runs while rendering the login page and no
+            // defect of an external feed may ever keep a user from logging in...
             Exceptions.handle()
                       .error(exception)
                       .to(Log.BACKGROUND)

--- a/src/main/java/sirius/biz/tycho/updates/UpdateManager.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdateManager.java
@@ -97,10 +97,22 @@ public class UpdateManager {
     private void fetchUpdatesFromFeed() {
         try {
             this.lastAttempt = LocalDateTime.now();
-            List<UpdateInfo> nextUpdates = new ArrayList<>();
             XMLCall call = XMLCall.to(new URI(feedUrl));
+            StructuredNode channel = call.getInput().getNode(ATOM_FEED_CHANNEL);
+            if (channel == null) {
+                Exceptions.handle()
+                          .to(Log.BACKGROUND)
+                          .withSystemErrorMessage(
+                                  "Failed to fetch updates feed: The response of '%s' contains no '%s' node.",
+                                  feedUrl,
+                                  ATOM_FEED_CHANNEL)
+                          .handle();
+                return;
+            }
+
+            List<UpdateInfo> nextUpdates = new ArrayList<>();
             Limit limit = new Limit(0, MAX_FEED_ITEMS_TO_FETCH);
-            for (StructuredNode node : call.getInput().getNode(ATOM_FEED_CHANNEL).queryNodeList(ATOM_FEED_ITEM)) {
+            for (StructuredNode node : channel.queryNodeList(ATOM_FEED_ITEM)) {
                 List<String> categories = node.queryNodeList(ATOM_ITEM_CATEGORY)
                                               .stream()
                                               .map(category -> category.queryString("."))


### PR DESCRIPTION
### Description

A `NullPointerException` in `UpdateManager` currently takes down the **login page** whenever the configured blog feed misbehaves:

```
Cannot invoke "sirius.kernel.xml.StructuredNode.queryNodeList(String)" because the return value of
"sirius.kernel.xml.XMLStructuredInput.getNode(String)" is null
    at sirius.biz.tycho.updates.UpdateManager.fetchUpdatesFromFeed(UpdateManager.java:103)
```

`StructuredInput.getNode` delegates to the explicitly `@Nullable` `StructuredNode.queryNode`, which returns `null` when the xpath matches nothing. The feed loop dereferenced that directly, so any well-formed XML response without a `<channel>` element raised an NPE rather than yielding an empty update list.

The blast radius is what makes this worth fixing rather than just logging: `dashboard-news.html.pasta` is embedded via `tycho-login/support.html.pasta` into `login.html.pasta`. Since the NPE is unchecked, it escaped the `catch (IOException | URISyntaxException)` clause, escaped `fetchUpdates()`, and failed the template render — so **a broken third party blog feed produced a 500 on login**. It recurs every `FEED_FETCH_RETRY_MINUTES` (15), because `lastAttempt` is set before the throw and the cached list serves the page in between, which is why this shows up as an intermittent rather than a permanent failure.

Two commits, deliberately separate:

1. **Guards against the missing `channel` node.** Reports the malformed response to `Log.BACKGROUND` and keeps the previously fetched updates — exactly the behaviour the surrounding code already implements for an unreachable feed.
2. **Widens the catch clause to `RuntimeException`.** The null dereference was not the only unchecked route out of this method: `parseFeedItem` runs `RFC_1123_DATE_TIME.parse(node.queryString(ATOM_ITEM_PUB_DATE))`, and `queryString` yields an empty string for an absent `pubDate`, so a feed item without a publication date answers with a `DateTimeParseException` and fails the login render the same way. The broad clause is intentional and commented: nothing about an external feed may keep a user from logging in. Nothing is swallowed silently — everything is still reported to the background log.

No behaviour changes for a well-formed feed.

#### Note on the trigger

The default feed (`https://scireum.de/category/Blog-Aktuelles/feed/`, configured in scireum-core) is **currently returning HTTP 500** with a WordPress error page — as is `https://scireum.de/feed/`, so the site's whole feed infrastructure is down. That is an unrelated upstream problem and someone should look at it separately.

Worth noting for reviewers: the response *as it stands right now* would take the already-handled path, because `XMLCall.getInput()` rejects an erroneous response unless the content type contains "xml", and this one is `text/html`. So the payload logged at the time of the incident must have been well-formed XML lacking `<channel>` — either an HTTP 200, or a 500 that still carried the feed content type (typical when PHP dies after WordPress has already sent `application/rss+xml`). I could not reconstruct the exact body, so the fix targets the structural defect, which holds for any of those shapes.

### Additional Notes

- This PR fixes or works on following ticket(s): none — the defect surfaced from a production log on a staging system
- This PR is related to PR: —

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.

Scope of what was actually verified, so the ticks are not read too broadly:

- `mvn compile` passes, and the IntelliJ formatter reports *"Formatted well"* against `.idea/codeStyles/Project.xml`.
- **SonarLint was not run** — it cannot run headlessly (the plugin registers no inspection extension points). Please run *Analyze VCS Changed Files* in the IDE if you want that covered.
- **No automated test was added.** `fetchUpdatesFromFeed` is private and performs the HTTP call itself, so covering this would need the feed parsing extracted behind a `StructuredInput` seam. Happy to add that refactor if it is wanted here rather than in a follow-up.
- No patch tasks are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
