### PR TITLE
FTP uplink: Fail early if authentication fails

### DIFF
--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
@@ -16,7 +16,6 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.health.Exceptions;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.function.Function;
 
@@ -42,9 +41,9 @@ class FTPSUplinkConnectorConfig extends FTPUplinkConnectorConfig {
 
     @Override
     protected FTPClient create() {
-        try {
-            FTPSClient client = new FTPSClient();
+        FTPSClient client = new FTPSClient();
 
+        try {
             if (Strings.isFilled(sslProtocol)) {
                 client.setEnabledProtocols(new String[]{sslProtocol});
             }
@@ -66,7 +65,11 @@ class FTPSUplinkConnectorConfig extends FTPUplinkConnectorConfig {
             client.enterLocalPassiveMode();
 
             return client;
-        } catch (IOException exception) {
+        } catch (Exception exception) {
+            // If the client couldn't be fully initialized, it is never handed over to the connector pool and would
+            // therefore keep its connection open until the JVM collects it...
+            safeClose(client);
+
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
                             .error(exception)

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
@@ -57,7 +57,7 @@ class FTPSUplinkConnectorConfig extends FTPUplinkConnectorConfig {
             client.setDefaultPort(port);
 
             client.connect(host, port);
-            client.login(user, password);
+            login(client);
             client.setFileType(FTP.BINARY_FILE_TYPE);
             // Set protection buffer size
             client.execPBSZ(0);

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
@@ -59,7 +59,7 @@ class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {
             client.setControlEncoding(encoding);
 
             client.connect(host, port);
-            client.login(user, password);
+            login(client);
             client.setFileType(FTP.BINARY_FILE_TYPE);
             client.enterLocalPassiveMode();
 
@@ -73,6 +73,30 @@ class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {
                                     this)
                             .handle();
         }
+    }
+
+    /**
+     * Logs the given client in using the configured credentials.
+     * <p>
+     * Note that {@link FTPClient#login(String, String)} doesn't throw if the destination rejects the given
+     * credentials but simply returns <tt>false</tt>. As an unauthenticated session cannot execute any command at
+     * all, we abort right here instead of letting all subsequent commands fail with misleading errors.
+     *
+     * @param client the client to log in
+     * @throws IOException                           if the login command itself fails
+     * @throws sirius.kernel.health.HandledException if the destination rejected the configured credentials
+     */
+    protected void login(FTPClient client) throws IOException {
+        if (client.login(user, password)) {
+            return;
+        }
+
+        throw Exceptions.handle()
+                        .to(StorageUtils.LOG)
+                        .withSystemErrorMessage("Layer 3/FTP: The uplink %s rejected the given credentials: %s",
+                                                this,
+                                                client.getReplyString())
+                        .handle();
     }
 
     @Override

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
@@ -50,8 +50,9 @@ class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {
     @SuppressWarnings("java:S5332")
     @Explain("A FTP uplink of course uses insecure FTP, which is not an issue with this code.")
     protected FTPClient create() {
+        FTPClient client = new FTPClient();
+
         try {
-            FTPClient client = new FTPClient();
             client.setConnectTimeout(connectTimeoutMillis);
             client.setDataTimeout(Duration.ofMillis(readTimeoutMillis));
             client.setDefaultTimeout(readTimeoutMillis);
@@ -64,7 +65,11 @@ class FTPUplinkConnectorConfig extends UplinkConnectorConfig<FTPClient> {
             client.enterLocalPassiveMode();
 
             return client;
-        } catch (IOException exception) {
+        } catch (Exception exception) {
+            // If the client couldn't be fully initialized, it is never handed over to the connector pool and would
+            // therefore keep its connection open until the JVM collects it...
+            safeClose(client);
+
             throw Exceptions.handle()
                             .to(StorageUtils.LOG)
                             .error(exception)


### PR DESCRIPTION
### Description
As an unauthenticated session cannot execute any command at all, we abort right here instead of letting all subsequent commands fail with misleading errors or silently returning empty directory listings.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15351](https://scireum.myjetbrains.com/youtrack/issue/SE-15351)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
