### PR TITLE
Allow open search results to post their action

### DIFF
--- a/src/main/java/sirius/biz/tenants/UserAccountSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountSearchProvider.java
@@ -93,10 +93,10 @@ public abstract class UserAccountSearchProvider<I extends Serializable, T extend
                 openSearchResult.withDescription(userAccount + " (" + userAccount.getTenant()
                                                                                  .fetchCachedValue()
                                                                                  .toString() + ")")
-                                .withURL("/tenants/select/"
-                                         + userAccount.getTenant().getIdAsString()
-                                         + "?goto="
-                                         + Urls.encode("/user-account/" + userAccount.getIdAsString()));
+                                .withPostURL("/tenants/select/"
+                                             + userAccount.getTenant().getIdAsString()
+                                             + "?goto="
+                                             + Urls.encode("/user-account/" + userAccount.getIdAsString()));
             }
 
             if (currentUser.hasPermission(TenantUserManager.PERMISSION_SELECT_USER_ACCOUNT)) {

--- a/src/main/java/sirius/biz/tycho/search/OpenSearchController.java
+++ b/src/main/java/sirius/biz/tycho/search/OpenSearchController.java
@@ -106,6 +106,7 @@ public class OpenSearchController extends BizController {
     private static final String RESPONSE_LABEL = "label";
     private static final String RESPONSE_HTML_DESCRIPTION = "htmlDescription";
     private static final String RESPONSE_URL = "url";
+    private static final String RESPONSE_SEND_POST_REQUEST = "sendPostRequest";
     private static final String RESPONSE_ICON = "icon";
 
     @Parts(OpenSearchProvider.class)
@@ -231,6 +232,7 @@ public class OpenSearchController extends BizController {
         object.put(RESPONSE_LABEL, result.getLabel());
         object.put(RESPONSE_HTML_DESCRIPTION, result.getHtmlDescription());
         object.put(RESPONSE_URL, result.getUrl());
+        object.put(RESPONSE_SEND_POST_REQUEST, result.shouldSendPostRequest());
         return object;
     }
 }

--- a/src/main/java/sirius/biz/tycho/search/OpenSearchResult.java
+++ b/src/main/java/sirius/biz/tycho/search/OpenSearchResult.java
@@ -34,6 +34,7 @@ public class OpenSearchResult {
 
     private String label;
     private String url;
+    private boolean sendPostRequest;
     private String htmlDescription;
 
     /**
@@ -57,6 +58,22 @@ public class OpenSearchResult {
      */
     public OpenSearchResult withURL(String url) {
         this.url = url;
+        return this;
+    }
+
+    /**
+     * Specifies the URL to post to if the result label is clicked.
+     * <p>
+     * Use this instead of {@link #withURL(String)} for routes which are only accessible via POST - e.g. as they
+     * change the state of the system. The result is then rendered as a form which submits a CSRF token along with
+     * the request, so that no additional confirmation page is required.
+     *
+     * @param url the action to post to
+     * @return the result itself for fluent method calls.
+     */
+    public OpenSearchResult withPostURL(String url) {
+        this.url = url;
+        this.sendPostRequest = true;
         return this;
     }
 
@@ -131,6 +148,10 @@ public class OpenSearchResult {
 
     public String getUrl() {
         return url;
+    }
+
+    public boolean shouldSendPostRequest() {
+        return sendPostRequest;
     }
 
     public String getHtmlDescription() {

--- a/src/main/java/sirius/biz/tycho/search/OpenSearchResult.java
+++ b/src/main/java/sirius/biz/tycho/search/OpenSearchResult.java
@@ -58,6 +58,7 @@ public class OpenSearchResult {
      */
     public OpenSearchResult withURL(String url) {
         this.url = url;
+        this.sendPostRequest = false;
         return this;
     }
 

--- a/src/main/resources/default/templates/biz/tycho/search/search.html.pasta
+++ b/src/main/resources/default/templates/biz/tycho/search/search.html.pasta
@@ -124,7 +124,15 @@
                             '       <div class="card-body d-flex flex-column h-100">' +
                             '           <h5 class="card-title">{{label}}</h5>' +
                             '           <div class="flex-grow-1">{{{htmlDescription}}}</div>' +
+                            '           {{#sendPostRequest}}' +
+                            '           <form method="post" action="{{url}}">' +
+                            '               <input type="hidden" name="CSRFToken" value="' + tycho_csrf_token + '"/>' +
+                            '               <button type="submit" class="stretched-link border-0 bg-transparent p-0 d-block" aria-label="{{label}}"></button>' +
+                            '           </form>' +
+                            '           {{/sendPostRequest}}' +
+                            '           {{^sendPostRequest}}' +
                             '           <a href="{{url}}" class="stretched-link"></a>' +
+                            '           {{/sendPostRequest}}' +
                             '        </div>' +
                             '    </div>' +
                             '</div>', node);


### PR DESCRIPTION
### Description

- `OpenSearchResult.withPostURL(…)` marks a result whose action changes the state of the system
- Such a card renders a form with a CSRF token instead of a link
- `UserAccountSearchProvider` uses it
- Since `/tenants/select/:1` was split into GET (confirmation page) and POST (actual switch), every card pointing there ends up on the confirmation page
- A link cannot post
- `t:datacard`, `t:dropdownItem` and `SmartValue` have been able to post for a while, `OpenSearchResult` could not

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1242](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1242)
- This PR is related to PR: https://github.com/scireum/oxomi/pull/13209

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
