### PR TITLE
Pins the YAML rendering of lookup table entry sources

### DIFF
--- a/src/test/kotlin/sirius/biz/codelists/LookupTableEntryTest.kt
+++ b/src/test/kotlin/sirius/biz/codelists/LookupTableEntryTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.biz.codelists
+
+import org.junit.jupiter.api.Test
+import sirius.kernel.commons.Json
+import tools.jackson.databind.node.ObjectNode
+import kotlin.test.assertEquals
+
+/**
+ * Pins the YAML rendering of [LookupTableEntry.getSource].
+ *
+ * We use SnakeYAML in three places ([LookupTableEntry.withSource] plus
+ * [sirius.biz.jupiter.JupiterSync] and [sirius.biz.jupiter.JupiterYamlDataProvider]), and all three only ever
+ * emit YAML - we never parse it back. A version bump can therefore only regress the emitted formatting, which
+ * no other test in the suite would notice. This one does, at least for the single call site which is reachable
+ * without a running Jupiter instance.
+ *
+ * These are deliberately characterization tests: they compare the full output verbatim and are split by the
+ * emitter property they pin, so that a failure names the property which moved. The expected values were
+ * captured against SnakeYAML 2.7. When one of them goes red after a bump, do not just paste in the new value -
+ * open the source panel of the lookup table picker, judge whether the new rendering is still acceptable, and
+ * only then update the literal.
+ */
+class LookupTableEntryTest {
+
+    @Test
+    fun `source is emitted as block style YAML preserving the order of the payload`() {
+        val entry = entryWithSource(
+            """
+            {"code":"DE","name":"Deutschland","population":84000000,"euMember":true,
+             "successor":null,"codes":{"iso3":"DEU","numeric":276},"languages":["de","en"]}
+            """
+        )
+
+        val expected = """
+            code: DE
+            name: Deutschland
+            population: 84000000
+            euMember: true
+            successor: null
+            codes:
+              iso3: DEU
+              numeric: 276
+            languages:
+            - de
+            - en
+        """.trimIndent() + "\n"
+
+        assertEquals(expected, entry.source)
+    }
+
+    @Test
+    fun `source folds long scalars at the default width of eighty characters`() {
+        val entry = entryWithSource(
+            """
+            {"description":"Die Bundesrepublik Deutschland ist ein Staat in Mitteleuropa und besteht aus sechzehn Laendern."}
+            """
+        )
+
+        val expected = """
+            description: Die Bundesrepublik Deutschland ist ein Staat in Mitteleuropa und besteht
+              aus sechzehn Laendern.
+        """.trimIndent() + "\n"
+
+        assertEquals(expected, entry.source)
+    }
+
+    @Test
+    fun `source quotes scalars which would otherwise resolve to another type`() {
+        val entry = entryWithSource(
+            """
+            {"zeroPadded":"007","boolLike":"yes","nullLike":"null","empty":"","colon":"a: b","hash":"a #b"}
+            """
+        )
+
+        val expected = """
+            zeroPadded: '007'
+            boolLike: 'yes'
+            nullLike: 'null'
+            empty: ''
+            colon: 'a: b'
+            hash: 'a #b'
+        """.trimIndent() + "\n"
+
+        assertEquals(expected, entry.source)
+    }
+
+    @Test
+    fun `source renders empty collections in pretty flow style`() {
+        val entry = entryWithSource("""{"emptyObject":{},"emptyArray":[]}""")
+
+        // This is the only rendering which observes options.setPrettyFlow(true) - without it, SnakeYAML would
+        // emit the far tidier "{}" and "[]" instead.
+        val expected = """
+            emptyObject: {
+              }
+            emptyArray: [
+              ]
+        """.trimIndent() + "\n"
+
+        assertEquals(expected, entry.source)
+    }
+
+    @Test
+    fun `source emits non-ASCII characters literally instead of escaping them`() {
+        val entry = entryWithSource("""{"note":"Grüße aus Remshalden – 100 % Erfolg"}""")
+
+        assertEquals("note: Grüße aus Remshalden – 100 % Erfolg\n", entry.source)
+    }
+
+    /**
+     * Creates an entry whose source is derived from the given JSON.
+     *
+     * The JSON is parsed rather than assembled via the typed setters of [ObjectNode], as this is what the only
+     * production caller ([IDBLookupTable]) does - it hands over the parsed source column of an IDB row. Parsing
+     * also determines the numeric node types, which in turn decide how the values are emitted.
+     */
+    private fun entryWithSource(json: String): LookupTableEntry {
+        val source: ObjectNode = Json.parseObject(json.trimIndent())
+
+        return LookupTableEntry("DE", "Deutschland", null).withSource(source)
+    }
+}


