### PR TITLE
Moves the copyright headers to Stuttgart and https

### DIFF
--- a/.run/run.run.xml
+++ b/.run/run.run.xml
@@ -1,9 +1,9 @@
 <!--
   ~ Made with all the love in the world
-  ~ by scireum in Remshalden, Germany
+  ~ by scireum in Stuttgart, Germany
   ~
   ~ Copyright by scireum GmbH
-  ~ http://www.scireum.de - info@scireum.de
+  ~ https://www.scireum.de - info@scireum.de
   -->
 
 <component name="ProjectRunConfigurationManager">

--- a/src/main/java/sirius/biz/analytics/charts/ComparisonPeriod.java
+++ b/src/main/java/sirius/biz/analytics/charts/ComparisonPeriod.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.charts;

--- a/src/main/java/sirius/biz/analytics/charts/Interval.java
+++ b/src/main/java/sirius/biz/analytics/charts/Interval.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.charts;

--- a/src/main/java/sirius/biz/analytics/charts/Timeseries.java
+++ b/src/main/java/sirius/biz/analytics/charts/Timeseries.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.charts;

--- a/src/main/java/sirius/biz/analytics/charts/Unit.java
+++ b/src/main/java/sirius/biz/analytics/charts/Unit.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.charts;

--- a/src/main/java/sirius/biz/analytics/checks/ChangeCheck.java
+++ b/src/main/java/sirius/biz/analytics/checks/ChangeCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.checks;

--- a/src/main/java/sirius/biz/analytics/checks/CheckBatchExecutor.java
+++ b/src/main/java/sirius/biz/analytics/checks/CheckBatchExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.checks;

--- a/src/main/java/sirius/biz/analytics/checks/CheckSchedulerExecutor.java
+++ b/src/main/java/sirius/biz/analytics/checks/CheckSchedulerExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.checks;

--- a/src/main/java/sirius/biz/analytics/checks/DailyCheck.java
+++ b/src/main/java/sirius/biz/analytics/checks/DailyCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.checks;

--- a/src/main/java/sirius/biz/analytics/checks/MongoChangeCheckScheduler.java
+++ b/src/main/java/sirius/biz/analytics/checks/MongoChangeCheckScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.checks;

--- a/src/main/java/sirius/biz/analytics/checks/MongoDailyCheckScheduler.java
+++ b/src/main/java/sirius/biz/analytics/checks/MongoDailyCheckScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.checks;

--- a/src/main/java/sirius/biz/analytics/checks/SQLChangeCheckScheduler.java
+++ b/src/main/java/sirius/biz/analytics/checks/SQLChangeCheckScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.checks;

--- a/src/main/java/sirius/biz/analytics/checks/SQLDailyCheckScheduler.java
+++ b/src/main/java/sirius/biz/analytics/checks/SQLDailyCheckScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.checks;

--- a/src/main/java/sirius/biz/analytics/events/ClickhousePartsReportJobFactory.java
+++ b/src/main/java/sirius/biz/analytics/events/ClickhousePartsReportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/ClickhouseSizeChartJobFactory.java
+++ b/src/main/java/sirius/biz/analytics/events/ClickhouseSizeChartJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/Event.java
+++ b/src/main/java/sirius/biz/analytics/events/Event.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/EventProcessorLoop.java
+++ b/src/main/java/sirius/biz/analytics/events/EventProcessorLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/EventRecorder.java
+++ b/src/main/java/sirius/biz/analytics/events/EventRecorder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
+++ b/src/main/java/sirius/biz/analytics/events/EventSpliterator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/PageImpressionEvent.java
+++ b/src/main/java/sirius/biz/analytics/events/PageImpressionEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/UserActivityEvent.java
+++ b/src/main/java/sirius/biz/analytics/events/UserActivityEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/UserData.java
+++ b/src/main/java/sirius/biz/analytics/events/UserData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/UserEvent.java
+++ b/src/main/java/sirius/biz/analytics/events/UserEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/events/WebData.java
+++ b/src/main/java/sirius/biz/analytics/events/WebData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/main/java/sirius/biz/analytics/explorer/BrowserDistributionTimeSeriesComputer.java
+++ b/src/main/java/sirius/biz/analytics/explorer/BrowserDistributionTimeSeriesComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/ChartFactory.java
+++ b/src/main/java/sirius/biz/analytics/explorer/ChartFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/ChartObjectResolver.java
+++ b/src/main/java/sirius/biz/analytics/explorer/ChartObjectResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/ComparisonPeriod.java
+++ b/src/main/java/sirius/biz/analytics/explorer/ComparisonPeriod.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
+++ b/src/main/java/sirius/biz/analytics/explorer/DataExplorerController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/EntityChartObjectResolver.java
+++ b/src/main/java/sirius/biz/analytics/explorer/EntityChartObjectResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/EventTimeSeriesComputer.java
+++ b/src/main/java/sirius/biz/analytics/explorer/EventTimeSeriesComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/Granularity.java
+++ b/src/main/java/sirius/biz/analytics/explorer/Granularity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/MetricTimeSeriesComputer.java
+++ b/src/main/java/sirius/biz/analytics/explorer/MetricTimeSeriesComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/PlatformDistributionTimeSeriesComputer.java
+++ b/src/main/java/sirius/biz/analytics/explorer/PlatformDistributionTimeSeriesComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/TimeSeries.java
+++ b/src/main/java/sirius/biz/analytics/explorer/TimeSeries.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/TimeSeriesChartFactory.java
+++ b/src/main/java/sirius/biz/analytics/explorer/TimeSeriesChartFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/TimeSeriesComputer.java
+++ b/src/main/java/sirius/biz/analytics/explorer/TimeSeriesComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/explorer/TimeSeriesData.java
+++ b/src/main/java/sirius/biz/analytics/explorer/TimeSeriesData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.explorer;

--- a/src/main/java/sirius/biz/analytics/flags/ExecutionFlags.java
+++ b/src/main/java/sirius/biz/analytics/flags/ExecutionFlags.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags;

--- a/src/main/java/sirius/biz/analytics/flags/KillExecutionFlagCommand.java
+++ b/src/main/java/sirius/biz/analytics/flags/KillExecutionFlagCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags;

--- a/src/main/java/sirius/biz/analytics/flags/PerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/PerformanceData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags;

--- a/src/main/java/sirius/biz/analytics/flags/PerformanceDataImportExtender.java
+++ b/src/main/java/sirius/biz/analytics/flags/PerformanceDataImportExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags;

--- a/src/main/java/sirius/biz/analytics/flags/PerformanceFlag.java
+++ b/src/main/java/sirius/biz/analytics/flags/PerformanceFlag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags;

--- a/src/main/java/sirius/biz/analytics/flags/PerformanceFlagModifier.java
+++ b/src/main/java/sirius/biz/analytics/flags/PerformanceFlagModifier.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags;

--- a/src/main/java/sirius/biz/analytics/flags/PerformanceFlagged.java
+++ b/src/main/java/sirius/biz/analytics/flags/PerformanceFlagged.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags;

--- a/src/main/java/sirius/biz/analytics/flags/jdbc/ExecutionFlag.java
+++ b/src/main/java/sirius/biz/analytics/flags/jdbc/ExecutionFlag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.jdbc;

--- a/src/main/java/sirius/biz/analytics/flags/jdbc/PerformanceFlagConstraint.java
+++ b/src/main/java/sirius/biz/analytics/flags/jdbc/PerformanceFlagConstraint.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.jdbc;

--- a/src/main/java/sirius/biz/analytics/flags/jdbc/SQLExecutionFlags.java
+++ b/src/main/java/sirius/biz/analytics/flags/jdbc/SQLExecutionFlags.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.jdbc;

--- a/src/main/java/sirius/biz/analytics/flags/jdbc/SQLPerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/jdbc/SQLPerformanceData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.jdbc;

--- a/src/main/java/sirius/biz/analytics/flags/jdbc/SQLPerformanceFlagModifier.java
+++ b/src/main/java/sirius/biz/analytics/flags/jdbc/SQLPerformanceFlagModifier.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.jdbc;

--- a/src/main/java/sirius/biz/analytics/flags/mongo/ExecutionFlag.java
+++ b/src/main/java/sirius/biz/analytics/flags/mongo/ExecutionFlag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.mongo;

--- a/src/main/java/sirius/biz/analytics/flags/mongo/MongoExecutionFlags.java
+++ b/src/main/java/sirius/biz/analytics/flags/mongo/MongoExecutionFlags.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.mongo;

--- a/src/main/java/sirius/biz/analytics/flags/mongo/MongoPerformanceData.java
+++ b/src/main/java/sirius/biz/analytics/flags/mongo/MongoPerformanceData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.mongo;

--- a/src/main/java/sirius/biz/analytics/flags/mongo/MongoPerformanceFlagModifier.java
+++ b/src/main/java/sirius/biz/analytics/flags/mongo/MongoPerformanceFlagModifier.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.flags.mongo;

--- a/src/main/java/sirius/biz/analytics/indicators/BatchIndicatorCheck.java
+++ b/src/main/java/sirius/biz/analytics/indicators/BatchIndicatorCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.indicators;

--- a/src/main/java/sirius/biz/analytics/indicators/IndicatedEntity.java
+++ b/src/main/java/sirius/biz/analytics/indicators/IndicatedEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.indicators;

--- a/src/main/java/sirius/biz/analytics/indicators/Indicator.java
+++ b/src/main/java/sirius/biz/analytics/indicators/Indicator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.indicators;

--- a/src/main/java/sirius/biz/analytics/indicators/IndicatorData.java
+++ b/src/main/java/sirius/biz/analytics/indicators/IndicatorData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.indicators;

--- a/src/main/java/sirius/biz/analytics/metrics/BasicMetrics.java
+++ b/src/main/java/sirius/biz/analytics/metrics/BasicMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/DailyMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/DailyMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/Dataset.java
+++ b/src/main/java/sirius/biz/analytics/metrics/Dataset.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricComputerContext.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricComputerContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricExportInfo.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricExportInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricExporter.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricExporter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricQuery.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricQuery.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/Metrics.java
+++ b/src/main/java/sirius/biz/analytics/metrics/Metrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricsBestEffortBatchExecutor.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricsBestEffortBatchExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricsBestEffortSchedulerExecutor.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricsBestEffortSchedulerExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricsGuaranteedBatchExecutor.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricsGuaranteedBatchExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricsGuaranteedSchedulerExecutor.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricsGuaranteedSchedulerExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MetricsImportHandlerExtender.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MetricsImportHandlerExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MonthlyLargeMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MonthlyLargeMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/MonthlyMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/MonthlyMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/DailyMetric.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/DailyMetric.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/Fact.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/Fact.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/MonthlyMetric.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/MonthlyMetric.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLBestEffortDailyScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLBestEffortDailyScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLDailyGlobalMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLDailyGlobalMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLGuaranteedDailyMetricScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLGuaranteedDailyMetricScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLGuaranteedMonthlyScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLGuaranteedMonthlyScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLMetrics.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLMonthlyGlobalMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLMonthlyGlobalMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLMonthlyLargeMetricsScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/SQLMonthlyLargeMetricsScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/jdbc/YearlyMetric.java
+++ b/src/main/java/sirius/biz/analytics/metrics/jdbc/YearlyMetric.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.jdbc;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/DailyMetric.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/DailyMetric.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/Fact.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/Fact.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoBestEffortDailyScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoBestEffortDailyScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoDailyGlobalMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoDailyGlobalMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoGuaranteedDailyMetricScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoGuaranteedDailyMetricScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoGuaranteedMonthlyScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoGuaranteedMonthlyScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoMetrics.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoMonthlyGlobalMetricComputer.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoMonthlyGlobalMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MongoMonthlyLargeMetricsScheduler.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MongoMonthlyLargeMetricsScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/MonthlyMetric.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/MonthlyMetric.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/metrics/mongo/YearlyMetric.java
+++ b/src/main/java/sirius/biz/analytics/metrics/mongo/YearlyMetric.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.metrics.mongo;

--- a/src/main/java/sirius/biz/analytics/reports/CSSCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/CSSCellFormat.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/Cell.java
+++ b/src/main/java/sirius/biz/analytics/reports/Cell.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/CellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/CellFormat.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/Cells.java
+++ b/src/main/java/sirius/biz/analytics/reports/Cells.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/LinesCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/LinesCellFormat.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/LinkCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/LinkCellFormat.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/ListCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/ListCellFormat.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/Report.java
+++ b/src/main/java/sirius/biz/analytics/reports/Report.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/SparklineCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/SparklineCellFormat.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/reports/TrendCellFormat.java
+++ b/src/main/java/sirius/biz/analytics/reports/TrendCellFormat.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.reports;

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticalEngine.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticalEngine.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticalTask.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticalTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsBatchExecutor.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsBatchExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsCommand.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/AnalyticsSchedulerExecutor.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/AnalyticsSchedulerExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/BaseAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/BaseAnalyticalTaskScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/BaseEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/BaseEntityBatchEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/ElasticEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/ElasticEntityBatchEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/MongoAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/MongoAnalyticalTaskScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/MongoEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/MongoEntityBatchEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/SQLAnalyticalTaskScheduler.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/SQLAnalyticalTaskScheduler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/SQLEntityBatchEmitter.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/SQLEntityBatchEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/analytics/scheduler/ScheduleInterval.java
+++ b/src/main/java/sirius/biz/analytics/scheduler/ScheduleInterval.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.scheduler;

