### PR TITLE
Adds change tracing and journaling to scheduler entries

### DIFF
--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerData.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerData.java
@@ -8,6 +8,7 @@
 
 package sirius.biz.jobs.scheduler;
 
+import sirius.biz.protocol.NoJournal;
 import sirius.biz.web.Autoloaded;
 import sirius.db.mixing.Composite;
 import sirius.db.mixing.Mapping;
@@ -101,12 +102,14 @@ public class SchedulerData extends Composite {
      */
     public static final Mapping LAST_EXECUTION = Mapping.named("lastExecution");
     @NullAllowed
+    @NoJournal
     private LocalDateTime lastExecution;
 
     /**
      * Stores how often this task has been executed / scheduled.
      */
     public static final Mapping NUMBER_OF_EXECUTIONS = Mapping.named("numberOfExecutions");
+    @NoJournal
     private int numberOfExecutions;
 
     /**

--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerEntry.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerEntry.java
@@ -9,6 +9,8 @@
 package sirius.biz.jobs.scheduler;
 
 import sirius.biz.jobs.JobConfigData;
+import sirius.biz.protocol.Journaled;
+import sirius.biz.protocol.Traced;
 import sirius.db.mixing.Entity;
 import sirius.db.mixing.Mapping;
 import sirius.kernel.commons.Explain;
@@ -18,7 +20,7 @@ import sirius.kernel.commons.Explain;
  */
 @SuppressWarnings("squid:S1214")
 @Explain("We rather keep the constants here, as this emulates the behaviour and layout of a real entity.")
-public interface SchedulerEntry extends Entity {
+public interface SchedulerEntry extends Entity, Traced, Journaled {
 
     /**
      * Contains the scheduler data composite which describes when the job is to be executed.

--- a/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntry.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntry.java
@@ -11,6 +11,7 @@ package sirius.biz.jobs.scheduler.jdbc;
 import sirius.biz.jobs.JobConfigData;
 import sirius.biz.jobs.scheduler.SchedulerData;
 import sirius.biz.jobs.scheduler.SchedulerEntry;
+import sirius.biz.protocol.JournalData;
 import sirius.biz.tenants.jdbc.SQLTenantAware;
 import sirius.db.mixing.annotations.TranslationSource;
 import sirius.kernel.di.std.Framework;
@@ -24,6 +25,7 @@ public class SQLSchedulerEntry extends SQLTenantAware implements SchedulerEntry 
 
     private final SchedulerData schedulerData = new SchedulerData();
     private final JobConfigData jobConfigData = new JobConfigData();
+    private final JournalData journal = new JournalData(this);
 
     @Override
     public SchedulerData getSchedulerData() {
@@ -33,6 +35,11 @@ public class SQLSchedulerEntry extends SQLTenantAware implements SchedulerEntry 
     @Override
     public JobConfigData getJobConfigData() {
         return jobConfigData;
+    }
+
+    @Override
+    public JournalData getJournal() {
+        return journal;
     }
 
     @Override

--- a/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntryProvider.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntryProvider.java
@@ -55,6 +55,9 @@ public class SQLSchedulerEntryProvider implements SchedulerEntryProvider<SQLSche
     @Override
     public void markExecuted(SQLSchedulerEntry job, LocalDateTime timestamp) {
         job.getSchedulerData().rememberExecution(timestamp);
+        // Only user-driven changes should be journaled - the execution counters updated here must not
+        // create a journal entry per run.
+        job.getJournal().setSilent(true);
         oma.update(job);
     }
 }

--- a/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntryProvider.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntryProvider.java
@@ -55,8 +55,8 @@ public class SQLSchedulerEntryProvider implements SchedulerEntryProvider<SQLSche
     @Override
     public void markExecuted(SQLSchedulerEntry job, LocalDateTime timestamp) {
         job.getSchedulerData().rememberExecution(timestamp);
-        // Only user-driven changes should be journaled - the execution counters updated here must not
-        // create a journal entry per run.
+        // Executions must not spam the journal - especially the decremented "runs" counter, which is
+        // user-editable and therefore not annotated with @NoJournal.
         job.getJournal().setSilent(true);
         oma.update(job);
     }

--- a/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntry.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntry.java
@@ -11,6 +11,7 @@ package sirius.biz.jobs.scheduler.mongo;
 import sirius.biz.jobs.JobConfigData;
 import sirius.biz.jobs.scheduler.SchedulerData;
 import sirius.biz.jobs.scheduler.SchedulerEntry;
+import sirius.biz.protocol.JournalData;
 import sirius.biz.tenants.mongo.MongoTenantAware;
 import sirius.db.mixing.annotations.TranslationSource;
 import sirius.kernel.di.std.Framework;
@@ -24,6 +25,7 @@ public class MongoSchedulerEntry extends MongoTenantAware implements SchedulerEn
 
     private final SchedulerData schedulerData = new SchedulerData();
     private final JobConfigData jobConfigData = new JobConfigData();
+    private final JournalData journal = new JournalData(this);
 
     @Override
     public SchedulerData getSchedulerData() {
@@ -33,6 +35,11 @@ public class MongoSchedulerEntry extends MongoTenantAware implements SchedulerEn
     @Override
     public JobConfigData getJobConfigData() {
         return jobConfigData;
+    }
+
+    @Override
+    public JournalData getJournal() {
+        return journal;
     }
 
     @Override

--- a/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntryProvider.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntryProvider.java
@@ -58,6 +58,9 @@ public class MongoSchedulerEntryProvider implements SchedulerEntryProvider<Mongo
     @Override
     public void markExecuted(MongoSchedulerEntry job, LocalDateTime timestamp) {
         job.getSchedulerData().rememberExecution(timestamp);
+        // Only user-driven changes should be journaled - the execution counters updated here must not
+        // create a journal entry per run.
+        job.getJournal().setSilent(true);
         mango.update(job);
     }
 }

--- a/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntryProvider.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntryProvider.java
@@ -58,8 +58,8 @@ public class MongoSchedulerEntryProvider implements SchedulerEntryProvider<Mongo
     @Override
     public void markExecuted(MongoSchedulerEntry job, LocalDateTime timestamp) {
         job.getSchedulerData().rememberExecution(timestamp);
-        // Only user-driven changes should be journaled - the execution counters updated here must not
-        // create a journal entry per run.
+        // Executions must not spam the journal - especially the decremented "runs" counter, which is
+        // user-editable and therefore not annotated with @NoJournal.
         job.getJournal().setSilent(true);
         mango.update(job);
     }

--- a/src/main/resources/default/templates/biz/codelists/code-list-entry.html.pasta
+++ b/src/main/resources/default/templates/biz/codelists/code-list-entry.html.pasta
@@ -51,9 +51,7 @@
                         labelKey="Model.description"/>
         </div>
         <t:formBar>
-            <i:if test="!entry.isNew()">
-                <t:tracing trace="@entry.getCodeListEntryData().getTrace()"/>
-            </i:if>
+            <t:tracing trace="@entry.getCodeListEntryData().getTrace()"/>
         </t:formBar>
     </t:editForm>
 </t:page>

--- a/src/main/resources/default/templates/biz/jobs/scheduler/entry.html.pasta
+++ b/src/main/resources/default/templates/biz/jobs/scheduler/entry.html.pasta
@@ -153,6 +153,8 @@
             </div>
         </i:if>
 
-        <t:formBar/>
+        <t:formBar>
+            <t:tracing trace="entry.getTrace()" journal="entry.getJournal()"/>
+        </t:formBar>
     </t:editForm>
 </t:page>


### PR DESCRIPTION
### Description
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

BREAKING: SchedulerEntry now extends Traced and Journaled. Custom implementations must provide getJournal() (getTrace() is inherited when extending BizEntity/MongoBizEntity).

- Adds a JournalData to SQLSchedulerEntry and MongoSchedulerEntry. JournalData only contains transient fields, so no schema change.
- Silences the journal in markExecuted so that the execution counters (lastExecution, numberOfExecutions, runs) updated by the scheduler loop do not create a journal entry per run. Only user-driven changes and deletions are journaled.
- Shows the tracing/journal button in the scheduler entry editor.
<img width="2482" height="1141" alt="Bildschirmfoto 2026-08-28 um 14 01 25" src="https://github.com/user-attachments/assets/0aebb308-6d09-4b87-9bb7-65eb9c5fb66b" />

### Additional Notes

- This PR fixes or works on following ticket(s): NO Ticket
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
