### PR TITLE
Record all decimal places of amounts in the change journal

### DIFF
--- a/src/main/java/sirius/biz/protocol/DelegateJournalData.java
+++ b/src/main/java/sirius/biz/protocol/DelegateJournalData.java
@@ -22,7 +22,6 @@ import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
-import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
@@ -218,11 +217,9 @@ public class DelegateJournalData extends Composite {
                                       changes.append("- ");
                                       changes.append(property.getName());
                                       changes.append(": ");
-                                      changes.append(NLS.toUserString(owner.getPersistedValue(property),
-                                                                      NLS.getDefaultLanguage()));
+                                      changes.append(JournalData.formatValue(owner.getPersistedValue(property)));
                                       changes.append(" -> ");
-                                      changes.append(NLS.toUserString(property.getValue(owner),
-                                                                      NLS.getDefaultLanguage()));
+                                      changes.append(JournalData.formatValue(property.getValue(owner)));
                                       changes.append("\n");
                                   });
 
@@ -244,7 +241,7 @@ public class DelegateJournalData extends Composite {
             changes.append("- ");
             changes.append(property.getName());
             changes.append(": ");
-            changes.append(NLS.toUserString(owner.getPersistedValue(property), NLS.getDefaultLanguage()));
+            changes.append(JournalData.formatValue(owner.getPersistedValue(property)));
             changes.append("\n");
         });
 

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -20,6 +20,7 @@ import sirius.db.mixing.annotations.AfterSave;
 import sirius.db.mixing.annotations.Transient;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.TaskContext;
+import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
@@ -27,6 +28,8 @@ import sirius.kernel.nls.NLS;
 import sirius.web.security.UserContext;
 
 import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
@@ -112,9 +115,9 @@ public class JournalData extends Composite {
         fetchJournaledAndChangedProperties().forEach(property -> {
             changes.append(property.getName());
             changes.append(": ");
-            changes.append(NLS.toUserString(owner.getPersistedValue(property), NLS.getDefaultLanguage()));
+            changes.append(formatValue(owner.getPersistedValue(property)));
             changes.append(" -> ");
-            changes.append(NLS.toUserString(property.getValue(owner), NLS.getDefaultLanguage()));
+            changes.append(formatValue(property.getValue(owner)));
             changes.append("\n");
         });
 
@@ -123,6 +126,28 @@ public class JournalData extends Composite {
         }
 
         return changes.toString();
+    }
+
+    /**
+     * Formats the given property value for the change journal.
+     * <p>
+     * {@link NLS#toUserString(Object)} would round decimal values to two decimal places. As the resulting string is
+     * persisted, a change in the third or a later decimal place would be recorded as two identical values. Therefore,
+     * amounts (the only decimal property type) are formatted using their actual number of decimal places here.
+     *
+     * @param value the value to format
+     * @return a string representation of the given value which retains all decimal places
+     */
+    public static String formatValue(Object value) {
+        if (value instanceof Amount amount && amount.isFilled()) {
+            BigDecimal decimalValue = amount.getAmount();
+            NumberFormat format = NLS.getDecimalFormat(NLS.getDefaultLanguage());
+            format.setMaximumFractionDigits(Math.max(format.getMaximumFractionDigits(),
+                                                     decimalValue.stripTrailingZeros().scale()));
+            return format.format(decimalValue);
+        }
+
+        return NLS.toUserString(value, NLS.getDefaultLanguage());
     }
 
     /**

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -136,7 +136,7 @@ public class JournalData extends Composite {
      * amounts (the only decimal property type) are formatted using their actual number of decimal places here.
      *
      * @param value the value to format
-     * @return a string representation of the given value which retains all decimal places
+     * @return a string representation of the given value which retains all significant decimal places
      */
     public static String formatValue(Object value) {
         if (value instanceof Amount amount && amount.isFilled()) {


### PR DESCRIPTION
### Description
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
Previously, changed values were journaled via NLS.toUserString, which formats decimals using the two-digit pattern NLS.patternDecimal. As the journal string is persisted, a change in the third or a later decimal place was recorded as two identical values (e.g. "1,23 -> 1,23").

Filled amounts are now formatted by the new JournalData.formatValue using the localized decimal format, with maximumFractionDigits raised to the actual scale of the value (stripTrailingZeros), so all significant decimal places are recorded. DelegateJournalData uses the same helper for its change and delete journals. Amount is the only decimal property type in sirius-db, so no other types need special handling; the BigDecimal is formatted directly, avoiding the doubleValue() precision loss of NLS.toUserString.

Edge cases / intentional behavior:
- Localized formatting is kept (decimal comma, grouping separators of the default language) and at least two decimal places are always shown, so typical entries ("1.500,00 -> 1.600,00") look as before.
- Trailing zeros stemming from the @Numeric scale of the column are stripped; only significant decimal places are shown.
- Values may now legitimately show up to five decimal places even for "money-like" fields: user input parsed via Amount.of is normalized to Amount.SCALE (5) before the @Numeric rounding applies. The journal simply reveals what is actually persisted.
- Fields written via Amount.ofRounded (e.g. import or manual controller paths) keep their full scale and may show more decimal places (up to the @Numeric scale, e.g. 15).

Empty amounts are still recorded as an empty string. Existing journal entries remain rounded, as the strings are persisted at write time.


- fixes: SIRI-1265

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1265](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1265)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