--- a/src/main/java/sirius/biz/charts/Chart.java
+++ b/src/main/java/sirius/biz/charts/Chart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.charts;

--- a/src/main/java/sirius/biz/charts/Charts.java
+++ b/src/main/java/sirius/biz/charts/Charts.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.charts;

--- a/src/main/java/sirius/biz/charts/Dataset.java
+++ b/src/main/java/sirius/biz/charts/Dataset.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.charts;

--- a/src/main/java/sirius/biz/charts/DoughnutChart.java
+++ b/src/main/java/sirius/biz/charts/DoughnutChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.charts;

--- a/src/main/java/sirius/biz/charts/PieChart.java
+++ b/src/main/java/sirius/biz/charts/PieChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.charts;

--- a/src/main/java/sirius/biz/charts/RadarChart.java
+++ b/src/main/java/sirius/biz/charts/RadarChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.charts;

--- a/src/main/java/sirius/biz/cluster/BackgroundInfo.java
+++ b/src/main/java/sirius/biz/cluster/BackgroundInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/BackgroundJobInfo.java
+++ b/src/main/java/sirius/biz/cluster/BackgroundJobInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/ClusterController.java
+++ b/src/main/java/sirius/biz/cluster/ClusterController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/Interconnect.java
+++ b/src/main/java/sirius/biz/cluster/Interconnect.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/InterconnectCacheCoherence.java
+++ b/src/main/java/sirius/biz/cluster/InterconnectCacheCoherence.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/InterconnectClusterManager.java
+++ b/src/main/java/sirius/biz/cluster/InterconnectClusterManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/InterconnectHandler.java
+++ b/src/main/java/sirius/biz/cluster/InterconnectHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/NLSController.java
+++ b/src/main/java/sirius/biz/cluster/NLSController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
+++ b/src/main/java/sirius/biz/cluster/NeighborhoodWatch.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/RedisUserMessageCache.java
+++ b/src/main/java/sirius/biz/cluster/RedisUserMessageCache.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/SynchronizeType.java
+++ b/src/main/java/sirius/biz/cluster/SynchronizeType.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster;

--- a/src/main/java/sirius/biz/cluster/work/DistributedQueueInfo.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedQueueInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/DistributedQueueLoadInfo.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedQueueLoadInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/DistributedTaskExecutor.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTaskExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/DistributedTaskExecutorLoadAction.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTaskExecutorLoadAction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
+++ b/src/main/java/sirius/biz/cluster/work/DistributedTasks.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/FifoQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/FifoQueue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/LocalFifoQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/LocalFifoQueue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/LocalNamedCounters.java
+++ b/src/main/java/sirius/biz/cluster/work/LocalNamedCounters.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/LocalPrioritizedQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/LocalPrioritizedQueue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/NamedCounters.java
+++ b/src/main/java/sirius/biz/cluster/work/NamedCounters.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/NamedRegions.java
+++ b/src/main/java/sirius/biz/cluster/work/NamedRegions.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/PrioritizedQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/PrioritizedQueue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/RedisFifoQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/RedisFifoQueue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/RedisNamedCounters.java
+++ b/src/main/java/sirius/biz/cluster/work/RedisNamedCounters.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/RedisPrioritizedQueue.java
+++ b/src/main/java/sirius/biz/cluster/work/RedisPrioritizedQueue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/cluster/work/WorkLoaderLoop.java
+++ b/src/main/java/sirius/biz/cluster/work/WorkLoaderLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work;

--- a/src/main/java/sirius/biz/codelists/CodeList.java
+++ b/src/main/java/sirius/biz/codelists/CodeList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/CodeListController.java
+++ b/src/main/java/sirius/biz/codelists/CodeListController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/CodeListData.java
+++ b/src/main/java/sirius/biz/codelists/CodeListData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/CodeListEntry.java
+++ b/src/main/java/sirius/biz/codelists/CodeListEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/CodeListEntryData.java
+++ b/src/main/java/sirius/biz/codelists/CodeListEntryData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CodeListLookupTable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/CodeListTenantProvider.java
+++ b/src/main/java/sirius/biz/codelists/CodeListTenantProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/CodeLists.java
+++ b/src/main/java/sirius/biz/codelists/CodeLists.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/ConfigLookupTable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/CustomLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/CustomLookupTable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBFilteredLookupTable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/IDBLookupTable.java
+++ b/src/main/java/sirius/biz/codelists/IDBLookupTable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupTable.java
+++ b/src/main/java/sirius/biz/codelists/LookupTable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupTableController.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupTableEntry.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupTableMessageExpander.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableMessageExpander.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupTableParameter.java
+++ b/src/main/java/sirius/biz/codelists/LookupTableParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupTables.java
+++ b/src/main/java/sirius/biz/codelists/LookupTables.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupValue.java
+++ b/src/main/java/sirius/biz/codelists/LookupValue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupValueExtender.java
+++ b/src/main/java/sirius/biz/codelists/LookupValueExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupValueProperty.java
+++ b/src/main/java/sirius/biz/codelists/LookupValueProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupValues.java
+++ b/src/main/java/sirius/biz/codelists/LookupValues.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/LookupValuesProperty.java
+++ b/src/main/java/sirius/biz/codelists/LookupValuesProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists;

--- a/src/main/java/sirius/biz/codelists/jdbc/DeleteSQLCodeListsTask.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/DeleteSQLCodeListsTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.jdbc;

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeList.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.jdbc;

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListController.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.jdbc;

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListEntry.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.jdbc;

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListEntryImportHandler.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListEntryImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.jdbc;

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListExportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.jdbc;

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListImportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeListImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.jdbc;

--- a/src/main/java/sirius/biz/codelists/jdbc/SQLCodeLists.java
+++ b/src/main/java/sirius/biz/codelists/jdbc/SQLCodeLists.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.jdbc;

--- a/src/main/java/sirius/biz/codelists/mongo/DeleteMongoCodeListsTask.java
+++ b/src/main/java/sirius/biz/codelists/mongo/DeleteMongoCodeListsTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.mongo;

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeList.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.mongo;

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListController.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.mongo;

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntry.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.mongo;

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntryImportHandler.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListEntryImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.mongo;

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListExportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.mongo;

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeListImportJobFactory.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeListImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.mongo;

--- a/src/main/java/sirius/biz/codelists/mongo/MongoCodeLists.java
+++ b/src/main/java/sirius/biz/codelists/mongo/MongoCodeLists.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists.mongo;

--- a/src/main/java/sirius/biz/elastic/AutoBatchLoop.java
+++ b/src/main/java/sirius/biz/elastic/AutoBatchLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.elastic;

--- a/src/main/java/sirius/biz/elastic/ElasticIndexSizeReportJobFactory.java
+++ b/src/main/java/sirius/biz/elastic/ElasticIndexSizeReportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.elastic;

--- a/src/main/java/sirius/biz/elastic/MoveIndexAliasJobFactory.java
+++ b/src/main/java/sirius/biz/elastic/MoveIndexAliasJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.elastic;

--- a/src/main/java/sirius/biz/elastic/ReindexJobFactory.java
+++ b/src/main/java/sirius/biz/elastic/ReindexJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.elastic;

--- a/src/main/java/sirius/biz/elastic/SearchContent.java
+++ b/src/main/java/sirius/biz/elastic/SearchContent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.elastic;

--- a/src/main/java/sirius/biz/elastic/SearchableEntity.java
+++ b/src/main/java/sirius/biz/elastic/SearchableEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.elastic;

--- a/src/main/java/sirius/biz/importer/AfterCreateOrUpdateEvent.java
+++ b/src/main/java/sirius/biz/importer/AfterCreateOrUpdateEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/AfterLineLoadEvent.java
+++ b/src/main/java/sirius/biz/importer/AfterLineLoadEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/AfterLoadEvent.java
+++ b/src/main/java/sirius/biz/importer/AfterLoadEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/AfterNodeLoadEvent.java
+++ b/src/main/java/sirius/biz/importer/AfterNodeLoadEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/AutoImport.java
+++ b/src/main/java/sirius/biz/importer/AutoImport.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/BaseImportHandler.java
+++ b/src/main/java/sirius/biz/importer/BaseImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/BeforeCreateOrUpdateEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeCreateOrUpdateEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/BeforeDeleteEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeDeleteEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/BeforeFindEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeFindEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/BeforeLoadEvent.java
+++ b/src/main/java/sirius/biz/importer/BeforeLoadEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/ContextScriptableEvent.java
+++ b/src/main/java/sirius/biz/importer/ContextScriptableEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/EntityImportHandlerExtender.java
+++ b/src/main/java/sirius/biz/importer/EntityImportHandlerExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/Exportable.java
+++ b/src/main/java/sirius/biz/importer/Exportable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/IgnoreInImportChangedCheck.java
+++ b/src/main/java/sirius/biz/importer/IgnoreInImportChangedCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/ImportHandler.java
+++ b/src/main/java/sirius/biz/importer/ImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/ImportHandlerFactory.java
+++ b/src/main/java/sirius/biz/importer/ImportHandlerFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/ImportHelper.java
+++ b/src/main/java/sirius/biz/importer/ImportHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/Importer.java
+++ b/src/main/java/sirius/biz/importer/Importer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/ImporterContext.java
+++ b/src/main/java/sirius/biz/importer/ImporterContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/MissingEntityMode.java
+++ b/src/main/java/sirius/biz/importer/MissingEntityMode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/MongoEntityImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/SQLEntityImportHandlerExtender.java
+++ b/src/main/java/sirius/biz/importer/SQLEntityImportHandlerExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/main/java/sirius/biz/importer/format/AllInListCheck.java
+++ b/src/main/java/sirius/biz/importer/format/AllInListCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/AmountPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/AmountPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/AmountRangeCheck.java
+++ b/src/main/java/sirius/biz/importer/format/AmountRangeCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/AmountScaleCheck.java
+++ b/src/main/java/sirius/biz/importer/format/AmountScaleCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/BaseFieldDefinitionTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/BaseFieldDefinitionTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/BooleanPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/BooleanPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
+++ b/src/main/java/sirius/biz/importer/format/DateTimeFormatCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/EnumPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/EnumPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/FieldDefinition.java
+++ b/src/main/java/sirius/biz/importer/format/FieldDefinition.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/FieldDefinitionSupplier.java
+++ b/src/main/java/sirius/biz/importer/format/FieldDefinitionSupplier.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/ImportDictionary.java
+++ b/src/main/java/sirius/biz/importer/format/ImportDictionary.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/IntegerPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/IntegerPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LengthCheck.java
+++ b/src/main/java/sirius/biz/importer/format/LengthCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LocalDatePropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/LocalDatePropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LocalDateTimePropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/LocalDateTimePropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LocalTimePropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/LocalTimePropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LongPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/LongPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LookupValueCheck.java
+++ b/src/main/java/sirius/biz/importer/format/LookupValueCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LookupValuePropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/LookupValuePropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LookupValuesCheck.java
+++ b/src/main/java/sirius/biz/importer/format/LookupValuesCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/LookupValuesPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/LookupValuesPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/PropertyFallbackTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/PropertyFallbackTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/RegexCheck.java
+++ b/src/main/java/sirius/biz/importer/format/RegexCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/RequiredCheck.java
+++ b/src/main/java/sirius/biz/importer/format/RequiredCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/StringCheck.java
+++ b/src/main/java/sirius/biz/importer/format/StringCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/StringListPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/StringListPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/StringPropertyTransformer.java
+++ b/src/main/java/sirius/biz/importer/format/StringPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/ValueCheck.java
+++ b/src/main/java/sirius/biz/importer/format/ValueCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/format/ValueInListCheck.java
+++ b/src/main/java/sirius/biz/importer/format/ValueInListCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format;

--- a/src/main/java/sirius/biz/importer/txn/ImportTransactionData.java
+++ b/src/main/java/sirius/biz/importer/txn/ImportTransactionData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.txn;

--- a/src/main/java/sirius/biz/importer/txn/ImportTransactionHelper.java
+++ b/src/main/java/sirius/biz/importer/txn/ImportTransactionHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.txn;

--- a/src/main/java/sirius/biz/importer/txn/ImportTransactionalEntity.java
+++ b/src/main/java/sirius/biz/importer/txn/ImportTransactionalEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.txn;

