### PR TITLE
Implement #performFetchObject for ConfigLookupTable

### DIFF
--- a/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
@@ -9,11 +9,13 @@
 package sirius.biz.codelists;
 
 import sirius.kernel.commons.Explain;
+import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
+import tools.jackson.databind.node.ObjectNode;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -86,9 +88,17 @@ class ConfigLookupTable extends LookupTable {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    @Explain("The data is provided in the configuration as String keys with assigned value objects.")
     protected <T> Optional<T> performFetchObject(Class<T> type, String code, boolean useCache) {
-        // Not supported yet
-        return Optional.empty();
+        if (!performContains(code)) {
+            return Optional.empty();
+        }
+
+        ObjectNode data = Json.convertFromMap(extension.get(Strings.apply("%s.%s", CONFIG_KEY_DATA, code))
+                                                       .get(Map.class, Collections.emptyMap()));
+
+        return Optional.of(makeObject(type, data));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
@@ -41,15 +41,13 @@ class ConfigLookupTable extends LookupTable {
 
     @Override
     protected Optional<String> performResolveName(String code, String language) {
-        return Optional.ofNullable(extension.getTranslatedString(Strings.apply("%s.%s.name", CONFIG_KEY_DATA, code),
-                                                                 language));
+        return Optional.of(extension.getTranslatedString(Strings.apply("%s.%s.name", CONFIG_KEY_DATA, code), language));
     }
 
     @Override
     protected Optional<String> performResolveDescription(@Nonnull String code, String language) {
-        return Optional.ofNullable(extension.getTranslatedString(Strings.apply("%s.%s.description",
-                                                                               CONFIG_KEY_DATA,
-                                                                               code), language));
+        return Optional.of(extension.getTranslatedString(Strings.apply("%s.%s.description", CONFIG_KEY_DATA, code),
+                                                         language));
     }
 
     @Override
@@ -60,10 +58,8 @@ class ConfigLookupTable extends LookupTable {
 
     @Override
     protected Optional<String> performFetchTranslatedField(String code, String targetField, String language) {
-        return Optional.ofNullable(extension.getTranslatedString(Strings.apply("%s.%s.%s",
-                                                                               CONFIG_KEY_DATA,
-                                                                               code,
-                                                                               targetField), language));
+        return Optional.of(extension.getTranslatedString(Strings.apply("%s.%s.%s", CONFIG_KEY_DATA, code, targetField),
+                                                         language));
     }
 
     @Override

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -8,7 +8,6 @@
 
 package sirius.biz.codelists;
 
-import tools.jackson.databind.node.ObjectNode;
 import sirius.biz.jupiter.IDBTable;
 import sirius.biz.jupiter.Jupiter;
 import sirius.kernel.commons.Json;
@@ -23,7 +22,6 @@ import sirius.web.security.UserContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.lang.reflect.Constructor;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -262,17 +260,6 @@ class IDBLookupTable extends LookupTable {
                                               table.getName())
                       .handle();
             return Optional.empty();
-        }
-    }
-
-    protected <T> T makeObject(Class<T> type, ObjectNode jsonData) {
-        try {
-            Constructor<T> constructor = type.getConstructor(ObjectNode.class);
-            return constructor.newInstance(jsonData);
-        } catch (Exception exception) {
-            throw new IllegalArgumentException(
-                    "Cannot create a payload object for %s - A public accessible constructor accepting a value is required!",
-                    exception);
         }
     }
 

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -21,6 +21,7 @@ import sirius.kernel.settings.Extension;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -606,6 +607,26 @@ public abstract class LookupTable {
     }
 
     protected abstract <T> Optional<T> performFetchObject(Class<T> type, @Nonnull String code, boolean useCache);
+
+    /**
+     * Instantiates the given type using the JSON data of a lookup table entry.
+     *
+     * @param type     the type to instantiate; a public constructor accepting an {@link ObjectNode} is required
+     * @param jsonData the data of the entry to hand to that constructor
+     * @param <T>      the generic type to instantiate
+     * @return the created object
+     * @throws IllegalArgumentException if the type has no public constructor accepting an {@link ObjectNode}
+     */
+    protected <T> T makeObject(Class<T> type, ObjectNode jsonData) {
+        try {
+            Constructor<T> constructor = type.getConstructor(ObjectNode.class);
+            return constructor.newInstance(jsonData);
+        } catch (Exception exception) {
+            throw new IllegalArgumentException(Strings.apply(
+                    "Cannot create a payload object for %s - a public constructor accepting an ObjectNode is required.",
+                    type.getName()), exception);
+        }
+    }
 
     /**
      * Provides a helper method to extract a translation table as used by Jupiter.

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -8,16 +8,16 @@
 
 package sirius.biz.codelists;
 
-import tools.jackson.core.JsonPointer;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.node.ArrayNode;
-import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -644,7 +644,8 @@ public abstract class LookupTable {
             if (translations.isObject()) {
                 return translations.properties()
                                    .stream()
-                                   .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().asString("")));
+                                   .collect(Collectors.toMap(Map.Entry::getKey,
+                                                             entry -> entry.getValue().asString("")));
             } else {
                 return Collections.singletonMap(FALLBACK_LANGUAGE_CODE, translations.asString(""));
             }

--- a/src/test/kotlin/sirius/biz/codelists/LookupTablesTest.kt
+++ b/src/test/kotlin/sirius/biz/codelists/LookupTablesTest.kt
@@ -11,7 +11,10 @@ package sirius.biz.codelists
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.Json
+import tools.jackson.databind.node.ObjectNode
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExtendWith(SiriusExtension::class)
@@ -20,6 +23,11 @@ class LookupTablesTest {
     companion object {
         private val lookupTables = LookupTables()
     }
+
+    /**
+     * Receives the whole entry as JSON, which is what a lookup table hands to a payload type.
+     */
+    class TestPayload(val data: ObjectNode)
 
     @Test
     fun `ConfigLookupTable creation works`() {
@@ -34,5 +42,29 @@ class LookupTablesTest {
         // reading translations directly from the config works
         assertEquals("Die beste Beschreibung", table.resolveDescription("test").get())
         assertEquals("Den bästa beskrivningen", table.resolveDescription("test", "sv").get())
+    }
+
+    @Test
+    fun `ConfigLookupTable resolves an object from its data`() {
+        val table = lookupTables.fetchTable("test-payload-table")
+
+        val payload = table.fetchObject(TestPayload::class.java, "first")
+
+        assertTrue(payload.isPresent)
+        assertEquals("First", payload.get().data.path("name").asString(""))
+        assertEquals("kg", payload.get().data.path("unit").asString(""))
+        assertEquals("3", payload.get().data.path("limits").path("max").asString(""))
+
+        val tags = Json.getArray(payload.get().data, "tags")
+        assertEquals(2, tags.size())
+        assertEquals("alpha", tags.path(0).asString(""))
+        assertEquals("beta", tags.path(1).asString(""))
+    }
+
+    @Test
+    fun `ConfigLookupTable reports an unknown code as empty`() {
+        val table = lookupTables.fetchTable("test-payload-table")
+
+        assertFalse(table.fetchObject(TestPayload::class.java, "does-not-exist").isPresent)
     }
 }

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -260,6 +260,21 @@ lookup-tables {
         }
     }
 
+    # Provides a config based table whose entries carry a nested payload, so that fetching objects from
+    # a ConfigLookupTable can be tested.
+    test-payload-table {
+        data {
+            first {
+                name = "First"
+                unit = "kg"
+                tags = ["alpha", "beta"]
+                limits {
+                    max = "3"
+                }
+            }
+        }
+    }
+
     # Provide config based data for the salutations so that PersonData can be tested
     # without requiring a populated code list.
     salutations {

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -170,7 +170,7 @@ storage {
 
             s3-zip-test {
                 engine = "s3"
-                 compression = "default"
+                compression = "default"
             }
 
             s3-aes-test {
@@ -199,7 +199,7 @@ storage {
     }
     layer2.spaces {
         blob-files {
-                readPermission = "disabled"
+            readPermission = "disabled"
         }
     }
 


### PR DESCRIPTION
### Description

This is needed when we want to test code that relies internally deep-down on a LookupTable being able to fetch an object.

As Jupiter is not available in most test szenarios, we must be able to mock it.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15398](https://scireum.myjetbrains.com/youtrack/issue/SE-15398)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