### PR DESCRIPTION
### Description

Follow-up to #2435 (SnakeYAML 2.6 → 2.7). While reviewing that bump it turned out that **not a single test in the suite asserted anything about SnakeYAML output**, so the green build said nothing about the one thing a bump can actually break.

We depend on SnakeYAML in exactly three places, and all of them only ever *emit* YAML — nothing in the codebase parses it back:

- `LookupTableEntry#withSource`
- `JupiterSync#asYaml`
- `JupiterYamlDataProvider#execute`

This adds characterization tests for `LookupTableEntry`, the one call site reachable without a running Jupiter instance. They are split by the emitter property they pin — block style, scalar folding at the default width of 80, quoting of values which would otherwise resolve to another type (`'007'`, `'yes'`, `''`, `'a: b'`), empty collections, and non-ASCII output — so a failure names the property that moved instead of just reporting a long string mismatch.

The payload is parsed from JSON rather than assembled through the typed `ObjectNode` setters, because that is what the only production caller does (`IDBLookupTable` hands over the parsed source column of an IDB row). Parsing also picks the numeric node types, which decide how values get emitted.

**Verified by mutation**, not just by going green:

| Mutation to `LookupTableEntry` | Result |
| --- | --- |
| `FlowStyle.BLOCK` → `FlowStyle.FLOW` | 5 of 5 tests fail |
| drop `setPrettyFlow(true)` | exactly 1 test fails (empty collections) |
| drop both (default `DumperOptions`) | 5 of 5 tests fail |

Empty collections are the *only* rendering `setPrettyFlow(true)` influences under `BLOCK` style (`{`/`  }` instead of `{}`), so without that case the option would have stayed unpinned — the first draft of this test missed it.

No production code is touched.

### Additional Notes

- This PR fixes or works on following ticket(s): _no ticket — small test-only follow-up to #2435_
- This PR is related to PR: #2435

**Deliberately left out of scope** (happy to do as follow-ups if wanted):

- The identical 3-line `DumperOptions` block is duplicated across all three call sites. Extracting it into one shared factory and characterizing *that* would protect all three at once; this PR pins only one copy.
- `JupiterSync#asYaml` and `JupiterYamlDataProvider#execute` remain untested, and their surface differs materially: `asYaml` receives plain `HashMap`s (so the key ordering these tests pin does **not** transfer) and `Value#asString` results (empty/numeric-looking strings, i.e. the quoting layer), while `JupiterYamlDataProvider` dumps repeatedly into one `Writer` and hand-writes `---` separators. For those two an emitter regression would be a functional break, not a cosmetic one.
- `JupiterYamlDataProvider#execute` has a pre-existing format-string bug: `withSystemErrorMessage("Failed to write %s (%s): %s (%s)", getFilename(), getName())` passes 2 arguments for 4 placeholders.
- FTR on the 2.7 bump itself: `jackson-dataformat-yaml` 2.15.2 reaches us transitively (sirius-kernel → docker-compose-rule-core, **compile** scope) and *does* use SnakeYAML's parser. It was compiled against SnakeYAML 2.0 and now runs against 2.7. It fails loudly rather than silently, so this is not a hidden-regression risk, but "we only ever dump" holds for our own code, not for the whole classpath.

### Checklist

- [x] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
  - IntelliJ formatter **did** run against `.idea/codeStyles/Project.xml` and reports *"Formatted well"* (headless, so bundled Kotlin formatting only, no plugins).
  - SonarLint was **not** checked — it cannot be run headlessly. Please run *Analyze VCS Changed Files* in the IDE before merging.
- [x] Patch Tasks: not necessary — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