--- a/src/main/java/sirius/biz/isenguard/BlockedIPsReportJobFactory.java
+++ b/src/main/java/sirius/biz/isenguard/BlockedIPsReportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/IPBlockedEvent.java
+++ b/src/main/java/sirius/biz/isenguard/IPBlockedEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/Isenguard.java
+++ b/src/main/java/sirius/biz/isenguard/Isenguard.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/IsenguardFirewall.java
+++ b/src/main/java/sirius/biz/isenguard/IsenguardFirewall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/Limiter.java
+++ b/src/main/java/sirius/biz/isenguard/Limiter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/NOOPLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/NOOPLimiter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/RateLimitEventsReportJobFactory.java
+++ b/src/main/java/sirius/biz/isenguard/RateLimitEventsReportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/RateLimitReportJobFactory.java
+++ b/src/main/java/sirius/biz/isenguard/RateLimitReportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/RateLimitedEntity.java
+++ b/src/main/java/sirius/biz/isenguard/RateLimitedEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/RateLimitingInfo.java
+++ b/src/main/java/sirius/biz/isenguard/RateLimitingInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/RateLimitingTriggeredEvent.java
+++ b/src/main/java/sirius/biz/isenguard/RateLimitingTriggeredEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/RedisLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/RedisLimiter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/RedisLimiterCleanupLoop.java
+++ b/src/main/java/sirius/biz/isenguard/RedisLimiterCleanupLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/isenguard/SmartLimiter.java
+++ b/src/main/java/sirius/biz/isenguard/SmartLimiter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard;

--- a/src/main/java/sirius/biz/jdbc/BizEntity.java
+++ b/src/main/java/sirius/biz/jdbc/BizEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jdbc;

--- a/src/main/java/sirius/biz/jdbc/DatabaseController.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jdbc;

--- a/src/main/java/sirius/biz/jdbc/DatabaseDisplayUtils.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseDisplayUtils.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jdbc;

--- a/src/main/java/sirius/biz/jdbc/DatabaseParameter.java
+++ b/src/main/java/sirius/biz/jdbc/DatabaseParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jdbc;

--- a/src/main/java/sirius/biz/jdbc/ExportQueryResultJobFactory.java
+++ b/src/main/java/sirius/biz/jdbc/ExportQueryResultJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jdbc;

--- a/src/main/java/sirius/biz/jdbc/ExportSchemaChangesJobFactory.java
+++ b/src/main/java/sirius/biz/jdbc/ExportSchemaChangesJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jdbc;

--- a/src/main/java/sirius/biz/jobs/BasicJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/BasicJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/JobConfigData.java
+++ b/src/main/java/sirius/biz/jobs/JobConfigData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/JobFactory.java
+++ b/src/main/java/sirius/biz/jobs/JobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/JobStartingRoot.java
+++ b/src/main/java/sirius/biz/jobs/JobStartingRoot.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/Jobs.java
+++ b/src/main/java/sirius/biz/jobs/Jobs.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/JobsController.java
+++ b/src/main/java/sirius/biz/jobs/JobsController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/JobsRoot.java
+++ b/src/main/java/sirius/biz/jobs/JobsRoot.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/JobsSearchProvider.java
+++ b/src/main/java/sirius/biz/jobs/JobsSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/StandardCategories.java
+++ b/src/main/java/sirius/biz/jobs/StandardCategories.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs;

--- a/src/main/java/sirius/biz/jobs/batch/BatchJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/BatchProcessTaskExecutor.java
+++ b/src/main/java/sirius/biz/jobs/batch/BatchProcessTaskExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/CheckBatchProcessFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/CheckBatchProcessFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/DefaultBatchProcessFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/DefaultBatchProcessFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/ExportBatchProcessFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/ExportBatchProcessFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/ImportBatchProcessFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/ImportBatchProcessFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/ImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/ImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/ImportJobStartedEvent.java
+++ b/src/main/java/sirius/biz/jobs/batch/ImportJobStartedEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/ReportBatchProcessFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/ReportBatchProcessFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/SimpleBatchProcessJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/SimpleBatchProcessJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/SimpleReportBatchProcessFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/SimpleReportBatchProcessFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch;

--- a/src/main/java/sirius/biz/jobs/batch/entity/EntityBatchJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/entity/EntityBatchJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.entity;

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveExportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ArchiveImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedArchiveImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImport.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImport.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/DictionaryBasedImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityExportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityExportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/EntityImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/ExportCSV.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ExportCSV.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/ExportFileType.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ExportFileType.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/ExportXLS.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ExportXLS.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/ExportXLSX.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ExportXLSX.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/FileExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/FileExportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/FileExportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/FileExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/FileImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/FileImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/FileImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/FileImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/ImportMode.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/ImportMode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedArchiveImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedArchiveImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedExport.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedExport.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportExportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportExportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/LineBasedImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/RelationalEntityImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/SyncMode.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/SyncMode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/SyncSourceDeleteMode.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/SyncSourceDeleteMode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/XMLExportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/XMLExportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/XMLExportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/XMLExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/XMLImportJob.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/XMLImportJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/XMLImportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/XMLImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/batch/file/XMLValidator.java
+++ b/src/main/java/sirius/biz/jobs/batch/file/XMLValidator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.batch.file;

--- a/src/main/java/sirius/biz/jobs/infos/CardInfo.java
+++ b/src/main/java/sirius/biz/jobs/infos/CardInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.infos;

--- a/src/main/java/sirius/biz/jobs/infos/HTMLInfo.java
+++ b/src/main/java/sirius/biz/jobs/infos/HTMLInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.infos;

--- a/src/main/java/sirius/biz/jobs/infos/HeadingInfo.java
+++ b/src/main/java/sirius/biz/jobs/infos/HeadingInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.infos;

--- a/src/main/java/sirius/biz/jobs/infos/JobInfo.java
+++ b/src/main/java/sirius/biz/jobs/infos/JobInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.infos;

--- a/src/main/java/sirius/biz/jobs/infos/JobInfoCollector.java
+++ b/src/main/java/sirius/biz/jobs/infos/JobInfoCollector.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.infos;

--- a/src/main/java/sirius/biz/jobs/infos/ReportInfo.java
+++ b/src/main/java/sirius/biz/jobs/infos/ReportInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.infos;

--- a/src/main/java/sirius/biz/jobs/infos/TextInfo.java
+++ b/src/main/java/sirius/biz/jobs/infos/TextInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.infos;

--- a/src/main/java/sirius/biz/jobs/interactive/DoughnutChartJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/DoughnutChartJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.interactive;

--- a/src/main/java/sirius/biz/jobs/interactive/InteractiveJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/InteractiveJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.interactive;

--- a/src/main/java/sirius/biz/jobs/interactive/LinearChartJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/LinearChartJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.interactive;

--- a/src/main/java/sirius/biz/jobs/interactive/PolarAreaChartJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/PolarAreaChartJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.interactive;

--- a/src/main/java/sirius/biz/jobs/interactive/ReportJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/ReportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.interactive;

--- a/src/main/java/sirius/biz/jobs/interactive/SingleDatasetChartJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/SingleDatasetChartJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.interactive;

--- a/src/main/java/sirius/biz/jobs/interactive/TimeseriesChartJobFactory.java
+++ b/src/main/java/sirius/biz/jobs/interactive/TimeseriesChartJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.interactive;

--- a/src/main/java/sirius/biz/jobs/interactive/TimeseriesDataProvider.java
+++ b/src/main/java/sirius/biz/jobs/interactive/TimeseriesDataProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.interactive;

--- a/src/main/java/sirius/biz/jobs/params/AmountParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/AmountParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/Autocompleter.java
+++ b/src/main/java/sirius/biz/jobs/params/Autocompleter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/BooleanParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/BooleanParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/CodeListEntryParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/CodeListEntryParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/CodeListParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/CodeListParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/DateRangeParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/DateRangeParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/EntityDescriptorParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityDescriptorParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/EntityParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EntityParameter.java
@@ -1,6 +1,6 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
  * https://www.scireum.de - info@scireum.de

--- a/src/main/java/sirius/biz/jobs/params/EnumParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/EnumParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/FileParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/FileParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/IntParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/IntParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/LocalDateParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/LocalDateParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/LocalDateTimeParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/LocalDateTimeParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/MultiSelectParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/MultiSelectParameter.java
@@ -1,6 +1,6 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
  * https://www.scireum.de - info@scireum.de

--- a/src/main/java/sirius/biz/jobs/params/Parameter.java
+++ b/src/main/java/sirius/biz/jobs/params/Parameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/ParameterBuilder.java
+++ b/src/main/java/sirius/biz/jobs/params/ParameterBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/PartListParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/PartListParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/PriorizedPartListParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/PriorizedPartListParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/StringParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/StringParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/TenantParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/TenantParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/TextParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/TextParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/TextareaParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/TextareaParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/params/UserAccountParameter.java
+++ b/src/main/java/sirius/biz/jobs/params/UserAccountParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/main/java/sirius/biz/jobs/presets/JobPreset.java
+++ b/src/main/java/sirius/biz/jobs/presets/JobPreset.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets;

--- a/src/main/java/sirius/biz/jobs/presets/JobPresets.java
+++ b/src/main/java/sirius/biz/jobs/presets/JobPresets.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets;

--- a/src/main/java/sirius/biz/jobs/presets/JobPresetsController.java
+++ b/src/main/java/sirius/biz/jobs/presets/JobPresetsController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets;

--- a/src/main/java/sirius/biz/jobs/presets/jdbc/DeleteSQLJobPresetsTask.java
+++ b/src/main/java/sirius/biz/jobs/presets/jdbc/DeleteSQLJobPresetsTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets.jdbc;

--- a/src/main/java/sirius/biz/jobs/presets/jdbc/SQLJobPreset.java
+++ b/src/main/java/sirius/biz/jobs/presets/jdbc/SQLJobPreset.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets.jdbc;

--- a/src/main/java/sirius/biz/jobs/presets/jdbc/SQLJobPresets.java
+++ b/src/main/java/sirius/biz/jobs/presets/jdbc/SQLJobPresets.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets.jdbc;

--- a/src/main/java/sirius/biz/jobs/presets/jdbc/SQLJobPresetsController.java
+++ b/src/main/java/sirius/biz/jobs/presets/jdbc/SQLJobPresetsController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets.jdbc;

--- a/src/main/java/sirius/biz/jobs/presets/mongo/DeleteMongoJobPresetsTask.java
+++ b/src/main/java/sirius/biz/jobs/presets/mongo/DeleteMongoJobPresetsTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets.mongo;

--- a/src/main/java/sirius/biz/jobs/presets/mongo/MongoJobPreset.java
+++ b/src/main/java/sirius/biz/jobs/presets/mongo/MongoJobPreset.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets.mongo;

--- a/src/main/java/sirius/biz/jobs/presets/mongo/MongoJobPresets.java
+++ b/src/main/java/sirius/biz/jobs/presets/mongo/MongoJobPresets.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets.mongo;

--- a/src/main/java/sirius/biz/jobs/presets/mongo/MongoJobPresetsController.java
+++ b/src/main/java/sirius/biz/jobs/presets/mongo/MongoJobPresetsController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.presets.mongo;

--- a/src/main/java/sirius/biz/jobs/scheduler/JobSchedulerLoop.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/JobSchedulerLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler;

--- a/src/main/java/sirius/biz/jobs/scheduler/ScheduledEntryExecution.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/ScheduledEntryExecution.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler;

--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerController.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler;

--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerData.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler;

--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerEntry.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler;

--- a/src/main/java/sirius/biz/jobs/scheduler/SchedulerEntryProvider.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/SchedulerEntryProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler;

--- a/src/main/java/sirius/biz/jobs/scheduler/jdbc/DeleteSQLSchedulerEntriesTask.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/jdbc/DeleteSQLSchedulerEntriesTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler.jdbc;

--- a/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerController.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler.jdbc;

--- a/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntry.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler.jdbc;

--- a/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntryProvider.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/jdbc/SQLSchedulerEntryProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler.jdbc;

--- a/src/main/java/sirius/biz/jobs/scheduler/mongo/DeleteMongoSchedulerEntriesTask.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/mongo/DeleteMongoSchedulerEntriesTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler.mongo;

--- a/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerController.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler.mongo;

--- a/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntry.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler.mongo;

--- a/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntryProvider.java
+++ b/src/main/java/sirius/biz/jobs/scheduler/mongo/MongoSchedulerEntryProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.scheduler.mongo;

--- a/src/main/java/sirius/biz/jupiter/IDBSet.java
+++ b/src/main/java/sirius/biz/jupiter/IDBSet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/IDBSetInfo.java
+++ b/src/main/java/sirius/biz/jupiter/IDBSetInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/IDBTable.java
+++ b/src/main/java/sirius/biz/jupiter/IDBTable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/IDBTableInfo.java
+++ b/src/main/java/sirius/biz/jupiter/IDBTableInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/InfoGraphDB.java
+++ b/src/main/java/sirius/biz/jupiter/InfoGraphDB.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/Jupiter.java
+++ b/src/main/java/sirius/biz/jupiter/Jupiter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterCommand.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterConfigUpdater.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConfigUpdater.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterConnection.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnection.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterConnector.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterConnector.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterDataProvider.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterDataProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterSync.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSync.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterSyncJob.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSyncJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterSyncSystemTenantSupplier.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterSyncSystemTenantSupplier.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/JupiterYamlDataProvider.java
+++ b/src/main/java/sirius/biz/jupiter/JupiterYamlDataProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/LRUCache.java
+++ b/src/main/java/sirius/biz/jupiter/LRUCache.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/LRUCacheConfigUpdater.java
+++ b/src/main/java/sirius/biz/jupiter/LRUCacheConfigUpdater.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/Repository.java
+++ b/src/main/java/sirius/biz/jupiter/Repository.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/RepositoryConfigUpdater.java
+++ b/src/main/java/sirius/biz/jupiter/RepositoryConfigUpdater.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/jupiter/RepositoryFile.java
+++ b/src/main/java/sirius/biz/jupiter/RepositoryFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter;

--- a/src/main/java/sirius/biz/locks/BasicLockManager.java
+++ b/src/main/java/sirius/biz/locks/BasicLockManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks;

--- a/src/main/java/sirius/biz/locks/JavaLockManager.java
+++ b/src/main/java/sirius/biz/locks/JavaLockManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks;

--- a/src/main/java/sirius/biz/locks/LockInfo.java
+++ b/src/main/java/sirius/biz/locks/LockInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks;

--- a/src/main/java/sirius/biz/locks/LockManager.java
+++ b/src/main/java/sirius/biz/locks/LockManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks;

--- a/src/main/java/sirius/biz/locks/Locks.java
+++ b/src/main/java/sirius/biz/locks/Locks.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks;

--- a/src/main/java/sirius/biz/locks/RedisLockManager.java
+++ b/src/main/java/sirius/biz/locks/RedisLockManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks;

--- a/src/main/java/sirius/biz/locks/SmartLockManager.java
+++ b/src/main/java/sirius/biz/locks/SmartLockManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks;

--- a/src/main/java/sirius/biz/locks/jdbc/ManagedLock.java
+++ b/src/main/java/sirius/biz/locks/jdbc/ManagedLock.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks.jdbc;

--- a/src/main/java/sirius/biz/locks/jdbc/SQLLockManager.java
+++ b/src/main/java/sirius/biz/locks/jdbc/SQLLockManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks.jdbc;

--- a/src/main/java/sirius/biz/model/AddressData.java
+++ b/src/main/java/sirius/biz/model/AddressData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/ContactData.java
+++ b/src/main/java/sirius/biz/model/ContactData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/InternationalAddressData.java
+++ b/src/main/java/sirius/biz/model/InternationalAddressData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/LegacyMD5HashFunction.java
+++ b/src/main/java/sirius/biz/model/LegacyMD5HashFunction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/LoginData.java
+++ b/src/main/java/sirius/biz/model/LoginData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/PBKDF2SHA256Function.java
+++ b/src/main/java/sirius/biz/model/PBKDF2SHA256Function.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/PasswordHashFunction.java
+++ b/src/main/java/sirius/biz/model/PasswordHashFunction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/PermissionData.java
+++ b/src/main/java/sirius/biz/model/PermissionData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/PermissionDataImportExtender.java
+++ b/src/main/java/sirius/biz/model/PermissionDataImportExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/PersonData.java
+++ b/src/main/java/sirius/biz/model/PersonData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/QueryController.java
+++ b/src/main/java/sirius/biz/model/QueryController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/model/ResaveEntitiesJobFactory.java
+++ b/src/main/java/sirius/biz/model/ResaveEntitiesJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model;

--- a/src/main/java/sirius/biz/mongo/CustomSortValues.java
+++ b/src/main/java/sirius/biz/mongo/CustomSortValues.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/MongoBizEntity.java
+++ b/src/main/java/sirius/biz/mongo/MongoBizEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/MultiLanguageStringPropertyTransformer.java
+++ b/src/main/java/sirius/biz/mongo/MultiLanguageStringPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/PrefixSearchContent.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchContent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/PrefixSearchableContentComputer.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableContentComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
+++ b/src/main/java/sirius/biz/mongo/PrefixSearchableEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/PrefixTokenizer.java
+++ b/src/main/java/sirius/biz/mongo/PrefixTokenizer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/SequenceId.java
+++ b/src/main/java/sirius/biz/mongo/SequenceId.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/SortField.java
+++ b/src/main/java/sirius/biz/mongo/SortField.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/SortValue.java
+++ b/src/main/java/sirius/biz/mongo/SortValue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/StringListPropertyTransformer.java
+++ b/src/main/java/sirius/biz/mongo/StringListPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/mongo/StringMapPropertyTransformer.java
+++ b/src/main/java/sirius/biz/mongo/StringMapPropertyTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/main/java/sirius/biz/packages/AdditionalPackagePermissionsProvider.java
+++ b/src/main/java/sirius/biz/packages/AdditionalPackagePermissionsProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.packages;

--- a/src/main/java/sirius/biz/packages/PackageData.java
+++ b/src/main/java/sirius/biz/packages/PackageData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.packages;

--- a/src/main/java/sirius/biz/packages/Packages.java
+++ b/src/main/java/sirius/biz/packages/Packages.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.packages;

--- a/src/main/java/sirius/biz/password/PasswordGenerator.java
+++ b/src/main/java/sirius/biz/password/PasswordGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.password;

--- a/src/main/java/sirius/biz/password/PasswordSettings.java
+++ b/src/main/java/sirius/biz/password/PasswordSettings.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.password;

--- a/src/main/java/sirius/biz/password/PasswordValidator.java
+++ b/src/main/java/sirius/biz/password/PasswordValidator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.password;

--- a/src/main/java/sirius/biz/process/DeleteExpiredProcessesTask.java
+++ b/src/main/java/sirius/biz/process/DeleteExpiredProcessesTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ErrorContext.java
+++ b/src/main/java/sirius/biz/process/ErrorContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ExportLogsAsFileTaskExecutor.java
+++ b/src/main/java/sirius/biz/process/ExportLogsAsFileTaskExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/NumberOfProcessesChart.java
+++ b/src/main/java/sirius/biz/process/NumberOfProcessesChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/PersistencePeriod.java
+++ b/src/main/java/sirius/biz/process/PersistencePeriod.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/Process.java
+++ b/src/main/java/sirius/biz/process/Process.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessCommand.java
+++ b/src/main/java/sirius/biz/process/ProcessCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessContext.java
+++ b/src/main/java/sirius/biz/process/ProcessContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessController.java
+++ b/src/main/java/sirius/biz/process/ProcessController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessDurationChart.java
+++ b/src/main/java/sirius/biz/process/ProcessDurationChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessEnvironment.java
+++ b/src/main/java/sirius/biz/process/ProcessEnvironment.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessLink.java
+++ b/src/main/java/sirius/biz/process/ProcessLink.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessState.java
+++ b/src/main/java/sirius/biz/process/ProcessState.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/Processes.java
+++ b/src/main/java/sirius/biz/process/Processes.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessesDailyMetrics.java
+++ b/src/main/java/sirius/biz/process/ProcessesDailyMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProcessesMonthlyMetrics.java
+++ b/src/main/java/sirius/biz/process/ProcessesMonthlyMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/ProgressTracker.java
+++ b/src/main/java/sirius/biz/process/ProgressTracker.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/SimpleProcessCommand.java
+++ b/src/main/java/sirius/biz/process/SimpleProcessCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process;

--- a/src/main/java/sirius/biz/process/logs/ProcessLog.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLog.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.logs;

--- a/src/main/java/sirius/biz/process/logs/ProcessLogAction.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLogAction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.logs;

--- a/src/main/java/sirius/biz/process/logs/ProcessLogHandler.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLogHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.logs;

--- a/src/main/java/sirius/biz/process/logs/ProcessLogState.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLogState.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.logs;

--- a/src/main/java/sirius/biz/process/logs/ProcessLogType.java
+++ b/src/main/java/sirius/biz/process/logs/ProcessLogType.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.logs;

--- a/src/main/java/sirius/biz/process/output/ChartOutput.java
+++ b/src/main/java/sirius/biz/process/output/ChartOutput.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.output;

--- a/src/main/java/sirius/biz/process/output/ChartProcessOutputType.java
+++ b/src/main/java/sirius/biz/process/output/ChartProcessOutputType.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.output;

--- a/src/main/java/sirius/biz/process/output/LogsProcessOutputType.java
+++ b/src/main/java/sirius/biz/process/output/LogsProcessOutputType.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.output;

--- a/src/main/java/sirius/biz/process/output/ProcessOutput.java
+++ b/src/main/java/sirius/biz/process/output/ProcessOutput.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.output;

--- a/src/main/java/sirius/biz/process/output/ProcessOutputType.java
+++ b/src/main/java/sirius/biz/process/output/ProcessOutputType.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.output;

--- a/src/main/java/sirius/biz/process/output/TableOutput.java
+++ b/src/main/java/sirius/biz/process/output/TableOutput.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.output;

--- a/src/main/java/sirius/biz/process/output/TableProcessOutputType.java
+++ b/src/main/java/sirius/biz/process/output/TableProcessOutputType.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.process.output;

--- a/src/main/java/sirius/biz/protocol/AuditLog.java
+++ b/src/main/java/sirius/biz/protocol/AuditLog.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/AuditLogController.java
+++ b/src/main/java/sirius/biz/protocol/AuditLogController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/AuditLogEntry.java
+++ b/src/main/java/sirius/biz/protocol/AuditLogEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/CleanupProtocolsTask.java
+++ b/src/main/java/sirius/biz/protocol/CleanupProtocolsTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/CustomJournalProvider.java
+++ b/src/main/java/sirius/biz/protocol/CustomJournalProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/DelegateJournalData.java
+++ b/src/main/java/sirius/biz/protocol/DelegateJournalData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/FlushIncidentsCommand.java
+++ b/src/main/java/sirius/biz/protocol/FlushIncidentsCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/FlushLogsCommand.java
+++ b/src/main/java/sirius/biz/protocol/FlushLogsCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/IncidentController.java
+++ b/src/main/java/sirius/biz/protocol/IncidentController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/JournalController.java
+++ b/src/main/java/sirius/biz/protocol/JournalController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/JournalData.java
+++ b/src/main/java/sirius/biz/protocol/JournalData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/JournalEntry.java
+++ b/src/main/java/sirius/biz/protocol/JournalEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/Journaled.java
+++ b/src/main/java/sirius/biz/protocol/Journaled.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/LogController.java
+++ b/src/main/java/sirius/biz/protocol/LogController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/LoggedMessage.java
+++ b/src/main/java/sirius/biz/protocol/LoggedMessage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/MailController.java
+++ b/src/main/java/sirius/biz/protocol/MailController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/MailProtocol.java
+++ b/src/main/java/sirius/biz/protocol/MailProtocol.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/NoJournal.java
+++ b/src/main/java/sirius/biz/protocol/NoJournal.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/Protocols.java
+++ b/src/main/java/sirius/biz/protocol/Protocols.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/StoredIncident.java
+++ b/src/main/java/sirius/biz/protocol/StoredIncident.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/TraceData.java
+++ b/src/main/java/sirius/biz/protocol/TraceData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/protocol/Traced.java
+++ b/src/main/java/sirius/biz/protocol/Traced.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.protocol;

--- a/src/main/java/sirius/biz/saml/SamlHelper.java
+++ b/src/main/java/sirius/biz/saml/SamlHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.saml;

--- a/src/main/java/sirius/biz/saml/SamlReplayProtector.java
+++ b/src/main/java/sirius/biz/saml/SamlReplayProtector.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.saml;

--- a/src/main/java/sirius/biz/saml/SamlResponse.java
+++ b/src/main/java/sirius/biz/saml/SamlResponse.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.saml;

--- a/src/main/java/sirius/biz/saml/SamlUserHint.java
+++ b/src/main/java/sirius/biz/saml/SamlUserHint.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.saml;

--- a/src/main/java/sirius/biz/scripting/JobTaskContextAdapter.java
+++ b/src/main/java/sirius/biz/scripting/JobTaskContextAdapter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/LogMacro.java
+++ b/src/main/java/sirius/biz/scripting/LogMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/ScriptableEvent.java
+++ b/src/main/java/sirius/biz/scripting/ScriptableEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/ScriptableEventDispatcher.java
+++ b/src/main/java/sirius/biz/scripting/ScriptableEventDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/ScriptableEventDispatcherRepository.java
+++ b/src/main/java/sirius/biz/scripting/ScriptableEventDispatcherRepository.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/ScriptableEventRegistry.java
+++ b/src/main/java/sirius/biz/scripting/ScriptableEventRegistry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/ScriptableEvents.java
+++ b/src/main/java/sirius/biz/scripting/ScriptableEvents.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/Scripting.java
+++ b/src/main/java/sirius/biz/scripting/Scripting.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/ScriptingController.java
+++ b/src/main/java/sirius/biz/scripting/ScriptingController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/SimpleScriptableEventDispatcher.java
+++ b/src/main/java/sirius/biz/scripting/SimpleScriptableEventDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/TranscriptMessage.java
+++ b/src/main/java/sirius/biz/scripting/TranscriptMessage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/TypedScriptableEvent.java
+++ b/src/main/java/sirius/biz/scripting/TypedScriptableEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting;

--- a/src/main/java/sirius/biz/scripting/mongo/MongoCustomEventDispatcherRepository.java
+++ b/src/main/java/sirius/biz/scripting/mongo/MongoCustomEventDispatcherRepository.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting.mongo;

--- a/src/main/java/sirius/biz/scripting/mongo/MongoCustomScript.java
+++ b/src/main/java/sirius/biz/scripting/mongo/MongoCustomScript.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting.mongo;

--- a/src/main/java/sirius/biz/scripting/mongo/MongoCustomScriptController.java
+++ b/src/main/java/sirius/biz/scripting/mongo/MongoCustomScriptController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.scripting.mongo;

--- a/src/main/java/sirius/biz/sequences/SequenceStrategy.java
+++ b/src/main/java/sirius/biz/sequences/SequenceStrategy.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences;

--- a/src/main/java/sirius/biz/sequences/Sequences.java
+++ b/src/main/java/sirius/biz/sequences/Sequences.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences;

--- a/src/main/java/sirius/biz/sequences/SequencesCommand.java
+++ b/src/main/java/sirius/biz/sequences/SequencesCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences;

--- a/src/main/java/sirius/biz/sequences/SmartSequenceStrategy.java
+++ b/src/main/java/sirius/biz/sequences/SmartSequenceStrategy.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences;

--- a/src/main/java/sirius/biz/sequences/jdbc/SQLSequenceStrategy.java
+++ b/src/main/java/sirius/biz/sequences/jdbc/SQLSequenceStrategy.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences.jdbc;

--- a/src/main/java/sirius/biz/sequences/jdbc/SequenceCounter.java
+++ b/src/main/java/sirius/biz/sequences/jdbc/SequenceCounter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences.jdbc;

--- a/src/main/java/sirius/biz/sequences/mongo/MongoSequenceCounter.java
+++ b/src/main/java/sirius/biz/sequences/mongo/MongoSequenceCounter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences.mongo;

--- a/src/main/java/sirius/biz/sequences/mongo/MongoSequenceStrategy.java
+++ b/src/main/java/sirius/biz/sequences/mongo/MongoSequenceStrategy.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences.mongo;

--- a/src/main/java/sirius/biz/storage/layer1/DownloadManager.java
+++ b/src/main/java/sirius/biz/storage/layer1/DownloadManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpace.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpaceFactory.java
+++ b/src/main/java/sirius/biz/storage/layer1/FSObjectStorageSpaceFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/FileHandle.java
+++ b/src/main/java/sirius/biz/storage/layer1/FileHandle.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/ObjectMetadata.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectMetadata.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpace.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpaceFactory.java
+++ b/src/main/java/sirius/biz/storage/layer1/ObjectStorageSpaceFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpace.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpaceFactory.java
+++ b/src/main/java/sirius/biz/storage/layer1/S3ObjectStorageSpaceFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1;

--- a/src/main/java/sirius/biz/storage/layer1/replication/BaseReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/BaseReplicationTaskStorage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication;

--- a/src/main/java/sirius/biz/storage/layer1/replication/ForceReplicationJob.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ForceReplicationJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication;

--- a/src/main/java/sirius/biz/storage/layer1/replication/ReplicationBackgroundLoop.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ReplicationBackgroundLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication;

--- a/src/main/java/sirius/biz/storage/layer1/replication/ReplicationManager.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ReplicationManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication;

--- a/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskExecutor.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskExecutor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication;

--- a/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/ReplicationTaskStorage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication;

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTask.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication.jdbc;

--- a/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/jdbc/SQLReplicationTaskStorage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication.jdbc;

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTask.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication.mongo;

--- a/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
+++ b/src/main/java/sirius/biz/storage/layer1/replication/mongo/MongoReplicationTaskStorage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.replication.mongo;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/AES256CipherFactory.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/AES256CipherFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/ByteBlockTransformer.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/ByteBlockTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/CipherFactory.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/CipherFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/CipherProvider.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/CipherProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/CipherTransformer.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/CipherTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/CombinedTransformer.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/CombinedTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/CompressionLevel.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/CompressionLevel.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/DeflateTransformer.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/DeflateTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/InflateTransformer.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/InflateTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/SecretKeyCipherProvider.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/SecretKeyCipherProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer1/transformer/TransformingInputStream.java
+++ b/src/main/java/sirius/biz/storage/layer1/transformer/TransformingInputStream.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer;

--- a/src/main/java/sirius/biz/storage/layer2/BaseBlobContainer.java
+++ b/src/main/java/sirius/biz/storage/layer2/BaseBlobContainer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BasicBlobStorageSpace.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/Blob.java
+++ b/src/main/java/sirius/biz/storage/layer2/Blob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobChangedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobChangedHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobContainer.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobContainer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobContentUpdatedHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobController.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobCreatedHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobDispatcherHook.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDispatcherHook.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobDuplicator.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobDuplicator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobHardRef.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobHardRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobHardRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobHardRefProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobParentChangedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobParentChangedHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRefProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobReferenceContainer.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobReferenceContainer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobRenamedHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobRenamedHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRef.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobSoftRefProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorage.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobStorageSpace.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobUri.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobUri.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/BlobUriParser.java
+++ b/src/main/java/sirius/biz/storage/layer2/BlobUriParser.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/Directory.java
+++ b/src/main/java/sirius/biz/storage/layer2/Directory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/ExternalURLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/ExternalURLBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/FailedVariantConversionHandler.java
+++ b/src/main/java/sirius/biz/storage/layer2/FailedVariantConversionHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/HasBlobs.java
+++ b/src/main/java/sirius/biz/storage/layer2/HasBlobs.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
+++ b/src/main/java/sirius/biz/storage/layer2/L3Uplink.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/OptimisticCreate.java
+++ b/src/main/java/sirius/biz/storage/layer2/OptimisticCreate.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/ProcessBlobChangesLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/StorageCleanupTask.java
+++ b/src/main/java/sirius/biz/storage/layer2/StorageCleanupTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/TouchWritebackLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/TouchWritebackLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer2/URLBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.jdbc;

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorage.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.jdbc;

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLBlobStorageSpace.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.jdbc;

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLDirectory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.jdbc;

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLProcessBlobChangesLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.jdbc;

--- a/src/main/java/sirius/biz/storage/layer2/jdbc/SQLVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/jdbc/SQLVariant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.jdbc;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.mongo;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorage.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.mongo;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoBlobStorageSpace.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.mongo;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoDirectory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.mongo;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoProcessBlobChangesLoop.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.mongo;

--- a/src/main/java/sirius/biz/storage/layer2/mongo/MongoVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/mongo/MongoVariant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.mongo;

--- a/src/main/java/sirius/biz/storage/layer2/variants/BlobConversionEvent.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/BlobConversionEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.variants;

--- a/src/main/java/sirius/biz/storage/layer2/variants/BlobVariant.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/BlobVariant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.variants;

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionEngine.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.variants;

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConversionProcess.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.variants;

--- a/src/main/java/sirius/biz/storage/layer2/variants/Converter.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/Converter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.variants;

--- a/src/main/java/sirius/biz/storage/layer2/variants/ConverterFactory.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/ConverterFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.variants;

--- a/src/main/java/sirius/biz/storage/layer2/variants/IdentityConverter.java
+++ b/src/main/java/sirius/biz/storage/layer2/variants/IdentityConverter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2.variants;

--- a/src/main/java/sirius/biz/storage/layer3/AutoExtractRoot.java
+++ b/src/main/java/sirius/biz/storage/layer3/AutoExtractRoot.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/BlobUriFileResolver.java
+++ b/src/main/java/sirius/biz/storage/layer3/BlobUriFileResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/BlockwiseIterator.java
+++ b/src/main/java/sirius/biz/storage/layer3/BlockwiseIterator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/ChildPageProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/ChildPageProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/ChildProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/ChildProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/DeleteFilesJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/DeletionCheckHandler.java
+++ b/src/main/java/sirius/biz/storage/layer3/DeletionCheckHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/EnumerateOnlyProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/EnumerateOnlyProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/ExtractArchiveJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/FetchFromUrlMode.java
+++ b/src/main/java/sirius/biz/storage/layer3/FetchFromUrlMode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/FileQuickActionProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/FileQuickActionProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/FileSearch.java
+++ b/src/main/java/sirius/biz/storage/layer3/FileSearch.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/FindOnlyProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/FindOnlyProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/HeadRequestFileResolver.java
+++ b/src/main/java/sirius/biz/storage/layer3/HeadRequestFileResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/JobFileQuickActionProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/JobFileQuickActionProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/MutableVirtualFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/PathAndQueryStringFileResolver.java
+++ b/src/main/java/sirius/biz/storage/layer3/PathAndQueryStringFileResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/RemoteFileResolver.java
+++ b/src/main/java/sirius/biz/storage/layer3/RemoteFileResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/SingularVFSRoot.java
+++ b/src/main/java/sirius/biz/storage/layer3/SingularVFSRoot.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/TmpRoot.java
+++ b/src/main/java/sirius/biz/storage/layer3/TmpRoot.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/Transfer.java
+++ b/src/main/java/sirius/biz/storage/layer3/Transfer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/TransferFilesJob.java
+++ b/src/main/java/sirius/biz/storage/layer3/TransferFilesJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/TreeVisitorBuilder.java
+++ b/src/main/java/sirius/biz/storage/layer3/TreeVisitorBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/VFSRoot.java
+++ b/src/main/java/sirius/biz/storage/layer3/VFSRoot.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/VFSSearchProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/VFSSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystem.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileSystemController.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileSystemController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/VirtualFileWalker.java
+++ b/src/main/java/sirius/biz/storage/layer3/VirtualFileWalker.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFile.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFileSystemView.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFileSystemView.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFtplet.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeFtplet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeUser.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeUser.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeUserManager.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/BridgeUserManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/ConfigBasedConnectionConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/ConfigBasedConnectionConfig.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ftp/FTPServer.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ftp/FTPServer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeDirectoryStream.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeDirectoryStream.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeFileSystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeFileSystem.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeFileSystemProvider.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeFileSystemProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgePath.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgePath.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgePosixFileAttributes.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgePosixFileAttributes.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgePosixFileAttributesView.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgePosixFileAttributesView.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeSession.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/BridgeSession.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/NoopShell.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/NoopShell.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/SSHServer.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/SSHServer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/StringPath.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/StringPath.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpCommand.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.scp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpCommandFactory.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpCommandFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.scp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpFileOpener.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpFileOpener.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.scp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpSourceStreamResolver.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpSourceStreamResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.scp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpTargetStreamResolver.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/scp/BridgeScpTargetStreamResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.scp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeFileSystemAccessor.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeFileSystemAccessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.sftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeSeekableByteChannel.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeSeekableByteChannel.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.sftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeSftpSubsystem.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeSftpSubsystem.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.sftp;

--- a/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeSftpSubsystemFactory.java
+++ b/src/main/java/sirius/biz/storage/layer3/downlink/ssh/sftp/BridgeSftpSubsystemFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.downlink.ssh.sftp;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplink.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplinksRoot.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ConfigBasedUplinksRoot.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/UplinkFactory.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/UplinkFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/cifs/CIFSUplink.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.cifs;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/fs/LocalDirectoryUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/fs/LocalDirectoryUplink.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.fs;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplink.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPSUplinkConnectorConfig.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplink.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/ftp/FTPUplinkConnectorConfig.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.ftp;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplink.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplink.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.sftp;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/sftp/SFTPUplinkConnectorConfig.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.sftp;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/ListUplinkConnectorsCommand.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/ListUplinkConnectorsCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.util;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/RemotePath.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/RemotePath.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.util;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnector.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnector.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.util;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnectorConfig.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnectorConfig.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.util;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnectorFactory.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnectorFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.util;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnectorPool.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkConnectorPool.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.util;

--- a/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkMetrics.java
+++ b/src/main/java/sirius/biz/storage/layer3/uplink/util/UplinkMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.util;

--- a/src/main/java/sirius/biz/storage/legacy/BucketInfo.java
+++ b/src/main/java/sirius/biz/storage/legacy/BucketInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/DownloadBuilder.java
+++ b/src/main/java/sirius/biz/storage/legacy/DownloadBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/FSStorageEngine.java
+++ b/src/main/java/sirius/biz/storage/legacy/FSStorageEngine.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/PhysicalStorageEngine.java
+++ b/src/main/java/sirius/biz/storage/legacy/PhysicalStorageEngine.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/Storage.java
+++ b/src/main/java/sirius/biz/storage/legacy/Storage.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/StorageCleanupTask.java
+++ b/src/main/java/sirius/biz/storage/legacy/StorageCleanupTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/StorageController.java
+++ b/src/main/java/sirius/biz/storage/legacy/StorageController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/StoredObject.java
+++ b/src/main/java/sirius/biz/storage/legacy/StoredObject.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/StoredObjectRef.java
+++ b/src/main/java/sirius/biz/storage/legacy/StoredObjectRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/StoredObjectRefProperty.java
+++ b/src/main/java/sirius/biz/storage/legacy/StoredObjectRefProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/UpdatingOutputStream.java
+++ b/src/main/java/sirius/biz/storage/legacy/UpdatingOutputStream.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/VersionManager.java
+++ b/src/main/java/sirius/biz/storage/legacy/VersionManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/VersionedFile.java
+++ b/src/main/java/sirius/biz/storage/legacy/VersionedFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/VersionedFiles.java
+++ b/src/main/java/sirius/biz/storage/legacy/VersionedFiles.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/VirtualObject.java
+++ b/src/main/java/sirius/biz/storage/legacy/VirtualObject.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/legacy/VirtualObjectVersion.java
+++ b/src/main/java/sirius/biz/storage/legacy/VirtualObjectVersion.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy;

--- a/src/main/java/sirius/biz/storage/s3/BucketName.java
+++ b/src/main/java/sirius/biz/storage/s3/BucketName.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.s3;

--- a/src/main/java/sirius/biz/storage/s3/ObjectStore.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStore.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.s3;

--- a/src/main/java/sirius/biz/storage/s3/ObjectStores.java
+++ b/src/main/java/sirius/biz/storage/s3/ObjectStores.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.s3;

--- a/src/main/java/sirius/biz/storage/util/Attempt.java
+++ b/src/main/java/sirius/biz/storage/util/Attempt.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/FillBlobChecksumJob.java
+++ b/src/main/java/sirius/biz/storage/util/FillBlobChecksumJob.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingBlobObjectCheckJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingMongoBlobObjectCheckJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
+++ b/src/main/java/sirius/biz/storage/util/MissingSqlBlobObjectCheckJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/SearchOrphanS3ObjectsJob.java
+++ b/src/main/java/sirius/biz/storage/util/SearchOrphanS3ObjectsJob.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/SearchOrphanS3ObjectsMongoJob.java
+++ b/src/main/java/sirius/biz/storage/util/SearchOrphanS3ObjectsMongoJob.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/SearchOrphanS3ObjectsSQLJob.java
+++ b/src/main/java/sirius/biz/storage/util/SearchOrphanS3ObjectsSQLJob.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/StorageMetrics.java
+++ b/src/main/java/sirius/biz/storage/util/StorageMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/StorageUtils.java
+++ b/src/main/java/sirius/biz/storage/util/StorageUtils.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/WatchableInputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableInputStream.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
+++ b/src/main/java/sirius/biz/storage/util/WatchableOutputStream.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util;

--- a/src/main/java/sirius/biz/tenants/AdditionalRolesProvider.java
+++ b/src/main/java/sirius/biz/tenants/AdditionalRolesProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/BaseTenantAutoSetup.java
+++ b/src/main/java/sirius/biz/tenants/BaseTenantAutoSetup.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/BizInterceptor.java
+++ b/src/main/java/sirius/biz/tenants/BizInterceptor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/EmailAddressValidator.java
+++ b/src/main/java/sirius/biz/tenants/EmailAddressValidator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/HttpsUrlValidator.java
+++ b/src/main/java/sirius/biz/tenants/HttpsUrlValidator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/PhoneNumberValidator.java
+++ b/src/main/java/sirius/biz/tenants/PhoneNumberValidator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/ProfileController.java
+++ b/src/main/java/sirius/biz/tenants/ProfileController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/SamlController.java
+++ b/src/main/java/sirius/biz/tenants/SamlController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/Tenant.java
+++ b/src/main/java/sirius/biz/tenants/Tenant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/TenantAutoSetupExtender.java
+++ b/src/main/java/sirius/biz/tenants/TenantAutoSetupExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/TenantController.java
+++ b/src/main/java/sirius/biz/tenants/TenantController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/TenantData.java
+++ b/src/main/java/sirius/biz/tenants/TenantData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/TenantExportJobExtender.java
+++ b/src/main/java/sirius/biz/tenants/TenantExportJobExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/TenantExportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/TenantExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/TenantPermissionsExtender.java
+++ b/src/main/java/sirius/biz/tenants/TenantPermissionsExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/TenantSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/TenantSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/TenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/TenantUserManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/Tenants.java
+++ b/src/main/java/sirius/biz/tenants/Tenants.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/UserAccount.java
+++ b/src/main/java/sirius/biz/tenants/UserAccount.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/UserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/UserAccountData.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/UserAccountSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/UserAccountVideosCheck.java
+++ b/src/main/java/sirius/biz/tenants/UserAccountVideosCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/main/java/sirius/biz/tenants/deletion/DeleteEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/deletion/DeleteEntitiesTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.deletion;

--- a/src/main/java/sirius/biz/tenants/deletion/DeleteTenantJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/deletion/DeleteTenantJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.deletion;

--- a/src/main/java/sirius/biz/tenants/deletion/DeleteTenantTask.java
+++ b/src/main/java/sirius/biz/tenants/deletion/DeleteTenantTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.deletion;

--- a/src/main/java/sirius/biz/tenants/flags/CustomizationFlag.java
+++ b/src/main/java/sirius/biz/tenants/flags/CustomizationFlag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.flags;

--- a/src/main/java/sirius/biz/tenants/flags/CustomizationFlags.java
+++ b/src/main/java/sirius/biz/tenants/flags/CustomizationFlags.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.flags;

--- a/src/main/java/sirius/biz/tenants/jdbc/CheckForSQLChildrenTask.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/CheckForSQLChildrenTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLEntitiesTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLUserAccountsTask.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/DeleteSQLUserAccountsTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/RecomputeVideosCheck.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/RecomputeVideosCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenant.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantAutoSetup.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantAutoSetup.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantAware.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantAware.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantController.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantExportJobExtender.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantExportJobExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantExportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantGlobalMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantGlobalMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantImportHandler.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenantUserManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLTenants.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLTenants.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccount.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccount.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountAcademyMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountAcademyMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountActivityMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountActivityMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountExportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountImportHandler.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountImportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/jdbc/SQLUserAccountSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.jdbc;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/AverageActivityForTenantChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/AverageActivityForTenantChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/AverageEducationForTenantChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/AverageEducationForTenantChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfActiveTenantsChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfActiveTenantsChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfActiveUsersChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfActiveUsersChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfActiveUsersForTenantChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfActiveUsersForTenantChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfProcessesForTenantChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfProcessesForTenantChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfTenantsChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfTenantsChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfUserInteractionsChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfUserInteractionsChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfUserInteractionsForTenantChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfUserInteractionsForTenantChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfUsersChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/NumberOfUsersChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/ProcessDurationForTenantChart.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/ProcessDurationForTenantChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/charts/TenantResolver.java
+++ b/src/main/java/sirius/biz/tenants/metrics/charts/TenantResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.charts;

--- a/src/main/java/sirius/biz/tenants/metrics/computers/GlobalTenantMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/metrics/computers/GlobalTenantMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.computers;

--- a/src/main/java/sirius/biz/tenants/metrics/computers/TenantMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/metrics/computers/TenantMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.computers;

--- a/src/main/java/sirius/biz/tenants/metrics/computers/UserAccountAcademyMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/metrics/computers/UserAccountAcademyMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.computers;

--- a/src/main/java/sirius/biz/tenants/metrics/computers/UserAccountActivityMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/metrics/computers/UserAccountActivityMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.metrics.computers;

--- a/src/main/java/sirius/biz/tenants/mongo/CheckForMongoChildrenTask.java
+++ b/src/main/java/sirius/biz/tenants/mongo/CheckForMongoChildrenTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/DeleteMongoEntitiesTask.java
+++ b/src/main/java/sirius/biz/tenants/mongo/DeleteMongoEntitiesTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/DeleteMongoUserAccountTask.java
+++ b/src/main/java/sirius/biz/tenants/mongo/DeleteMongoUserAccountTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantAutoSetup.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantAutoSetup.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantAware.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantAware.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantController.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantExportJobExtender.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantExportJobExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantExportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantGlobalMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantGlobalMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantImportHandler.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenantUserManager.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenantUserManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoTenants.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoTenants.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccount.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountAcademyMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountAcademyMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountActivityMetricComputer.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountActivityMetricComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountController.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountExportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountExportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountImportHandler.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountImportJobFactory.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountImportJobFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountSearchProvider.java
+++ b/src/main/java/sirius/biz/tenants/mongo/MongoUserAccountSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/tenants/mongo/RecomputeVideosCheck.java
+++ b/src/main/java/sirius/biz/tenants/mongo/RecomputeVideosCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo;

--- a/src/main/java/sirius/biz/translations/MultiLanguageString.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageString.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringExtender.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringHelper.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
+++ b/src/main/java/sirius/biz/translations/MultiLanguageStringProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/main/java/sirius/biz/tycho/ContentListLayout.java
+++ b/src/main/java/sirius/biz/tycho/ContentListLayout.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/ContentPageSize.java
+++ b/src/main/java/sirius/biz/tycho/ContentPageSize.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/DashboardBrowserDistributionChart.java
+++ b/src/main/java/sirius/biz/tycho/DashboardBrowserDistributionChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/DashboardController.java
+++ b/src/main/java/sirius/biz/tycho/DashboardController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/DashboardPlatformDistributionChart.java
+++ b/src/main/java/sirius/biz/tycho/DashboardPlatformDistributionChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/QuickAction.java
+++ b/src/main/java/sirius/biz/tycho/QuickAction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/SiriusTechStackInfo.java
+++ b/src/main/java/sirius/biz/tycho/SiriusTechStackInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/TechStackInfo.java
+++ b/src/main/java/sirius/biz/tycho/TechStackInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/UserAssistant.java
+++ b/src/main/java/sirius/biz/tycho/UserAssistant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho;

--- a/src/main/java/sirius/biz/tycho/academy/AcademyProvider.java
+++ b/src/main/java/sirius/biz/tycho/academy/AcademyProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/AcademyReport.java
+++ b/src/main/java/sirius/biz/tycho/academy/AcademyReport.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/AcademyTrackInfo.java
+++ b/src/main/java/sirius/biz/tycho/academy/AcademyTrackInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/AcademyVideo.java
+++ b/src/main/java/sirius/biz/tycho/academy/AcademyVideo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/AcademyVideoData.java
+++ b/src/main/java/sirius/biz/tycho/academy/AcademyVideoData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/OXOMIAcademyProvider.java
+++ b/src/main/java/sirius/biz/tycho/academy/OXOMIAcademyProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/OnboardingController.java
+++ b/src/main/java/sirius/biz/tycho/academy/OnboardingController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/OnboardingData.java
+++ b/src/main/java/sirius/biz/tycho/academy/OnboardingData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/OnboardingEngine.java
+++ b/src/main/java/sirius/biz/tycho/academy/OnboardingEngine.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/OnboardingParticipant.java
+++ b/src/main/java/sirius/biz/tycho/academy/OnboardingParticipant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/OnboardingVideo.java
+++ b/src/main/java/sirius/biz/tycho/academy/OnboardingVideo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/OnboardingVideoData.java
+++ b/src/main/java/sirius/biz/tycho/academy/OnboardingVideoData.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/RecomputeOnboardingVideosCheck.java
+++ b/src/main/java/sirius/biz/tycho/academy/RecomputeOnboardingVideosCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy;

--- a/src/main/java/sirius/biz/tycho/academy/jdbc/SQLAcademyReport.java
+++ b/src/main/java/sirius/biz/tycho/academy/jdbc/SQLAcademyReport.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy.jdbc;

--- a/src/main/java/sirius/biz/tycho/academy/jdbc/SQLAcademyVideo.java
+++ b/src/main/java/sirius/biz/tycho/academy/jdbc/SQLAcademyVideo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy.jdbc;

--- a/src/main/java/sirius/biz/tycho/academy/jdbc/SQLOnboardingEngine.java
+++ b/src/main/java/sirius/biz/tycho/academy/jdbc/SQLOnboardingEngine.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy.jdbc;

--- a/src/main/java/sirius/biz/tycho/academy/jdbc/SQLOnboardingVideo.java
+++ b/src/main/java/sirius/biz/tycho/academy/jdbc/SQLOnboardingVideo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy.jdbc;

--- a/src/main/java/sirius/biz/tycho/academy/mongo/MongoAcademyReport.java
+++ b/src/main/java/sirius/biz/tycho/academy/mongo/MongoAcademyReport.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy.mongo;

--- a/src/main/java/sirius/biz/tycho/academy/mongo/MongoAcademyVideo.java
+++ b/src/main/java/sirius/biz/tycho/academy/mongo/MongoAcademyVideo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy.mongo;

--- a/src/main/java/sirius/biz/tycho/academy/mongo/MongoOnboardingEngine.java
+++ b/src/main/java/sirius/biz/tycho/academy/mongo/MongoOnboardingEngine.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy.mongo;

--- a/src/main/java/sirius/biz/tycho/academy/mongo/MongoOnboardingVideo.java
+++ b/src/main/java/sirius/biz/tycho/academy/mongo/MongoOnboardingVideo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.academy.mongo;

--- a/src/main/java/sirius/biz/tycho/kb/KBHelper.java
+++ b/src/main/java/sirius/biz/tycho/kb/KBHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBase.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBase.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseArticle.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseArticle.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseBrowserDistributionChart.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseBrowserDistributionChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseController.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntry.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntry.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntryResolver.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntryResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntryViewsChart.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseEntryViewsChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseMessageExpander.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseMessageExpander.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBasePlatformDistributionChart.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBasePlatformDistributionChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseSearchProvider.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseViewsChart.java
+++ b/src/main/java/sirius/biz/tycho/kb/KnowledgeBaseViewsChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/OpenKbaLogHandler.java
+++ b/src/main/java/sirius/biz/tycho/kb/OpenKbaLogHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/kb/SynchronizeArticlesTask.java
+++ b/src/main/java/sirius/biz/tycho/kb/SynchronizeArticlesTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.kb;

--- a/src/main/java/sirius/biz/tycho/metrics/BasicKeyMetricProvider.java
+++ b/src/main/java/sirius/biz/tycho/metrics/BasicKeyMetricProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/metrics/EntitiesKeyMetricProvider.java
+++ b/src/main/java/sirius/biz/tycho/metrics/EntitiesKeyMetricProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/metrics/EntityKeyMetricProvider.java
+++ b/src/main/java/sirius/biz/tycho/metrics/EntityKeyMetricProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/metrics/GlobalKeyMetricProvider.java
+++ b/src/main/java/sirius/biz/tycho/metrics/GlobalKeyMetricProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/metrics/KeyMetric.java
+++ b/src/main/java/sirius/biz/tycho/metrics/KeyMetric.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/metrics/KeyMetricProvider.java
+++ b/src/main/java/sirius/biz/tycho/metrics/KeyMetricProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/metrics/KeyMetrics.java
+++ b/src/main/java/sirius/biz/tycho/metrics/KeyMetrics.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/metrics/MetricDescription.java
+++ b/src/main/java/sirius/biz/tycho/metrics/MetricDescription.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/metrics/MetricsApiController.java
+++ b/src/main/java/sirius/biz/tycho/metrics/MetricsApiController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.metrics;

--- a/src/main/java/sirius/biz/tycho/search/OpenSearchController.java
+++ b/src/main/java/sirius/biz/tycho/search/OpenSearchController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.search;

--- a/src/main/java/sirius/biz/tycho/search/OpenSearchProvider.java
+++ b/src/main/java/sirius/biz/tycho/search/OpenSearchProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.search;

--- a/src/main/java/sirius/biz/tycho/search/OpenSearchResult.java
+++ b/src/main/java/sirius/biz/tycho/search/OpenSearchResult.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.search;

--- a/src/main/java/sirius/biz/tycho/smart/EmailSmartValueProvider.java
+++ b/src/main/java/sirius/biz/tycho/smart/EmailSmartValueProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/EntityResolver.java
+++ b/src/main/java/sirius/biz/tycho/smart/EntityResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/SmartValue.java
+++ b/src/main/java/sirius/biz/tycho/smart/SmartValue.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/SmartValueProvider.java
+++ b/src/main/java/sirius/biz/tycho/smart/SmartValueProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/SmartValueResolver.java
+++ b/src/main/java/sirius/biz/tycho/smart/SmartValueResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/SmartValuesController.java
+++ b/src/main/java/sirius/biz/tycho/smart/SmartValuesController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/TenantResolver.java
+++ b/src/main/java/sirius/biz/tycho/smart/TenantResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/TenantSmartValueProvider.java
+++ b/src/main/java/sirius/biz/tycho/smart/TenantSmartValueProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/UserAccountResolver.java
+++ b/src/main/java/sirius/biz/tycho/smart/UserAccountResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/smart/UserAccountSmartValueProvider.java
+++ b/src/main/java/sirius/biz/tycho/smart/UserAccountSmartValueProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.smart;

--- a/src/main/java/sirius/biz/tycho/updates/NumberOfUpdateClicksChart.java
+++ b/src/main/java/sirius/biz/tycho/updates/NumberOfUpdateClicksChart.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.updates;

--- a/src/main/java/sirius/biz/tycho/updates/UpdateClickEvent.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdateClickEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.updates;

--- a/src/main/java/sirius/biz/tycho/updates/UpdateInfo.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdateInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.updates;

--- a/src/main/java/sirius/biz/tycho/updates/UpdateManager.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdateManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.updates;

--- a/src/main/java/sirius/biz/tycho/updates/UpdatesController.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdatesController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.updates;

--- a/src/main/java/sirius/biz/tycho/updates/UpdatesReport.java
+++ b/src/main/java/sirius/biz/tycho/updates/UpdatesReport.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tycho.updates;

--- a/src/main/java/sirius/biz/util/ArchiveExtractor.java
+++ b/src/main/java/sirius/biz/util/ArchiveExtractor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/ArchiveHelper.java
+++ b/src/main/java/sirius/biz/util/ArchiveHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/Countries.java
+++ b/src/main/java/sirius/biz/util/Countries.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/Extracted7ZFile.java
+++ b/src/main/java/sirius/biz/util/Extracted7ZFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/ExtractedFile.java
+++ b/src/main/java/sirius/biz/util/ExtractedFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/ExtractedFileBuffer.java
+++ b/src/main/java/sirius/biz/util/ExtractedFileBuffer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/ExtractedZipFile.java
+++ b/src/main/java/sirius/biz/util/ExtractedZipFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/Languages.java
+++ b/src/main/java/sirius/biz/util/Languages.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/LocalArchiveExtractCallback.java
+++ b/src/main/java/sirius/biz/util/LocalArchiveExtractCallback.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/MonitoredSOAPClient.java
+++ b/src/main/java/sirius/biz/util/MonitoredSOAPClient.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/RedisController.java
+++ b/src/main/java/sirius/biz/util/RedisController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/ReportUnusedNLSKeysJob.java
+++ b/src/main/java/sirius/biz/util/ReportUnusedNLSKeysJob.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/SOAPCallEvent.java
+++ b/src/main/java/sirius/biz/util/SOAPCallEvent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/SevenZipAdapter.java
+++ b/src/main/java/sirius/biz/util/SevenZipAdapter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/util/ZipBuilder.java
+++ b/src/main/java/sirius/biz/util/ZipBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.util;

--- a/src/main/java/sirius/biz/vfs/VFSRoot.java
+++ b/src/main/java/sirius/biz/vfs/VFSRoot.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.vfs;

--- a/src/main/java/sirius/biz/vfs/VirtualFile.java
+++ b/src/main/java/sirius/biz/vfs/VirtualFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.vfs;

--- a/src/main/java/sirius/biz/web/Action.java
+++ b/src/main/java/sirius/biz/web/Action.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/Autoloaded.java
+++ b/src/main/java/sirius/biz/web/Autoloaded.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/BasePageHelper.java
+++ b/src/main/java/sirius/biz/web/BasePageHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/BizClassAliasProvider.java
+++ b/src/main/java/sirius/biz/web/BizClassAliasProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/BizContextExtender.java
+++ b/src/main/java/sirius/biz/web/BizContextExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/BizController.java
+++ b/src/main/java/sirius/biz/web/BizController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/BizLegacyGlobalsHandler.java
+++ b/src/main/java/sirius/biz/web/BizLegacyGlobalsHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
+++ b/src/main/java/sirius/biz/web/BlobPdfReplaceHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/ComplexLoadProperty.java
+++ b/src/main/java/sirius/biz/web/ComplexLoadProperty.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/ComputeAuthSignatureMacro.java
+++ b/src/main/java/sirius/biz/web/ComputeAuthSignatureMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/CurrentUserNameMacro.java
+++ b/src/main/java/sirius/biz/web/CurrentUserNameMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/DisasterController.java
+++ b/src/main/java/sirius/biz/web/DisasterController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/DisasterModeInfo.java
+++ b/src/main/java/sirius/biz/web/DisasterModeInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/ElasticPageHelper.java
+++ b/src/main/java/sirius/biz/web/ElasticPageHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/MongoPageHelper.java
+++ b/src/main/java/sirius/biz/web/MongoPageHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/MongoPageHelperExtender.java
+++ b/src/main/java/sirius/biz/web/MongoPageHelperExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/QueryTagController.java
+++ b/src/main/java/sirius/biz/web/QueryTagController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/QueryTagSuggester.java
+++ b/src/main/java/sirius/biz/web/QueryTagSuggester.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/RssFeedHelper.java
+++ b/src/main/java/sirius/biz/web/RssFeedHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/SQLPageHelper.java
+++ b/src/main/java/sirius/biz/web/SQLPageHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/SQLPageHelperExtender.java
+++ b/src/main/java/sirius/biz/web/SQLPageHelperExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/SaveHelper.java
+++ b/src/main/java/sirius/biz/web/SaveHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/SignLinkMacro.java
+++ b/src/main/java/sirius/biz/web/SignLinkMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/SortOrder.java
+++ b/src/main/java/sirius/biz/web/SortOrder.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/SpyUser.java
+++ b/src/main/java/sirius/biz/web/SpyUser.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/TableSortOption.java
+++ b/src/main/java/sirius/biz/web/TableSortOption.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/TableSorting.java
+++ b/src/main/java/sirius/biz/web/TableSorting.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/TenantAware.java
+++ b/src/main/java/sirius/biz/web/TenantAware.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/java/sirius/biz/web/UserIconProvider.java
+++ b/src/main/java/sirius/biz/web/UserIconProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web;

--- a/src/main/resources/default/assets/javascript/blobreffield.js
+++ b/src/main/resources/default/assets/javascript/blobreffield.js
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 /**

--- a/src/main/resources/default/assets/javascript/client-pagination.js
+++ b/src/main/resources/default/assets/javascript/client-pagination.js
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 function Pagination(_paginationContainer, pageSize, update) {

--- a/src/main/resources/default/assets/javascript/multiLanguageField.js
+++ b/src/main/resources/default/assets/javascript/multiLanguageField.js
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 function MultiLanguageField(options) {

--- a/src/main/resources/default/assets/scripts/multi-language-field.js
+++ b/src/main/resources/default/assets/scripts/multi-language-field.js
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 function MultiLanguageField(options) {

--- a/src/main/resources/default/assets/styles/biz-misc.scss
+++ b/src/main/resources/default/assets/styles/biz-misc.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .tracing-info .text-end {

--- a/src/test/java/sirius/biz/analytics/events/TestEvent1.java
+++ b/src/test/java/sirius/biz/analytics/events/TestEvent1.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/test/java/sirius/biz/analytics/events/TestEvent2.java
+++ b/src/test/java/sirius/biz/analytics/events/TestEvent2.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events;

--- a/src/test/java/sirius/biz/analytics/indicators/CheckValueIndicator.java
+++ b/src/test/java/sirius/biz/analytics/indicators/CheckValueIndicator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.indicators;

--- a/src/test/java/sirius/biz/analytics/indicators/IndicatorTestEntity.java
+++ b/src/test/java/sirius/biz/analytics/indicators/IndicatorTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.indicators;

--- a/src/test/java/sirius/biz/elastic/SearchableTestEntity.java
+++ b/src/test/java/sirius/biz/elastic/SearchableTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.elastic;

--- a/src/test/java/sirius/biz/importer/SQLTenantImportHandler.java
+++ b/src/test/java/sirius/biz/importer/SQLTenantImportHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer;

--- a/src/test/java/sirius/biz/jobs/params/ParameterTestEntity.java
+++ b/src/test/java/sirius/biz/jobs/params/ParameterTestEntity.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs.params;

--- a/src/test/java/sirius/biz/mongo/PrefixSearchableTestEntity.java
+++ b/src/test/java/sirius/biz/mongo/PrefixSearchableTestEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo;

--- a/src/test/java/sirius/biz/sequences/SequentialMongoBizEntityA.java
+++ b/src/test/java/sirius/biz/sequences/SequentialMongoBizEntityA.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences;

--- a/src/test/java/sirius/biz/sequences/SequentialMongoBizEntityB.java
+++ b/src/test/java/sirius/biz/sequences/SequentialMongoBizEntityB.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences;

--- a/src/test/java/sirius/biz/storage/layer2/BlobRefEntity.java
+++ b/src/test/java/sirius/biz/storage/layer2/BlobRefEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2;

--- a/src/test/java/sirius/biz/tenants/TenantsHelper.java
+++ b/src/test/java/sirius/biz/tenants/TenantsHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants;

--- a/src/test/java/sirius/biz/translations/ESMultiLanguageStringEntity.java
+++ b/src/test/java/sirius/biz/translations/ESMultiLanguageStringEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/test/java/sirius/biz/translations/MongoMultiLanguageStringComposite.java
+++ b/src/test/java/sirius/biz/translations/MongoMultiLanguageStringComposite.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/test/java/sirius/biz/translations/MongoMultiLanguageStringEntity.java
+++ b/src/test/java/sirius/biz/translations/MongoMultiLanguageStringEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/test/java/sirius/biz/translations/MongoMultiLanguageStringEntityWithMixin.java
+++ b/src/test/java/sirius/biz/translations/MongoMultiLanguageStringEntityWithMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/test/java/sirius/biz/translations/MongoMultiLanguageStringMixin.java
+++ b/src/test/java/sirius/biz/translations/MongoMultiLanguageStringMixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/test/java/sirius/biz/translations/MongoMultiLanguageStringRequiredNoFallbackEntity.java
+++ b/src/test/java/sirius/biz/translations/MongoMultiLanguageStringRequiredNoFallbackEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/test/java/sirius/biz/translations/SQLMultiLanguageStringEntity.java
+++ b/src/test/java/sirius/biz/translations/SQLMultiLanguageStringEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations;

--- a/src/test/java/sirius/biz/web/autoloading/AutoLoadController.java
+++ b/src/test/java/sirius/biz/web/autoloading/AutoLoadController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web.autoloading;

--- a/src/test/java/sirius/biz/web/autoloading/AutoLoadEntity.java
+++ b/src/test/java/sirius/biz/web/autoloading/AutoLoadEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web.autoloading;

--- a/src/test/java/sirius/biz/web/pagehelper/ElasticPageHelperEntity.java
+++ b/src/test/java/sirius/biz/web/pagehelper/ElasticPageHelperEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web.pagehelper;

--- a/src/test/java/sirius/biz/web/pagehelper/MongoPageHelperEntity.java
+++ b/src/test/java/sirius/biz/web/pagehelper/MongoPageHelperEntity.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web.pagehelper;

--- a/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
+++ b/src/test/kotlin/sirius/biz/analytics/events/EventRecorderTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.events

--- a/src/test/kotlin/sirius/biz/analytics/indicators/IndicatorTest.kt
+++ b/src/test/kotlin/sirius/biz/analytics/indicators/IndicatorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.analytics.indicators

--- a/src/test/kotlin/sirius/biz/cluster/RedisUserMessageCacheTest.kt
+++ b/src/test/kotlin/sirius/biz/cluster/RedisUserMessageCacheTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster

--- a/src/test/kotlin/sirius/biz/cluster/work/DistributedTasksTest.kt
+++ b/src/test/kotlin/sirius/biz/cluster/work/DistributedTasksTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work

--- a/src/test/kotlin/sirius/biz/cluster/work/FifoQueueTest.kt
+++ b/src/test/kotlin/sirius/biz/cluster/work/FifoQueueTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work

--- a/src/test/kotlin/sirius/biz/cluster/work/NamedCounterTest.kt
+++ b/src/test/kotlin/sirius/biz/cluster/work/NamedCounterTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work

--- a/src/test/kotlin/sirius/biz/cluster/work/PrioritizedQueueTest.kt
+++ b/src/test/kotlin/sirius/biz/cluster/work/PrioritizedQueueTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.cluster.work

--- a/src/test/kotlin/sirius/biz/codelists/CodeListsTest.kt
+++ b/src/test/kotlin/sirius/biz/codelists/CodeListsTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists

--- a/src/test/kotlin/sirius/biz/codelists/LookupTablesTest.kt
+++ b/src/test/kotlin/sirius/biz/codelists/LookupTablesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists

--- a/src/test/kotlin/sirius/biz/elastic/SearchableEntityTest.kt
+++ b/src/test/kotlin/sirius/biz/elastic/SearchableEntityTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.elastic

--- a/src/test/kotlin/sirius/biz/importer/ImportDictionaryTest.kt
+++ b/src/test/kotlin/sirius/biz/importer/ImportDictionaryTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer

--- a/src/test/kotlin/sirius/biz/importer/ImporterTest.kt
+++ b/src/test/kotlin/sirius/biz/importer/ImporterTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer

--- a/src/test/kotlin/sirius/biz/importer/format/AmountRangeCheckTest.kt
+++ b/src/test/kotlin/sirius/biz/importer/format/AmountRangeCheckTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format

--- a/src/test/kotlin/sirius/biz/importer/format/DateTimeFormatCheckTest.kt
+++ b/src/test/kotlin/sirius/biz/importer/format/DateTimeFormatCheckTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format

--- a/src/test/kotlin/sirius/biz/importer/format/ValueCheckTest.kt
+++ b/src/test/kotlin/sirius/biz/importer/format/ValueCheckTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.importer.format

--- a/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
+++ b/src/test/kotlin/sirius/biz/isenguard/IsenguardTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.isenguard

--- a/src/test/kotlin/sirius/biz/jobs/JobConfigDataTest.kt
+++ b/src/test/kotlin/sirius/biz/jobs/JobConfigDataTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jobs

--- a/src/test/kotlin/sirius/biz/jupiter/JupiterTest.kt
+++ b/src/test/kotlin/sirius/biz/jupiter/JupiterTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.jupiter

--- a/src/test/kotlin/sirius/biz/kb/KbaEditLinkTest.kt
+++ b/src/test/kotlin/sirius/biz/kb/KbaEditLinkTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.kb

--- a/src/test/kotlin/sirius/biz/locks/JavaLocksTest.kt
+++ b/src/test/kotlin/sirius/biz/locks/JavaLocksTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks

--- a/src/test/kotlin/sirius/biz/locks/LocksTest.kt
+++ b/src/test/kotlin/sirius/biz/locks/LocksTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks

--- a/src/test/kotlin/sirius/biz/locks/RedisLocksTest.kt
+++ b/src/test/kotlin/sirius/biz/locks/RedisLocksTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks

--- a/src/test/kotlin/sirius/biz/locks/SqlLocksTest.kt
+++ b/src/test/kotlin/sirius/biz/locks/SqlLocksTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.locks

--- a/src/test/kotlin/sirius/biz/model/AddressDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/AddressDataTest.kt
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model

--- a/src/test/kotlin/sirius/biz/model/InternationalAddressDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/InternationalAddressDataTest.kt
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model

--- a/src/test/kotlin/sirius/biz/model/PersonDataTest.kt
+++ b/src/test/kotlin/sirius/biz/model/PersonDataTest.kt
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.model

--- a/src/test/kotlin/sirius/biz/mongo/PrefixSearchableEntityTest.kt
+++ b/src/test/kotlin/sirius/biz/mongo/PrefixSearchableEntityTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.mongo

--- a/src/test/kotlin/sirius/biz/packages/PackageDataTest.kt
+++ b/src/test/kotlin/sirius/biz/packages/PackageDataTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.packages

--- a/src/test/kotlin/sirius/biz/packages/PackagesTest.kt
+++ b/src/test/kotlin/sirius/biz/packages/PackagesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.packages

--- a/src/test/kotlin/sirius/biz/pagehelper/ElasticPageHelperTest.kt
+++ b/src/test/kotlin/sirius/biz/pagehelper/ElasticPageHelperTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.pagehelper

--- a/src/test/kotlin/sirius/biz/pagehelper/MongoPageHelperTest.kt
+++ b/src/test/kotlin/sirius/biz/pagehelper/MongoPageHelperTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.pagehelper

--- a/src/test/kotlin/sirius/biz/saml/SamlTest.kt
+++ b/src/test/kotlin/sirius/biz/saml/SamlTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.saml

--- a/src/test/kotlin/sirius/biz/sequences/MongoSequencesTest.kt
+++ b/src/test/kotlin/sirius/biz/sequences/MongoSequencesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences

--- a/src/test/kotlin/sirius/biz/sequences/SequencesTest.kt
+++ b/src/test/kotlin/sirius/biz/sequences/SequencesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences

--- a/src/test/kotlin/sirius/biz/sequences/SqlSequencesTest.kt
+++ b/src/test/kotlin/sirius/biz/sequences/SqlSequencesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.sequences

--- a/src/test/kotlin/sirius/biz/storage/layer1/ObjectStorageTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer1/ObjectStorageTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1

--- a/src/test/kotlin/sirius/biz/storage/layer1/ReplicationTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer1/ReplicationTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1

--- a/src/test/kotlin/sirius/biz/storage/layer1/transformer/TransformingInputStreamTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer1/transformer/TransformingInputStreamTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer1.transformer

--- a/src/test/kotlin/sirius/biz/storage/layer2/BlobUriParserTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer2/BlobUriParserTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer2

--- a/src/test/kotlin/sirius/biz/storage/layer3/VirtualFileTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer3/VirtualFileTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3

--- a/src/test/kotlin/sirius/biz/storage/layer3/uplink/cifs/CIFSUplinkTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/layer3/uplink/cifs/CIFSUplinkTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.layer3.uplink.cifs

--- a/src/test/kotlin/sirius/biz/storage/legacy/StorageSigningTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/legacy/StorageSigningTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.legacy

--- a/src/test/kotlin/sirius/biz/storage/s3/ObjectStoresTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/s3/ObjectStoresTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.s3

--- a/src/test/kotlin/sirius/biz/storage/util/StorageUtilsTest.kt
+++ b/src/test/kotlin/sirius/biz/storage/util/StorageUtilsTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.storage.util

--- a/src/test/kotlin/sirius/biz/tenants/ContactDataTestEntity.kt
+++ b/src/test/kotlin/sirius/biz/tenants/ContactDataTestEntity.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants

--- a/src/test/kotlin/sirius/biz/tenants/PhoneNumberValidatorTest.kt
+++ b/src/test/kotlin/sirius/biz/tenants/PhoneNumberValidatorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants

--- a/src/test/kotlin/sirius/biz/tenants/SamlControllerTest.kt
+++ b/src/test/kotlin/sirius/biz/tenants/SamlControllerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants

--- a/src/test/kotlin/sirius/biz/tenants/TenantUserManagerTest.kt
+++ b/src/test/kotlin/sirius/biz/tenants/TenantUserManagerTest.kt
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants

--- a/src/test/kotlin/sirius/biz/tenants/TenantsTest.kt
+++ b/src/test/kotlin/sirius/biz/tenants/TenantsTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.codelists

--- a/src/test/kotlin/sirius/biz/tenants/mongo/SqlUserAccountImportHandlerTest.kt
+++ b/src/test/kotlin/sirius/biz/tenants/mongo/SqlUserAccountImportHandlerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.tenants.mongo

--- a/src/test/kotlin/sirius/biz/translations/ESMultiLanguageStringPropertyTest.kt
+++ b/src/test/kotlin/sirius/biz/translations/ESMultiLanguageStringPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations

--- a/src/test/kotlin/sirius/biz/translations/MongoMultiLanguageStringPropertyTest.kt
+++ b/src/test/kotlin/sirius/biz/translations/MongoMultiLanguageStringPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations

--- a/src/test/kotlin/sirius/biz/translations/MultiLanguageStringTest.kt
+++ b/src/test/kotlin/sirius/biz/translations/MultiLanguageStringTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations

--- a/src/test/kotlin/sirius/biz/translations/SQLMultiLanguageStringPropertyTest.kt
+++ b/src/test/kotlin/sirius/biz/translations/SQLMultiLanguageStringPropertyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.translations

--- a/src/test/kotlin/sirius/biz/web/autoloading/AutoloadControllerTest.kt
+++ b/src/test/kotlin/sirius/biz/web/autoloading/AutoloadControllerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web.autoloading

--- a/src/test/kotlin/sirius/biz/web/sorting/MongoPageHelperSortingTest.kt
+++ b/src/test/kotlin/sirius/biz/web/sorting/MongoPageHelperSortingTest.kt
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web.sorting

--- a/src/test/kotlin/sirius/biz/web/sorting/TableSortingTest.kt
+++ b/src/test/kotlin/sirius/biz/web/sorting/TableSortingTest.kt
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.biz.web.sorting


### PR DESCRIPTION
### Description

scireum sits in Stuttgart, but 1017 files still credited Remshalden or linked the website over plain `http`. Part of a sweep across the scireum repositories, prompted by a review in scireum/sirius-web#1729 where a file added this week had inherited the outdated header from the file next to it.

**Scope.** Two lines per file and nothing else - every changed line in the diff is one of these two forms, in whichever comment style the file uses:

```
- by scireum in Remshalden, Germany         + by scireum in Stuttgart, Germany
- http://www.scireum.de - info@scireum.de   + https://www.scireum.de - info@scireum.de
```

Two deliberate details in how the replacement is anchored:

- The city line is matched on the **whole header phrase**, never on the word alone, so postal addresses in test data or documentation cannot be caught by it.
- The URL is replaced **on its own**, not as part of the whole line, so `info@@scireum.de` survives - the doubled at-sign is the escape Tagliatelle needs in `.pasta` templates, and a whole-line pattern would have skipped those lines entirely, quietly leaving them on `http`.


### Verification

Compiles cleanly (`mvn clean test-compile`), and the pipeline runs the suite.

The suite was **not** run to completion locally, and the reason is worth recording rather than hiding: MongoDB will not start on this machine at all. `mongo:8.3.7` exits immediately with *"Linux kernel versions 6.19 and newer has a known incompatibility with this version of MongoDB"* ([SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912)), so every Mongo-backed test times out after 30 seconds against a port with nothing behind it. In a first run all 18 failing test methods were Mongo ones, by name or by that timeout signature; the JDBC, Redis, Elasticsearch and ClickHouse tests passed. A local run therefore cannot cover the Mongo paths of this change - which, being comment text, has no paths.

### Note on formatting

The IntelliJ formatter was deliberately **not** run: the change edits comment text only and cannot violate the code style, whereas formatting this many otherwise untouched files would bury the change under unrelated hunks.

### Additional Notes

- This PR fixes or works on following ticket(s): none - housekeeping
- This PR is related to PR: scireum/sirius-web#1731

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows best practices - see the note above on why the formatter was not run; **SonarLint was not run** either, as it cannot be executed headlessly
- [x] Patch Tasks: not necessary